### PR TITLE
build: depend stopwatch in sources

### DIFF
--- a/foundationdb-bench/Cargo.toml
+++ b/foundationdb-bench/Cargo.toml
@@ -26,5 +26,4 @@ foundationdb = { version = "*", path = "../foundationdb" }
 futures = "0.3.28"
 log = "0.4.18"
 rand = "0.8.5"
-stopwatch = "0.0.7"
 structopt = "0.3.26"

--- a/foundationdb-bench/src/bin/fdb-bench.rs
+++ b/foundationdb-bench/src/bin/fdb-bench.rs
@@ -9,11 +9,11 @@ extern crate structopt;
 use std::sync::atomic::*;
 use std::sync::Arc;
 
+use foundationdb_bench::Stopwatch;
 use futures::future::*;
 use rand::prelude::*;
 use rand::rngs::mock::StepRng;
 use structopt::StructOpt;
-use foundationdb_bench::Stopwatch;
 
 use crate::fdb::*;
 

--- a/foundationdb-bench/src/bin/fdb-bench.rs
+++ b/foundationdb-bench/src/bin/fdb-bench.rs
@@ -1,7 +1,6 @@
 extern crate foundationdb as fdb;
 extern crate futures;
 extern crate rand;
-extern crate stopwatch;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
@@ -13,8 +12,8 @@ use std::sync::Arc;
 use futures::future::*;
 use rand::prelude::*;
 use rand::rngs::mock::StepRng;
-use stopwatch::Stopwatch;
 use structopt::StructOpt;
+use foundationdb_bench::Stopwatch;
 
 use crate::fdb::*;
 

--- a/foundationdb-bench/src/lib.rs
+++ b/foundationdb-bench/src/lib.rs
@@ -1,1 +1,143 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2014 Chucky Ellison <cme at freefour.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
+use std::default::Default;
+use std::fmt;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy)]
+pub struct Stopwatch {
+    /// The time the stopwatch was started last, if ever.
+    start_time: Option<Instant>,
+    /// The time the stopwatch was split last, if ever.
+    split_time: Option<Instant>,
+    /// The time elapsed while the stopwatch was running (between start() and stop()).
+    elapsed: Duration,
+}
+
+impl Default for Stopwatch {
+    fn default() -> Stopwatch {
+        Stopwatch {
+            start_time: None,
+            split_time: None,
+            elapsed: Duration::from_secs(0),
+        }
+    }
+}
+
+impl fmt::Display for Stopwatch {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        return write!(f, "{}ms", self.elapsed_ms());
+    }
+}
+
+impl Stopwatch {
+    /// Returns a new stopwatch.
+    pub fn new() -> Stopwatch {
+        let sw: Stopwatch = Default::default();
+        return sw;
+    }
+
+    /// Returns a new stopwatch which will immediately be started.
+    pub fn start_new() -> Stopwatch {
+        let mut sw = Stopwatch::new();
+        sw.start();
+        return sw;
+    }
+
+    /// Starts the stopwatch.
+    pub fn start(&mut self) {
+        self.start_time = Some(Instant::now());
+    }
+
+    /// Stops the stopwatch.
+    pub fn stop(&mut self) {
+        self.elapsed = self.elapsed();
+        self.start_time = None;
+        self.split_time = None;
+    }
+
+    /// Resets all counters and stops the stopwatch.
+    pub fn reset(&mut self) {
+        self.elapsed = Duration::from_secs(0);
+        self.start_time = None;
+        self.split_time = None;
+    }
+
+    /// Resets and starts the stopwatch again.
+    pub fn restart(&mut self) {
+        self.reset();
+        self.start();
+    }
+
+    /// Returns whether the stopwatch is running.
+    pub fn is_running(&self) -> bool {
+        return self.start_time.is_some();
+    }
+
+    /// Returns the elapsed time since the start of the stopwatch.
+    pub fn elapsed(&self) -> Duration {
+        match self.start_time {
+            // stopwatch is running
+            Some(t1) => {
+                return t1.elapsed() + self.elapsed;
+            }
+            // stopwatch is not running
+            None => {
+                return self.elapsed;
+            }
+        }
+    }
+
+    /// Returns the elapsed time since the start of the stopwatch in milliseconds.
+    pub fn elapsed_ms(&self) -> i64 {
+        let dur = self.elapsed();
+        return (dur.as_secs() * 1000 + (dur.subsec_nanos() / 1000000) as u64) as i64;
+    }
+
+    /// Returns the elapsed time since last split or start/restart.
+    ///
+    /// If the stopwatch is in stopped state this will always return a zero Duration.
+    pub fn elapsed_split(&mut self) -> Duration {
+        match self.start_time {
+            // stopwatch is running
+            Some(start) => {
+                let res = match self.split_time {
+                    Some(split) => split.elapsed(),
+                    None => start.elapsed(),
+                };
+                self.split_time = Some(Instant::now());
+                res
+            }
+            // stopwatch is not running
+            None => Duration::from_secs(0),
+        }
+    }
+
+    /// Returns the elapsed time since last split or start/restart in milliseconds.
+    ///
+    /// If the stopwatch is in stopped state this will always return zero.
+    pub fn elapsed_split_ms(&mut self) -> i64 {
+        let dur = self.elapsed_split();
+        return (dur.as_secs() * 1000 + (dur.subsec_nanos() / 1_000_000) as u64) as i64;
+    }
+}


### PR DESCRIPTION
The upstream suffers from:

```
the following packages contain code that will be rejected by a future version of Rust: rustc-serialize v0.3.24
```

... which is introduced by old versioned "num" that is brought by stopwatch. Given that stopwatch is no longer maintained, we can copy its source and depend it in source form. I properly handled the LICENSE issue.