### PR TITLE
fix(directory): avoid throwing bad CannotMoveBetweenPartition

### DIFF
--- a/foundationdb/src/directory/directory_layer.rs
+++ b/foundationdb/src/directory/directory_layer.rs
@@ -572,12 +572,13 @@ impl DirectoryLayer {
             .await?
             .ok_or(DirectoryError::PathDoesNotExists)?;
         let old_node_exists_in_partition = old_node.is_in_partition(false);
+
         if let Some(new_node) = self.find(trx, new_path).await? {
             let new_node_exists_in_partition = new_node.is_in_partition(false);
             if old_node_exists_in_partition || new_node_exists_in_partition {
                 if !old_node_exists_in_partition
                     || !new_node_exists_in_partition
-                    || old_node.current_path.eq(&new_node.current_path)
+                    || !old_node.current_path.eq(&new_node.current_path)
                 {
                     return Err(DirectoryError::CannotMoveBetweenPartition);
                 }

--- a/scripts/run_bindingtester.sh
+++ b/scripts/run_bindingtester.sh
@@ -14,6 +14,7 @@ cd "${fdb_builddir:?}/foundationdb"
 ./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 630 --test-name directory --concurrency 1 rust --no-directory-snapshot-ops --compare python --seed 2483220251
 ./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 630 --test-name directory --concurrency 1 rust --no-directory-snapshot-ops --compare python --seed 241550211
 ./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 630 --test-name directory --concurrency 1 rust --no-directory-snapshot-ops --compare python --seed 1508488514
+./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 630 --test-name directory --concurrency 1 rust --no-directory-snapshot-ops --compare python --seed 4203526853
 
 START=1
 END=${1-1}


### PR DESCRIPTION
Related Python code is here: https://github.com/apple/foundationdb/blob/main/bindings/python/fdb/directory_impl.py#L352

Fix #36 