### PR TITLE
Handle `FdbError` retrieval from recursively nested `FdbBindingError`

### DIFF
--- a/foundationdb/examples/micro-queue.rs
+++ b/foundationdb/examples/micro-queue.rs
@@ -1,7 +1,10 @@
 use core::fmt;
 use std::error;
 
-use foundationdb::{future::FdbValue, tuple::Subspace, Database, FdbBindingError, RangeOption};
+use foundationdb::{
+    future::FdbValue, tuple::Subspace, Database, FdbBindingError, FdbError, GetFdbError,
+    RangeOption,
+};
 use futures::StreamExt;
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 
@@ -30,6 +33,12 @@ impl fmt::Display for Overflow {
 }
 
 impl error::Error for Overflow {}
+
+impl GetFdbError for Overflow {
+    fn get_fdb_error(&self) -> Option<FdbError> {
+        None
+    }
+}
 
 /// First-in-first-out (FIFO) queue of UTF-8 strings, implemented as a layer on
 /// top of `FoundationDB`, after the [Java recipe](https://github.com/apple/foundationdb/blob/main/recipes/java-recipes/MicroQueue.java).

--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -23,7 +23,7 @@ use crate::options;
 use crate::transaction::*;
 use crate::{error, FdbError, FdbResult};
 
-use crate::error::FdbBindingError;
+use crate::error::{FdbBindingError, GetFdbError};
 use futures::prelude::*;
 
 #[cfg(any(feature = "fdb-7_1", feature = "fdb-7_3"))]

--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -42,6 +42,7 @@ pub use crate::database::*;
 pub use crate::error::FdbBindingError;
 pub use crate::error::FdbError;
 pub use crate::error::FdbResult;
+pub use crate::error::GetFdbError;
 pub use crate::keyselector::*;
 pub use crate::transaction::*;
 

--- a/foundationdb/src/tenant.rs
+++ b/foundationdb/src/tenant.rs
@@ -7,6 +7,7 @@
 //! Tenants are currently experimental and are not recommended for use in production. Please note that
 //! currently, we [cannot upgrade a cluster with tenants enabled](https://forums.foundationdb.org/t/tenant-feature-metadata-changes-in-7-2-release/3459).
 
+use crate::error::GetFdbError;
 use crate::options::TransactionOption;
 use std::future::Future;
 

--- a/foundationdb/tests/tokio.rs
+++ b/foundationdb/tests/tokio.rs
@@ -40,6 +40,12 @@ impl Display for CustomError {
 
 impl std::error::Error for CustomError {}
 
+impl GetFdbError for CustomError {
+    fn get_fdb_error(&self) -> Option<FdbError> {
+        None
+    }
+}
+
 async fn do_run_with_custom_error() {
     let db = Arc::new(
         foundationdb::Database::new_compat(None)


### PR DESCRIPTION
This design breaks downcasting