### PR TITLE
feat(foundationdb): add raw method to create a Database

### DIFF
--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -57,10 +57,14 @@ impl Database {
         let err = unsafe { fdb_sys::fdb_create_database(path_ptr, &mut v) };
         drop(path_str); // path_str own the CString that we are getting the ptr from
         error::eval(err)?;
-        Ok(Database {
-            inner: NonNull::new(v)
-                .expect("fdb_create_database to not return null if there is no error"),
-        })
+        let ptr =
+            NonNull::new(v).expect("fdb_create_database to not return null if there is no error");
+        Ok(Self::new_from_pointer(ptr))
+    }
+
+    /// Create a new FDBDatabase from a raw pointer. Users are expected to use the `new` method.
+    pub fn new_from_pointer(ptr: NonNull<fdb_sys::FDBDatabase>) -> Self {
+        Self { inner: ptr }
     }
 
     /// Create a database for the given configuration path


### PR DESCRIPTION
This is required to create a Database from the simulation crate that we are developing.