### PR TITLE
chore: Use workspace package property inheritance.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,11 @@ members = [
     "foundationdb-macros",
 ]
 
+[workspace.package]
+edition = "2021"
+license = "MIT/Apache-2.0"
+repository = "https://github.com/foundationdb-rs/foundationdb-rs"
+rust-version = "1.63"
+
 [profile.release]
 debug = true

--- a/foundationdb-bench/Cargo.toml
+++ b/foundationdb-bench/Cargo.toml
@@ -5,20 +5,18 @@ authors = [
     "Benjamin Fry <benjaminfry@me.com>",
     "Vincent Rouillé <vincent@clikengo.com>",
 ]
-edition = "2021"
-rust-version = "1.63"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 description = """
 Bindings to the C api for FoundationDB
 """
 
-repository = "https://github.com/foundationdb-rs/foundationdb-rs"
-
 readme = "README.md"
 keywords = ["foundationdb", "kv"]
 categories = ["database"]
-
-license = "MIT/Apache-2.0"
 
 [dependencies]
 env_logger = "0.10.0"

--- a/foundationdb-bindingtester/Cargo.toml
+++ b/foundationdb-bindingtester/Cargo.toml
@@ -6,20 +6,18 @@ authors = [
     "Vincent Rouillé <vincent@clikengo.com>",
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
-edition = "2021"
-rust-version = "1.63"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 description = """
 Bindings to the C api for FoundationDB
 """
 
-repository = "https://github.com/foundationdb-rs/foundationdb-rs"
-
 readme = "README.md"
 keywords = ["foundationdb", "kv"]
 categories = ["database"]
-
-license = "MIT/Apache-2.0"
 
 [dependencies]
 env_logger = "0.10.0"

--- a/foundationdb-gen/Cargo.toml
+++ b/foundationdb-gen/Cargo.toml
@@ -6,16 +6,16 @@ authors = [
     "Vincent Rouillé <vincent@clikengo.com>",
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
-edition = "2021"
-rust-version = "1.63"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 description = """
 Binding generation helper for FoundationDB.
 """
 
 documentation = "https://docs.rs/foundationdb"
-repository = "https://github.com/foundationdb-rs/foundationdb-rs"
-license = "MIT/Apache-2.0"
 
 readme = "README.md"
 keywords = ["foundationdb", "kv"]

--- a/foundationdb-macros/Cargo.toml
+++ b/foundationdb-macros/Cargo.toml
@@ -4,16 +4,16 @@ version = "0.2.0"
 authors = [
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
-edition = "2021"
-rust-version = "1.63"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 description = """
 Macro definitions used to maintain the FoundationDB's crate
 """
 
 documentation = "https://docs.rs/foundationdb"
-repository = "https://github.com/foundationdb-rs/foundationdb-rs"
-license = "MIT/Apache-2.0"
 
 readme = "README.md"
 keywords = ["foundationdb", "proc-macro"]

--- a/foundationdb-sys/Cargo.toml
+++ b/foundationdb-sys/Cargo.toml
@@ -6,21 +6,20 @@ authors = [
     "Vincent Rouillé <vincent@clikengo.com>",
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
-edition = "2021"
-rust-version = "1.63"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 description = """
 Bindings to the C api for FoundationDB
 """
 
 documentation = "https://docs.rs/foundationdb-sys"
-repository = "https://github.com/foundationdb-rs/foundationdb-rs"
 
 readme = "README.md"
 keywords = ["foundationdb", "kv"]
 categories = ["database"]
-
-license = "MIT/Apache-2.0"
 
 [package.metadata.docs.rs]
 features = ["embedded-fdb-include", "fdb-7_1"]

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -6,16 +6,16 @@ authors = [
     "Vincent Rouillé <vincent@clikengo.com>",
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
-edition = "2021"
-rust-version = "1.63"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 description = """
 High level client bindings for FoundationDB.
 """
 
 documentation = "https://docs.rs/foundationdb"
-repository = "https://github.com/foundationdb-rs/foundationdb-rs"
-license = "MIT/Apache-2.0"
 
 readme = "README.md"
 keywords = ["foundationdb", "kv"]


### PR DESCRIPTION
A workspace can contain a `workspace.package` table to share property values across the crates within a workspace to make it easier to update things.

We now share `edition`, `license,` `repository`, and `rust-version` across the crates.