### PR TITLE
fix(foundationdb): make the db_run non capturing

### DIFF
--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -30,9 +30,9 @@ use futures::prelude::*;
 #[cfg(feature = "tenant-experimental")]
 use crate::tenant::FdbTenant;
 
-/// Wrapper around the boolean representing whether the 
+/// Wrapper around the boolean representing whether the
 /// previous transaction is still on fly
-/// This wrapper prevents the boolean to be copy and force it 
+/// This wrapper prevents the boolean to be copy and force it
 /// to be moved instead.
 /// This pretty handy when you don't want to see the `Database::run` closure
 /// capturing the environment.
@@ -288,7 +288,7 @@ impl Database {
     ///
     /// The closure will notify the user in case of a maybe_committed transaction in a previous run
     ///  with the `MaybeCommitted` provided in the closure.
-    /// 
+    ///
     /// This one can used as boolean with
     /// ```ignore
     /// db.run(|trx, maybe_committed| async {
@@ -309,7 +309,11 @@ impl Database {
 
         loop {
             // executing the closure
-            let result_closure = closure(transaction.clone(), MaybeCommitted(maybe_committed_transaction)).await;
+            let result_closure = closure(
+                transaction.clone(),
+                MaybeCommitted(maybe_committed_transaction),
+            )
+            .await;
 
             if let Err(e) = result_closure {
                 // checks if it is an FdbError


### PR DESCRIPTION
Hello 👋

I would like to introduce a modification in the `Database::run` parameters signature.

The function is great, but there is a little flaw with the `maybe_committed` closure parameter. As this one is a boolean which is "copiable".

Therefore, if you want to use this parameter, you have to make the closure capturing. 

```rust
db.run(|trx, maybe_committed| async move {
    if maybe_committed {
        // treatment
    }
    Ok(())
})
.await
```

But sometimes this behavior is not desired. For example, when, your closure uses an immutable reference of a variable in the outer environment.

```rust
#[derive(Debug)]
struct Data;
let data = Data;

db.run(|trx, maybe_committed| async move {
    if maybe_committed {
        // treatment
    }
    dbg!(&data)
    Ok(())
})
.await
```

With the error:

```
cannot move out of `data`, a captured variable in an `Fn` closure
```


There are two ways to making it functional

By using an Arc

```rust
#[derive(Debug)]
struct Data;

let data = Arc::new(Data);

db.run(|trx, maybe_committed| {
    let data = data.clone();

    async move {
        if maybe_committed {
            // treatment
        }
        dbg!(&data);
        Ok(())
    }
})
.await
```
Which wraps the variable in an immutable state.

Or by forcing the move of the boolean instead of its copy. This is done by wrapping the boolean into a non-copy structure.

The boolean can be recovered through the `into()` call

```rust
#[derive(Debug)]
struct Data;

let data = Data;

db.run(|trx, maybe_committed| {
    struct Wrapper(bool);
    impl From<Wrapper> for bool {
        fn from(value: Wrapper) -> Self {
            value.0
        }
    }

    let maybe_committed = Wrapper(maybe_committed);

    async {
        if maybe_committed.into() {
            // treatment
        }
        dbg!(&data);
        Ok(())
    }
})
.await
```

This way the data keeps its type.

As I prefer the second solution, but because the boilerplate is a bit heavy. I would like to modify the boolean type of mayby_committed into a wrapped boolean implementing Into<bool>.

This way the API becomes:

```rust
db.run(|trx, maybe_committed| async {
    if maybe_committed.into() {
        // treatment
    }
    dbg!(&data);
    Ok(())
})
.await
```

Leaving the closure non-capturing.