### PR TITLE
Add multi version support example

### DIFF
--- a/foundationdb/examples/multi_version.rs
+++ b/foundationdb/examples/multi_version.rs
@@ -2,7 +2,7 @@ use byteorder::ByteOrder;
 use foundationdb::api::FdbApiBuilder;
 use foundationdb::options::NetworkOption;
 use foundationdb::tuple::Subspace;
-use foundationdb::{options, Database, FdbError, Transaction};
+use foundationdb::{options, Database, FdbBindingError};
 
 /// This example demonstrate usage of multi_version compatibility client.
 ///
@@ -12,76 +12,69 @@ use foundationdb::{options, Database, FdbError, Transaction};
 ///
 /// Ref: https://apple.github.io/foundationdb/api-general.html#multi-version-client-api
 
-const NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY: &str = "FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY";
+const NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY: &str =
+    "FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY";
 
 #[tokio::main]
 async fn main() {
-    let mut network_builder = FdbApiBuilder::default().build().expect("Failed to build API");
+    let mut network_builder = FdbApiBuilder::default()
+        .build()
+        .expect("Failed to build API");
     // You can either use FoundationDB network option through environment variables
     // or through network options in code.
     // directory specified should contain at least one libfdb.so
     if !std::env::var(NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY).is_ok() {
         network_builder = network_builder
-            .set_option(NetworkOption::ExternalClientDirectory("/usr/lib/foundationdb/".to_string()))
+            .set_option(NetworkOption::ExternalClientDirectory(
+                "/usr/lib/foundationdb/".to_string(),
+            ))
             .expect("Failed to add external library directory");
     }
-    let _guard = unsafe { 
-        network_builder.boot()
-    };
+    let _guard = unsafe { network_builder.boot() };
 
     // You can replace `None` with an `Option` with the path to your `fdb.cluster` file
     let db = Database::new_compat(None)
         .await
         .expect("failed to get database");
 
-    let counter_key = Subspace::all().subspace(&"stats").pack(&"my_counter");
+    // used to catch the first cluster_version_changed error when using external clients
+    // when using external clients, it will throw cluster_version_changed for the first time establish the connection to
+    // the cluster. Thus, we catch it by doing a get version request to establish the connection
+    // The 3000ms timeout is a guard to avoid waiting forever when the cli cannot talk to any coordinators
+    let _ = db
+        .run(|trx, _| async move {
+            trx.set_option(options::TransactionOption::Timeout(3000))?;
+            let maybe_version = trx.get_read_version().await;
 
-	// used to catch the first cluster_version_changed error when using external clients
-	// when using external clients, it will throw cluster_version_changed for the first time establish the connection to
-	// the cluster. Thus, we catch it by doing a get version request to establish the connection
-	// The 3000ms timeout is a guard to avoid waiting forever when the cli cannot talk to any coordinators
-    loop {
-        let trx = db.create_trx().expect("could not create transaction");
-        trx.set_option(options::TransactionOption::Timeout(3000)).expect("Failed to set timeout option");
-        if let Err(e) = trx.get_read_version().await {
-            // 1039: cluster_version_changed
-            if e.code() == 1039 {
-                continue;
+            match maybe_version {
+                Ok(_) => Ok(()),
+                // 1039: cluster_version_changed
+                Err(err) if err.code() == 1039 => Err(FdbBindingError::from(err)),
+                Err(err) => Err(FdbBindingError::NonRetryableFdbError(err)),
             }
+        })
+        .await;
 
-            panic!("Unexpected error {} while initializing the multiversion client", e.code());
-        }
-        break;
-    }
-    // write initial value
+    let key = Subspace::all()
+        .subspace(&"examples")
+        .pack(&"multi_version_incr");
+
+    // increment or create key with "1"
     let trx = db.create_trx().expect("could not create transaction");
-    increment(&trx, &counter_key, 1);
+    let mut buf = [0u8; 8];
+    byteorder::LE::write_i64(&mut buf, 1);
+    trx.atomic_op(&key, &buf, options::MutationType::Add);
     trx.commit().await.expect("could not commit");
 
-    // read counter
+    // read counter value
     let trx = db.create_trx().expect("could not create transaction");
-    let v1 = read_counter(&trx, &counter_key)
-        .await
-        .expect("could not read counter");
-    dbg!(v1);
-    assert!(v1 > 0);
-}
-
-async fn read_counter(trx: &Transaction, key: &[u8]) -> Result<i64, FdbError> {
     let raw_counter = trx
-        .get(key, true)
+        .get(&key, true)
         .await
         .expect("could not read key")
         .expect("no value found");
 
     let counter = byteorder::LE::read_i64(raw_counter.as_ref());
-    Ok(counter)
-}
-
-fn increment(trx: &Transaction, key: &[u8], incr: i64) {
-    // generate the right buffer for atomic_op
-    let mut buf = [0u8; 8];
-    byteorder::LE::write_i64(&mut buf, incr);
-
-    trx.atomic_op(key, &buf, options::MutationType::Add);
+    dbg!(counter);
+    assert!(counter > 0);
 }

--- a/foundationdb/examples/multi_version.rs
+++ b/foundationdb/examples/multi_version.rs
@@ -1,0 +1,87 @@
+use byteorder::ByteOrder;
+use foundationdb::api::FdbApiBuilder;
+use foundationdb::options::NetworkOption;
+use foundationdb::tuple::Subspace;
+use foundationdb::{options, Database, FdbError, Transaction};
+
+/// This example demonstrate usage of multi_version compatibility client.
+///
+/// While you still need to compile the crate with a specific FoundationDB library version,
+/// it allows you to connect to a cluster with a different API version. Be aware that using
+/// this feature might lead to divergent behaviors.
+///
+/// Ref: https://apple.github.io/foundationdb/api-general.html#multi-version-client-api
+
+const NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY: &str = "FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY";
+
+#[tokio::main]
+async fn main() {
+    let mut network_builder = FdbApiBuilder::default().build().expect("Failed to build API");
+    // You can either use FoundationDB network option through environment variables
+    // or through network options in code.
+    // directory specified should contain at least one libfdb.so
+    if !std::env::var(NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY).is_ok() {
+        network_builder = network_builder
+            .set_option(NetworkOption::ExternalClientDirectory("/usr/lib/foundationdb/".to_string()))
+            .expect("Failed to add external library directory");
+    }
+    let _guard = unsafe { 
+        network_builder.boot()
+    };
+
+    // You can replace `None` with an `Option` with the path to your `fdb.cluster` file
+    let db = Database::new_compat(None)
+        .await
+        .expect("failed to get database");
+
+    let counter_key = Subspace::all().subspace(&"stats").pack(&"my_counter");
+
+	// used to catch the first cluster_version_changed error when using external clients
+	// when using external clients, it will throw cluster_version_changed for the first time establish the connection to
+	// the cluster. Thus, we catch it by doing a get version request to establish the connection
+	// The 3000ms timeout is a guard to avoid waiting forever when the cli cannot talk to any coordinators
+    loop {
+        let trx = db.create_trx().expect("could not create transaction");
+        trx.set_option(options::TransactionOption::Timeout(3000)).expect("Failed to set timeout option");
+        if let Err(e) = trx.get_read_version().await {
+            // 1039: cluster_version_changed
+            if e.code() == 1039 {
+                continue;
+            }
+
+            panic!("Unexpected error {} while initializing the multiversion client", e.code());
+        }
+        break;
+    }
+    // write initial value
+    let trx = db.create_trx().expect("could not create transaction");
+    increment(&trx, &counter_key, 1);
+    trx.commit().await.expect("could not commit");
+
+    // read counter
+    let trx = db.create_trx().expect("could not create transaction");
+    let v1 = read_counter(&trx, &counter_key)
+        .await
+        .expect("could not read counter");
+    dbg!(v1);
+    assert!(v1 > 0);
+}
+
+async fn read_counter(trx: &Transaction, key: &[u8]) -> Result<i64, FdbError> {
+    let raw_counter = trx
+        .get(key, true)
+        .await
+        .expect("could not read key")
+        .expect("no value found");
+
+    let counter = byteorder::LE::read_i64(raw_counter.as_ref());
+    Ok(counter)
+}
+
+fn increment(trx: &Transaction, key: &[u8], incr: i64) {
+    // generate the right buffer for atomic_op
+    let mut buf = [0u8; 8];
+    byteorder::LE::write_i64(&mut buf, incr);
+
+    trx.atomic_op(key, &buf, options::MutationType::Add);
+}

--- a/foundationdb/src/api.rs
+++ b/foundationdb/src/api.rs
@@ -72,7 +72,19 @@ impl FdbApiBuilder {
                 self.runtime_version,
                 fdb_sys::FDB_API_VERSION as i32,
             )
-        })?;
+        }).map_err(|e| {
+                // 2203: api_version_not_supported
+                // generally mean the local libfdb doesn't support requested target version
+                if e.code() == 2203 {
+                    let max_api_version = unsafe { fdb_sys::fdb_get_max_api_version() };
+                    if max_api_version < fdb_sys::FDB_API_VERSION as i32 {
+                        println!("The version of FoundationDB binding requested '{}' is not supported", fdb_sys::FDB_API_VERSION);
+                        println!("by the installed FoundationDB C library. Maximum supported version by the local library is {}", max_api_version);
+                    }
+                }
+                e
+            })?;
+
         Ok(NetworkBuilder { _private: () })
     }
 }


### PR DESCRIPTION
Hi :wave: 

This PR brings an example of usage for the multi_version feature of FoundationDB library client. Moreover, I added a small error handling when defining the client API version to use. It will help to better understand that the installed lib version is below required rust client version.