### PR TITLE
fix: Align slice memory before dereference

### DIFF
--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -23,6 +23,7 @@ mod keyselector;
 #[cfg(any(feature = "fdb-7_1"))]
 #[deny(missing_docs)]
 pub mod mapped_key_values;
+mod mem;
 /// Generated configuration types for use with the various `set_option` functions
 #[allow(clippy::all)]
 pub mod options;

--- a/foundationdb/src/mem.rs
+++ b/foundationdb/src/mem.rs
@@ -1,0 +1,14 @@
+use std::{alloc::Layout, ptr::copy_nonoverlapping};
+
+/** Foundationdb uses arenas for allocation which are not aligned.
+https://github.com/apple/foundationdb/blob/7aa578f616c24b60436429645427485b97520286/flow/Arena.cpp#L28-L31
+
+Rust does not allow dereferencing unaligned pointers, so we copy the memory first to an aligned
+pointer before constructing our slice.
+**/
+pub(crate) unsafe fn read_unaligned_slice<T>(src: *const T, len: usize) -> *const [T] {
+    let layout = Layout::array::<T>(len).expect("failed to create slice memory layout");
+    let aligned = std::alloc::alloc(layout);
+    copy_nonoverlapping(src as *const u8, aligned, layout.size());
+    std::slice::from_raw_parts(aligned as *const T, len)
+}


### PR DESCRIPTION
Dereferencing unaligned pointers is generally UB and not allowed in rust

Version 1.70 adds checks for unaligned pointer dereference when debug assertions are used.

https://github.com/rust-lang/rust/pull/98112

However, in this PR we eliminate the unaligned pointer dereferences by copying the slice memory to an aligned pointer before dereferencing.

Fixes #90