### PR TITLE
fix(directory): avoid initializing the version key on create_or_open

### DIFF
--- a/foundationdb/src/directory/directory_layer.rs
+++ b/foundationdb/src/directory/directory_layer.rs
@@ -221,7 +221,7 @@ impl DirectoryLayer {
         allow_create: bool,
         allow_open: bool,
     ) -> Result<DirectoryOutput, DirectoryError> {
-        self.check_version(trx, allow_create).await?;
+        self.check_version(trx, false).await?;
 
         if prefix.is_some() && !self.allow_manual_prefixes {
             if self.path.is_empty() {

--- a/scripts/run_bindingtester.sh
+++ b/scripts/run_bindingtester.sh
@@ -16,6 +16,12 @@ cd "${fdb_builddir:?}/foundationdb"
 ./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 630 --test-name directory --concurrency 1 rust --no-directory-snapshot-ops --compare python --seed 1508488514
 ./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 630 --test-name directory --concurrency 1 rust --no-directory-snapshot-ops --compare python --seed 4203526853
 
+# https://github.com/foundationdb-rs/foundationdb-rs/issues/38
+./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 630 --test-name directory --concurrency 1 rust --no-directory-snapshot-ops --compare python --seed 4142326254
+./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 630 --test-name directory --concurrency 1 rust --no-directory-snapshot-ops --compare python --seed 4275610547
+./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 630 --test-name directory --concurrency 1 rust --no-directory-snapshot-ops --compare python --seed 1951034301
+./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 630 --test-name directory --concurrency 1 rust --no-directory-snapshot-ops --compare python --seed 1700644945
+
 START=1
 END=${1-1}
 for i in $(eval echo "{$START..$END}")


### PR DESCRIPTION
This should fix #38.
More info can be found here: https://forums.foundationdb.org/t/binding-tester-set-read-version-instruction/3212/9