### PR TITLE
ci: Stop using most actions-rs actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,24 +36,16 @@ jobs:
         run: fdbcli --exec "configure single memory tenant_mode=optional_experimental"
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          profile: minimal
-          default: true
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose -p foundationdb --no-default-features --features ${{ matrix.fdb_feature_version }}
+        run: cargo build --verbose -p foundationdb --no-default-features --features ${{ matrix.fdb_feature_version }}
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          # Examples needs to have uuid enabled
-          args: --verbose -p foundationdb --no-default-features --features ${{ matrix.fdb_feature_version }},uuid
+        # Examples needs to have uuid enabled
+        run: cargo test --verbose -p foundationdb --no-default-features --features ${{ matrix.fdb_feature_version }},uuid
 
 
   test:
@@ -76,17 +68,13 @@ jobs:
       - name: Enable tenant
         run: fdbcli --exec "configure single memory tenant_mode=optional_experimental"
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: "${{ matrix.toolchain }}"
           components: rustfmt, clippy
 
       - name: Run all tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features num-bigint,embedded-fdb-include,tenant-experimental
+        run: cargo test --features num-bigint,embedded-fdb-include,tenant-experimental
 
   lint:
     name: Rustfmt / Clippy
@@ -104,22 +92,16 @@ jobs:
       - name: Enable tenant
         run: fdbcli --exec "configure single memory tenant_mode=optional_experimental"
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
           components: rustfmt, clippy
 
       - name: Fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
+        run: cargo clippy
 
   coverage:
     name: Code coverage
@@ -141,23 +123,16 @@ jobs:
       - name: Enable tenant
         run: fdbcli --exec "configure single memory tenant_mode=optional_experimental"
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
 
       - name: Build bindingtester
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p bindingtester --target x86_64-unknown-linux-gnu
+        run: cargo build -p bindingtester --target x86_64-unknown-linux-gnu
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          # doc tests are disabled fow now as they do not compile with -Cpanic=abort
-          args: --tests --no-fail-fast --target x86_64-unknown-linux-gnu
+        # doc tests are disabled fow now as they do not compile with -Cpanic=abort
+        run: cargo test --tests --no-fail-fast --target x86_64-unknown-linux-gnu
 
       - name: Setup bindingtester
         run: scripts/setup_bindingtester.sh target/x86_64-unknown-linux-gnu/debug/bindingtester

--- a/.github/workflows/cron-correctness.yml
+++ b/.github/workflows/cron-correctness.yml
@@ -36,16 +36,12 @@ jobs:
         run: fdbcli --exec "configure single memory tenant_mode=optional_experimental"
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          profile: minimal
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p bindingtester
+        run: cargo build -p bindingtester
 
       - name: Setup bindingtester
         run: scripts/setup_bindingtester.sh target/debug/bindingtester

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -20,10 +20,9 @@ jobs:
           version: "7.1.37"
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
 
       - name: Install cargo-msrv
         run: cargo install cargo-msrv

--- a/.github/workflows/pr-correctness.yml
+++ b/.github/workflows/pr-correctness.yml
@@ -34,16 +34,12 @@ jobs:
         run: fdbcli --exec "configure single memory tenant_mode=optional_experimental"
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          profile: minimal
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p bindingtester
+        run: cargo build -p bindingtester
 
       - name: Setup bindingtester
         run: scripts/setup_bindingtester.sh target/debug/bindingtester

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -21,16 +21,12 @@ jobs:
           version: "7.1.37"
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          profile: minimal
 
       - name: Build Documentation
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --all --no-deps
+        run: cargo doc --all --no-deps
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
This leaves a usage of their `grcov`. The actions from this organization aren't maintained and result in warnings within the GitHub Actions UI.