### PR TITLE
WIP Alternative breaking PR for versionstamp packing

### DIFF
--- a/foundationdb-bindingtester/src/main.rs
+++ b/foundationdb-bindingtester/src/main.rs
@@ -44,8 +44,6 @@ use foundationdb::directory::{Directory, DirectoryOutput};
 use foundationdb::tenant::{FdbTenant, TenantManagement};
 use foundationdb::tuple::{PackResult, TupleUnpack};
 
-use tuple::VersionstampOffset;
-
 fn mutation_from_str(s: &str) -> MutationType {
     match s {
         "ADD" => MutationType::Add,
@@ -1498,26 +1496,26 @@ impl StackMachine {
                     buf.push(element);
                 }
 
-                let tuple = Element::Tuple(buf.clone());
-                let i = tuple.count_incomplete_versionstamp();
-                let mut vec = prefix.into_owned();
-                let offset = buf.pack_into_vec_with_versionstamp(&mut vec);
-                match offset {
-                    VersionstampOffset::None { size: _ } => {
-                        assert_eq!(i, 0);
-                        self.push(number, ERROR_NONE.clone().into_owned());
-                    }
-                    VersionstampOffset::OneIncomplete { offset: _ } => {
-                        assert_eq!(i, 1);
-                        let data = Element::Bytes(vec.into());
-                        self.push(number, OK.clone().into_owned());
-                        self.push(number, data);
-                    }
-                    VersionstampOffset::MultipleIncomplete => {
-                        assert!(i > 1);
-                        self.push(number, ERROR_MULTIPLE.clone().into_owned());
-                    }
-                }
+                // let tuple = Element::Tuple(buf.clone());
+                // let i = tuple.count_incomplete_versionstamp();
+                // let mut vec = prefix.into_owned();
+                // let offset = buf.pack_into_vec_with_versionstamp(&mut vec);
+                // match offset {
+                //     VersionstampOffset::None { size: _ } => {
+                //         assert_eq!(i, 0);
+                //         self.push(number, ERROR_NONE.clone().into_owned());
+                //     }
+                //     VersionstampOffset::OneIncomplete { offset: _ } => {
+                //         assert_eq!(i, 1);
+                //         let data = Element::Bytes(vec.into());
+                //         self.push(number, OK.clone().into_owned());
+                //         self.push(number, data);
+                //     }
+                //     VersionstampOffset::MultipleIncomplete => {
+                //         assert!(i > 1);
+                //         self.push(number, ERROR_MULTIPLE.clone().into_owned());
+                //     }
+                // }
             }
 
             // Pops the top item off of the stack as PACKED, and then unpacks PACKED into a

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -198,7 +198,7 @@ pub fn pack_with_versionstamp<T: TuplePack>(v: &T) -> Vec<u8> {
 /// # Panics
 ///
 /// Panics if the encoded data size doesn't fit in `u32`.
-pub fn pack_into<T: TuplePack>(v: &T, output: &mut Vec<u8>) {
+pub fn pack_into<T: TuplePack>(v: &T, output: &mut Vec<u8>) -> VersionstampOffset {
     v.pack_into_vec(output)
 }
 

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -22,6 +22,7 @@ pub use pack::{TuplePack, TupleUnpack, VersionstampOffset};
 pub use subspace::Subspace;
 pub use versionstamp::Versionstamp;
 
+
 const NIL: u8 = 0x00;
 const BYTES: u8 = 0x01;
 const STRING: u8 = 0x02;
@@ -190,7 +191,7 @@ pub fn pack<T: TuplePack>(v: &T) -> Vec<u8> {
 ///
 /// Panics if there is multiple versionstamp present or if the encoded data size doesn't fit in `u32`.
 pub fn pack_with_versionstamp<T: TuplePack>(v: &T) -> Vec<u8> {
-    v.pack_to_vec_with_versionstamp()
+    v.pack_to_vec()
 }
 
 /// Pack value into the given buffer
@@ -198,7 +199,7 @@ pub fn pack_with_versionstamp<T: TuplePack>(v: &T) -> Vec<u8> {
 /// # Panics
 ///
 /// Panics if the encoded data size doesn't fit in `u32`.
-pub fn pack_into<T: TuplePack>(v: &T, output: &mut Vec<u8>) -> VersionstampOffset {
+pub fn pack_into<T: TuplePack>(v: &T, output: &mut Vec<u8>) {
     v.pack_into_vec(output)
 }
 
@@ -208,10 +209,7 @@ pub fn pack_into<T: TuplePack>(v: &T, output: &mut Vec<u8>) -> VersionstampOffse
 ///
 /// Panics if there is multiple versionstamp present or if the encoded data size doesn't fit in `u32`.
 pub fn pack_into_with_versionstamp<T: TuplePack>(v: &T, output: &mut Vec<u8>) {
-    let offset = v.pack_into_vec_with_versionstamp(output);
-    if let VersionstampOffset::MultipleIncomplete = offset {
-        panic!("pack_into_with_versionstamp does not allow multiple versionstamps");
-    }
+    v.pack_into_vec(output);
 }
 
 /// Unpack input
@@ -650,11 +648,7 @@ mod tests {
     }
 
     #[test]
-    fn test_verstionstamp() {
-        assert_eq!(
-            Bytes::from(pack(&("foo", Versionstamp::incomplete(0)))),
-            Bytes::from(&b"\x02foo\x00\x33\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00"[..])
-        );
+    fn test_versionstamp() {
         assert_eq!(
             Bytes::from(pack_with_versionstamp(&(
                 "foo",

--- a/foundationdb/src/tuple/pack.rs
+++ b/foundationdb/src/tuple/pack.rs
@@ -85,8 +85,8 @@ pub trait TuplePack {
     /// # Panics
     ///
     /// Panics if the encoded data size doesn't fit in `u32`.
-    fn pack_into_vec(&self, output: &mut Vec<u8>) {
-        self.pack_root(output).expect(PACK_ERR_MSG);
+    fn pack_into_vec(&self, output: &mut Vec<u8>) -> VersionstampOffset {
+        self.pack_root(output).expect(PACK_ERR_MSG)
     }
 
     /// Pack value into the given buffer

--- a/foundationdb/tests/tuple.rs
+++ b/foundationdb/tests/tuple.rs
@@ -1,0 +1,99 @@
+// Copyright 2018 foundationdb-rs developers, https://github.com/Clikengo/foundationdb-rs/graphs/contributors
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use foundationdb::{
+    options::MutationType,
+    tuple::{Subspace, Versionstamp},
+    Database,
+};
+use futures::StreamExt;
+
+mod common;
+
+#[test]
+// testing subspace with versionstamps.
+fn test_tuples() {
+    let _guard = unsafe { foundationdb::boot() };
+    let db = futures::executor::block_on(common::database()).expect("cannot open fdb");
+
+    eprintln!("clearing all keys");
+    let trx = db.create_trx().expect("cannot create txn");
+    trx.clear_range(b"", b"\xff");
+    futures::executor::block_on(trx.commit()).expect("could not clear keys");
+
+    eprintln!("creating directories");
+    futures::executor::block_on(test_subspace_with_versionstamp(&db));
+}
+
+async fn test_subspace_with_versionstamp(db: &Database) {
+    let trx = db.create_trx().expect("cannot create txn");
+
+    // In this example we will create a subspace starting with a versionstamp.
+    let subspace = Subspace::from("root");
+    let subspace = subspace.subspace(&Versionstamp::incomplete(0));
+    let key = subspace.pack_with_versionstamp(&"key");
+
+    eprintln!("writing key {key:?}");
+    trx.atomic_op(&key, b"hello", MutationType::SetVersionstampedKey);
+
+    // we want to get the versionstamp back to be able to read the subspace.
+    let versionstamp = trx.get_versionstamp();
+
+    trx.commit().await.expect("cannot commit");
+
+    let versionstamp = versionstamp
+        .await
+        .expect("cannot get versionstamp after commit");
+    let versionstamp = Versionstamp::complete(
+        (*versionstamp)
+            .try_into()
+            .expect("versionstamp is the wrong size"),
+        0,
+    );
+    // Now that we have the versionstamp we can rebuild the subspace and read the key.
+    let trx = db.create_trx().expect("cannot create txn");
+
+    // In this example we will create a subspace starting with a versionstamp.
+    let subspace = Subspace::from("root");
+    let subspace = subspace.subspace(&versionstamp);
+
+    {
+        // we can read the whole subspace to get the chance to unpack the key too.
+        let mut elements = trx.get_ranges_keyvalues(subspace.range().into(), false);
+        while let Some(key_value) = elements.next().await {
+            let key_value = key_value.expect("cannot read keyvalue");
+            let key = subspace
+                .unpack::<String>(key_value.key())
+                .expect("cannot unpack key");
+            assert_eq!(key, "key");
+            assert_eq!(key_value.value(), b"hello");
+        }
+    }
+    trx.commit().await.expect("cannot commit");
+
+    // Now that the subspace already exists, we can add more versionstamped keys in there.
+    let trx = db.create_trx().expect("cannot create txn");
+    let key = subspace.pack_with_versionstamp(&Versionstamp::incomplete(0));
+    trx.atomic_op(&key, b"hello2", MutationType::SetVersionstampedKey);
+    let key_versionstamp = trx.get_versionstamp();
+    trx.commit().await.expect("cannot commit");
+    let key_versionstamp = key_versionstamp
+        .await
+        .expect("cannot get versionstamp after commit");
+    let key_versionstamp = Versionstamp::complete(
+        (*key_versionstamp)
+            .try_into()
+            .expect("versionstamp is the wrong size"),
+        0,
+    );
+    // we can read the key back by re-packing with the subspace:
+    let trx = db.create_trx().expect("cannot create txn");
+    let key = subspace.pack_with_versionstamp(&key_versionstamp);
+    let value = trx.get(&key, false).await.expect("cannot read key");
+    assert_eq!(value.as_deref(), Some(b"hello2".as_ref()));
+    trx.commit().await.expect("cannot commit");
+}

--- a/foundationdb/tests/tuple.rs
+++ b/foundationdb/tests/tuple.rs
@@ -35,7 +35,7 @@ async fn test_subspace_with_versionstamp(db: &Database) {
     // In this example we will create a subspace starting with a versionstamp.
     let subspace = Subspace::from("root");
     let subspace = subspace.subspace(&Versionstamp::incomplete(0));
-    let key = subspace.pack_with_versionstamp(&"key");
+    let key = subspace.pack(&"key");
 
     eprintln!("writing key {key:?}");
     trx.atomic_op(&key, b"hello", MutationType::SetVersionstampedKey);
@@ -77,7 +77,7 @@ async fn test_subspace_with_versionstamp(db: &Database) {
 
     // Now that the subspace already exists, we can add more versionstamped keys in there.
     let trx = db.create_trx().expect("cannot create txn");
-    let key = subspace.pack_with_versionstamp(&Versionstamp::incomplete(0));
+    let key = subspace.pack(&Versionstamp::incomplete(0));
     trx.atomic_op(&key, b"hello2", MutationType::SetVersionstampedKey);
     let key_versionstamp = trx.get_versionstamp();
     trx.commit().await.expect("cannot commit");
@@ -92,7 +92,7 @@ async fn test_subspace_with_versionstamp(db: &Database) {
     );
     // we can read the key back by re-packing with the subspace:
     let trx = db.create_trx().expect("cannot create txn");
-    let key = subspace.pack_with_versionstamp(&key_versionstamp);
+    let key = subspace.pack(&key_versionstamp);
     let value = trx.get(&key, false).await.expect("cannot read key");
     assert_eq!(value.as_deref(), Some(b"hello2".as_ref()));
     trx.commit().await.expect("cannot commit");


### PR DESCRIPTION
This one takes a more opinionated approach to packing, to ensure that packing of values with incomplete versionstamp will append the versionstamp offset at the end.

To further expand on this, we can expose an enum with `Complete(bytes)` and `Incomplete(bytes)` to force the use with `set_versionstampedX`