### PR TITLE
feat(foundationdb): Initial commit for tracing support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,12 @@ jobs:
           command: test
           args: --manifest-path foundationdb/Cargo.toml --features num-bigint --tests
 
+      - name: Test trace
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path foundationdb/Cargo.toml --features trace --tests
+
       - name: Test 7.1
         uses: actions-rs/cargo@v1
         with:

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -42,6 +42,7 @@ fdb-6_2 = ["foundationdb-sys/fdb-6_2", "foundationdb-gen/fdb-6_2"]
 fdb-6_3 = ["foundationdb-sys/fdb-6_3", "foundationdb-gen/fdb-6_3"]
 fdb-7_0 = ["foundationdb-sys/fdb-7_0", "foundationdb-gen/fdb-7_0"]
 fdb-7_1 = ["foundationdb-sys/fdb-7_1", "foundationdb-gen/fdb-7_1"]
+trace = ["tracing", "tracing-futures"]
 
 [build-dependencies]
 foundationdb-gen = { version = "0.7.0", path = "../foundationdb-gen", default-features = false }
@@ -57,6 +58,8 @@ uuid = { version = "1.1.2", optional = true }
 num-bigint = { version = "0.4.3", optional = true }
 async-trait = "0.1.56"
 async-recursion = "1.0.0"
+tracing = { version = "^0.1.37", optional = true }
+tracing-futures = { version = "^0.2.5", optional = true }
 
 [dev-dependencies]
 byteorder = "1.4.3"
@@ -67,3 +70,4 @@ ring = "0.16.20"
 data-encoding = "2.3.2"
 pretty-bytes = "0.2.2"
 uuid = { version = "1.1.2", features = ["v4"] }
+tracing-subscriber = "0.3.16"

--- a/foundationdb/README.md
+++ b/foundationdb/README.md
@@ -77,6 +77,7 @@ This Rust crate is not tied to any Async Runtime.
 | `embedded-fdb-include` | Use the locally embedded FoundationDB fdb_c.h and fdb.options files to compile |
 | `uuid`                 | Support for the uuid crate for Tuples                                          |
 | `num-bigint`           | Support for the bigint crate for Tuples                                        |
+| `trace`                | Support for the tracing crate                                                  |
 
 ### Hello, World using the crate
 

--- a/foundationdb/tests/trace.rs
+++ b/foundationdb/tests/trace.rs
@@ -1,0 +1,42 @@
+#[cfg(feature = "trace")]
+#[test]
+fn test_trace() {
+    use tracing_subscriber::fmt::format::FmtSpan;
+
+    let _guard = unsafe { foundationdb::boot() };
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let test_writer = tracing_subscriber::fmt::TestWriter::new();
+
+    let _e = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .with_span_events(FmtSpan::FULL)
+        .with_writer(test_writer)
+        .try_init();
+
+    rt.block_on(async {
+        test_traces_on_run().await;
+    });
+}
+
+#[cfg(feature = "trace")]
+#[tracing::instrument(skip_all)]
+async fn test_traces_on_run() {
+    let db = foundationdb::Database::new_compat(None)
+        .await
+        .expect("failed to open fdb");
+
+    db.run(|trx, _b| async move {
+        trx.set("tracing".as_ref(), "ok".as_ref());
+        Ok(())
+    })
+    .await
+    .expect("could not run transaction");
+
+    // cleaning up
+    db.run(|trx, _b| async move {
+        trx.clear("tracing".as_ref());
+        Ok(())
+    })
+    .await
+    .expect("could not run transaction");
+}


### PR DESCRIPTION
The goal of the PR is to enable some basic tracing capabilities to the foundationdb crate. It is behind a feature not enabled by default.

More tracing operations will be added, once [the relevant issue will be fixed](https://github.com/tokio-rs/tracing/issues/1863)