### PR TITLE
Make `Element::code` public

### DIFF
--- a/foundationdb-tuple/src/element.rs
+++ b/foundationdb-tuple/src/element.rs
@@ -98,7 +98,7 @@ impl<'a> Ord for Element<'a> {
 }
 
 impl<'a> Element<'a> {
-    fn code(&self) -> u8 {
+    pub fn code(&self) -> u8 {
         match self {
             Element::Nil => super::NIL,
             Element::Bytes(_) => super::BYTES,


### PR DESCRIPTION
Expose the underlying byte representation of tuple elements, which makes it easier to parse/write them. Its also part of the [public design](https://github.com/apple/foundationdb/blob/main/design/tuple.md) so it seems reasonable to expose it as the API is unlikely to break and the behavior is well defined.