### PR TITLE
Fix foundationdb-simulation compilation with fdb-7_1 feature

### DIFF
--- a/foundationdb-simulation/build.rs
+++ b/foundationdb-simulation/build.rs
@@ -49,7 +49,7 @@ fn display_build_warnings() {
 fn build_with_gcc(api_version: &str) {
     cc::Build::new()
         .cpp(true)
-        .std("c++17")
+        .std("c++14")
         .define("FDB_API_VERSION", api_version)
         .file("src/FDBWrapper.cpp")
         .file("src/FDBWorkload.cpp")
@@ -61,7 +61,7 @@ fn build_with_clang(api_version: &str) {
         .compiler("clang")
         .cpp_set_stdlib("c++")
         .cpp(true)
-        .std("c++17")
+        .std("c++14")
         .define("FDB_API_VERSION", api_version)
         .file("src/FDBWrapper.cpp")
         .file("src/FDBWorkload.cpp")

--- a/foundationdb-simulation/build.rs
+++ b/foundationdb-simulation/build.rs
@@ -34,7 +34,7 @@ fn main() {
         display_build_warnings();
 
         // FDB is built with gcc
-        build_with_gcc(&stringified_api_version);
+        build_with_gcc(&api_version);
     }
 }
 
@@ -49,6 +49,7 @@ fn display_build_warnings() {
 fn build_with_gcc(api_version: &str) {
     cc::Build::new()
         .cpp(true)
+        .std("c++17")
         .define("FDB_API_VERSION", api_version)
         .file("src/FDBWrapper.cpp")
         .file("src/FDBWorkload.cpp")
@@ -60,6 +61,7 @@ fn build_with_clang(api_version: &str) {
         .compiler("clang")
         .cpp_set_stdlib("c++")
         .cpp(true)
+        .std("c++17")
         .define("FDB_API_VERSION", api_version)
         .file("src/FDBWrapper.cpp")
         .file("src/FDBWorkload.cpp")

--- a/foundationdb-simulation/src/headers/ClientWorkload.h
+++ b/foundationdb-simulation/src/headers/ClientWorkload.h
@@ -47,7 +47,7 @@ class FDBLogger {
 public:
 	virtual void trace(FDBSeverity sev,
 	                   const std::string& name,
-	                   const std::vector<std::pair<std::string, std::string>>& details) = 0;
+	                   const std::vector<std::pair<std::string, std::string> >& details) = 0;
 };
 
 class FDBWorkloadContext : public FDBLogger {


### PR DESCRIPTION
Also this MR fixes compilation by old compilers like gcc from centos-7.