### PR TITLE
97 bump dependencies

### DIFF
--- a/foundationdb-bench/Cargo.toml
+++ b/foundationdb-bench/Cargo.toml
@@ -21,10 +21,10 @@ categories = ["database"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-env_logger = "0.9.0"
+env_logger = "0.9.3"
 foundationdb = { version = "*", path = "../foundationdb" }
-futures = "0.3.21"
-log = "0.4.17"
+futures = "0.3.28"
+log = "0.4.18"
 rand = "0.8.5"
 stopwatch = "0.0.7"
 structopt = "0.3.26"

--- a/foundationdb-bindingtester/Cargo.toml
+++ b/foundationdb-bindingtester/Cargo.toml
@@ -22,11 +22,11 @@ categories = ["database"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-env_logger = "0.9.0"
+env_logger = "0.9.3"
 foundationdb = { path = "../foundationdb", features = ["uuid", "num-bigint", "fdb-7_1", "embedded-fdb-include", "tenant-experimental"], default-features = false }
 foundationdb-sys = { version = "0.7.0", path = "../foundationdb-sys", features = ["embedded-fdb-include"], default-features = false }
-futures = "0.3.21"
-log = "0.4.17"
+futures = "0.3.28"
+log = "0.4.18"
 num-bigint = "0.4.3"
 structopt = "0.3.26"
-async-trait = "0.1.56"
+async-trait = "0.1.68"

--- a/foundationdb-gen/Cargo.toml
+++ b/foundationdb-gen/Cargo.toml
@@ -41,4 +41,4 @@ fdb-7_0 = []
 fdb-7_1 = []
 
 [dependencies]
-xml-rs = "0.8.4"
+xml-rs = "0.8.14"

--- a/foundationdb-macros/Cargo.toml
+++ b/foundationdb-macros/Cargo.toml
@@ -23,5 +23,6 @@ proc-macro = true
 
 [dependencies]
 syn = { version = "2.0.18", features = ["full"] }
-quote = "1.0.20"
+proc-macro2 = "1.0.59"
+try_map = "0.3.1"
 quote = "1.0.28"

--- a/foundationdb-macros/Cargo.toml
+++ b/foundationdb-macros/Cargo.toml
@@ -22,5 +22,6 @@ keywords = ["foundationdb", "proc-macro"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.98", features = ["full"] }
+syn = { version = "2.0.18", features = ["full"] }
 quote = "1.0.20"
+quote = "1.0.28"

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -50,25 +50,25 @@ foundationdb-gen = { version = "0.7.0", path = "../foundationdb-gen", default-fe
 [dependencies]
 foundationdb-sys = { version = "0.7.0", path = "../foundationdb-sys", default-features = false }
 foundationdb-macros = { version = "0.1.1", path = "../foundationdb-macros" }
-futures = "0.3.21"
+futures = "0.3.28"
 memchr = "2.5.0"
 rand = { version = "0.8.5", features = ["default", "small_rng"] }
 static_assertions = "1.1.0"
-uuid = { version = "1.1.2", optional = true }
+uuid = { version = "1.3.3", optional = true }
 num-bigint = { version = "0.4.3", optional = true }
-async-trait = "0.1.56"
-async-recursion = "1.0.0"
+async-trait = "0.1.68"
+async-recursion = "1.0.4"
 # Required to deserialize tenant info
-serde = { version = "1.0.144", features = ["derive"], optional = true}
-serde_json = { version = "1.0.85", optional = true}
-serde_bytes = { version = "0.11.7", optional = true}
+serde = { version = "1.0.163", features = ["derive"], optional = true}
+serde_json = { version = "1.0.96", optional = true}
+serde_bytes = { version = "0.11.9", optional = true}
 
 [dev-dependencies]
 byteorder = "1.4.3"
 lazy_static = "1.4.0"
-log = "0.4.17"
-tokio = { version = "1.19.2", features = ["full"] }
+log = "0.4.18"
+tokio = { version = "1.28.2", features = ["full"] }
 ring = "0.16.20"
-data-encoding = "2.3.2"
+data-encoding = "2.4.0"
 pretty-bytes = "0.2.2"
-uuid = { version = "1.1.2", features = ["v4"] }
+uuid = { version = "1.3.3", features = ["v4"] }


### PR DESCRIPTION
This PR closes the issue https://github.com/foundationdb-rs/foundationdb-rs/issues/97

As we bump to the syn 2 major version, I've also added some unit test around the new cfg_api_versions proc_macro_attribute implementation.