### PR TITLE
Bump MSRV

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,9 +1,5 @@
-# reload when these files change
-watch_file flake.nix
-watch_file flake.lock
-
-# load the flake devShell
-eval "$(nix print-dev-env)"
+# Load the flake
+use flake
 
 # bindingTester
 layout python3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        toolchain: ["1.65.0", "stable"]
+        toolchain: ["1.70.0", "stable"]
         fdb_feature_version: ["fdb-7_1", "fdb-7_0", "fdb-6_3", "fdb-6_2", "fdb-6_1"]
 
     runs-on: ${{ matrix.os }}
@@ -88,7 +88,7 @@ jobs:
     name: "Test foundationDB with ${{ matrix.toolchain }}"
     strategy:
       matrix:
-        toolchain: ["1.65.0", "stable", "beta", "nightly"]
+        toolchain: ["1.70.0", "stable", "beta", "nightly"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/cron-correctness.yml
+++ b/.github/workflows/cron-correctness.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         parallelism: ["1", "2", "3"]
-        toolchain: ["1.65.0", "stable", "beta", "nightly"]
+        toolchain: ["1.70.0", "stable", "beta", "nightly"]
     env:
       CARGO_INCREMENTAL: 0
       RUST_BACKTRACE: 1

--- a/.github/workflows/pr-correctness.yml
+++ b/.github/workflows/pr-correctness.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         parallelism: ["1", "2", "3"]
-        toolchain: ["1.65.0", "stable", "beta", "nightly"]
+        toolchain: ["1.70.0", "stable", "beta", "nightly"]
     env:
       CARGO_INCREMENTAL: 0
       RUST_BACKTRACE: 1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/foundationdb-rs/foundationdb-rs/ci.yml?branch=main)](https://github.com/foundationdb-rs/foundationdb-rs/actions)
 [![dependency status](https://deps.rs/repo/github/foundationdb-rs/foundationdb-rs/status.svg)](https://deps.rs/repo/github/foundationdb-rs/foundationdb-rs)
 [![Codecov](https://img.shields.io/codecov/c/github/foundationdb-rs/foundationdb-rs)](https://codecov.io/gh/foundationdb-rs/foundationdb-rs)
-![Rustc 1.65+](https://img.shields.io/badge/rustc-1.65+-lightgrey)
+![Rustc 1.70+](https://img.shields.io/badge/rustc-1.70+-lightgrey)
 
 # FoundationDB Rust Client
 
@@ -14,7 +14,7 @@ The repo consists of multiple crates:
 | [**foundationdb-sys**](foundationdb-sys/README.md) | [![Crates.io](https://img.shields.io/crates/v/foundationdb-sys)](https://crates.io/crates/foundationdb-sys) [![foundationdb-sys](https://docs.rs/foundationdb-sys/badge.svg)](https://docs.rs/foundationdb-sys) | C API bindings for FoundationDB                             |
 | **foundationdb-gen**                               | n/a                                                                                                                                                                                                             | Code generator for common options and types of FoundationDB |
 
-The current version requires rustc 1.65+ to work.
+The current version requires rustc 1.70+ to work.
 The previous version (0.3) is still maintained and is available within the 0.3 branch.
 
 You can access the `main` branch documentation [here](https://foundationdb-rs.github.io/foundationdb-rs/foundationdb/index.html).

--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699343069,
-        "narHash": "sha256-s7BBhyLA6MI6FuJgs4F/SgpntHBzz40/qV0xLPW6A1Q=",
+        "lastModified": 1702900294,
+        "narHash": "sha256-pt7sSoJYNw3n8YtXw0Z/Nnr6/PfY2YrjDvqboErXnRM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ec750fd01963ab6b20ee1f0cb488754e8036d89d",
+        "rev": "886c9aee6ca9324e127f9c2c4e6f68c2641c8256",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699409596,
-        "narHash": "sha256-L3g1smIol3dGTxkUQOlNShJtZLvjLzvtbaeTRizwZBU=",
+        "lastModified": 1702952173,
+        "narHash": "sha256-24kUnTZgXP5B/fs1/f61tJuHyFrJ8824rn1B/0hL1og=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "58240e1ac627cef3ea30c7732fedfb4f51afd8e7",
+        "rev": "20fd62b0891707a1db8117d09fc3e65a1cd0f6d7",
         "type": "github"
       },
       "original": {

--- a/foundationdb-bench/Cargo.toml
+++ b/foundationdb-bench/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Vincent Rouillé <vincent@clikengo.com>",
 ]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 description = """
 Bindings to the C api for FoundationDB

--- a/foundationdb-bindingtester/Cargo.toml
+++ b/foundationdb-bindingtester/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 description = """
 Bindings to the C api for FoundationDB

--- a/foundationdb-gen/Cargo.toml
+++ b/foundationdb-gen/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 description = """
 Binding generation helper for FoundationDB.

--- a/foundationdb-macros/Cargo.toml
+++ b/foundationdb-macros/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 description = """
 Macro definitions used to maintain the FoundationDB's crate

--- a/foundationdb-sys/Cargo.toml
+++ b/foundationdb-sys/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 description = """
 Bindings to the C api for FoundationDB

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 description = """
 High level client bindings for FoundationDB.

--- a/foundationdb/README.md
+++ b/foundationdb/README.md
@@ -4,7 +4,7 @@ This is a wrapper library around the FoundationDB (Fdb) C API. It implements fut
 
 ## Prerequisites
 
-* Rust 1.65.0 or more,
+* Rust 1.70.0 or more,
 * FoundationDB's client installed.
 
 ## Platform Support


### PR DESCRIPTION
Fix CI error:

```
  Downloaded linux-raw-sys v0.4.12
  Downloaded libc v0.2.151
error: package `home v0.5.9` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.65.0
Either upgrade to rustc 1.70.0 or newer, or use
cargo update -p home@0.5.9 --precise ver
where `ver` is the latest version of `home` supporting rustc 1.65.0
```