### PR TITLE
feat(foundationdb-profiling): Profiling Keyspace Scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,10 +96,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.84"
+name = "async-stream"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -301,8 +323,6 @@ dependencies = [
  "foundationdb-tuple",
  "futures",
  "lazy_static",
- "log",
- "memchr",
  "num-bigint",
  "pretty-bytes",
  "rand",
@@ -342,6 +362,18 @@ dependencies = [
  "quote",
  "syn 2.0.96",
  "try_map",
+]
+
+[[package]]
+name = "foundationdb-profiling"
+version = "0.1.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "foundationdb",
+ "futures-util",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1026,6 +1058,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "foundationdb-bench",
     "foundationdb-bindingtester",
     "foundationdb-macros",
+    "foundationdb-profiling",
     "foundationdb-simulation",
 ]
 

--- a/foundationdb-profiling/Cargo.toml
+++ b/foundationdb-profiling/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "foundationdb-profiling"
+version = "0.1.0"
+authors = [
+    "Pierre Zemb <contact@pierrezemb.fr>",
+    "Yannick Guern <dev@guern.eu>"
+]
+edition = "2021"
+
+[dependencies]
+async-stream = "0.3.6"
+async-trait = "0.1.85"
+foundationdb = { version = "0.9.2", path = "../foundationdb", default-features = false, features = ["fdb-7_3"] }
+futures-util = "0.3.31"
+thiserror = "2.0.11"
+
+[dev-dependencies]
+tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }

--- a/foundationdb-profiling/src/errors.rs
+++ b/foundationdb-profiling/src/errors.rs
@@ -1,0 +1,8 @@
+use std::string::FromUtf8Error;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ParseError {
+    #[error("Unable to decode UTF-8 string from slice : {0}")]
+    Utf8Decode(#[from] FromUtf8Error),
+}

--- a/foundationdb-profiling/src/lib.rs
+++ b/foundationdb-profiling/src/lib.rs
@@ -1,0 +1,203 @@
+//! FoundationDB natively implements transaction profiling and analyzing.
+//!
+//! The transactions are sampled at the specified rate and all the events for that sampled transaction are recorded.
+//! Then at 30 second interval, the data for all the sampled transactions during that interval is flushed to the database.
+//! The sampled data is written into special key space `\xff\x02/fdbClientInfo/ - \xff\x02/fdbClientInfo0`
+//!
+//! [source](https://apple.github.io/foundationdb/transaction-profiler-analyzer.html)
+//!
+//! Each data are recorded as chunked events. Events are referenced by the tuple (VersionStamp, TransactionId),
+//! then a header defined how much chunks defined the data block.
+//!
+//! Profiling Keys look like this:
+//! ```ignore
+//!     FF               - 2 bytes \xff\x02
+//!     SSSSSSSSSS       - 10 bytes Version Stamp
+//!     RRRRRRRRRRRRRRRR - 16 bytes Transaction id
+//!     NNNN             - 4 Bytes Chunk number
+//!     TTTT             - 4 Bytes Total number of chunks
+//!```
+//! [source](https://github.com/apple/foundationdb/blob/main/contrib/transaction_profiling_analyzer/transaction_profiling_analyzer.py#L413)
+//!
+//! To get the data block, each chunk which composes the data block must be accumulated until
+//! reaching the "chunk number"
+//!
+//! Noted: It could have more than one event in the data block
+
+use crate::parsed_key::parse_key;
+use crate::raw_transaction_profiling_block::RawTransactionProfilingBlock;
+use foundationdb::{FdbBindingError, RangeOption, Transaction};
+use futures_util::{Stream, TryStreamExt};
+use std::pin::pin;
+
+mod errors;
+mod parse;
+mod parsed_key;
+mod raw_transaction_profiling_block;
+mod scanner;
+
+/// Defined by the following [pattern](https://github.com/apple/foundationdb/blob/main/contrib/transaction_profiling_analyzer/transaction_profiling_analyzer.py#L421)
+pub const PROFILE_PREFIX: &[u8; 32] = b"\xff\x02/fdbClientInfo/client_latency/";
+
+/// Retrieves raw profiling datablocks stored in the database within the specified read version range.
+///
+/// This function fetches raw events from the FoundationDB range key-value store. The keys are
+/// processed to parse the profiling event data. Events are grouped into chunks and consolidated
+/// into complete [RawTransactionProfilingBlock] instances. The resulting stream yields these complete profiling event
+/// data blocks. Events are referenced using a key structure which includes the transaction ID,
+/// version stamp, and a chunk identifier.
+///
+/// # Arguments
+///
+/// * `trx` - A reference to the FoundationDB `Transaction` used for fetching data.
+/// * `start_read_version` - An optional lower bound read version. If provided, only events
+///                          occurring at or after this version are fetched.
+/// * `end_read_version` - An optional upper bound read version. If provided, only events
+///                        occurring before this version are fetched.
+///
+/// # Returns
+///
+/// Returns an asynchronous stream (`impl Stream`) where each item of the stream is either:
+/// * A `Result<DataBlock, FdbBindingError>`
+///   - `DataBlock`: A complete profiling event data block.
+///   - `FdbBindingError`: An error that occurred during data retrieval or processing.
+///
+/// # Errors
+///
+/// This function will return an error in the following cases:
+/// * If the transaction (provided by `trx`) encounters issues fetching ranges.
+/// * If an error occurs during key or value parsing.
+///
+/// # Notes
+///
+/// Profiling keys follow a specific binary layout defined by the FoundationDB profiling data space:
+/// * `\xff\x02/fdbClientInfo/client_latency/` acts as the prefix for profiling events.
+/// * Events are referred to by tuple: (VersionStamp, TransactionId).
+/// * Events contain chunks, defined by a chunk number and total chunks.
+///
+/// The function ensures fully constructed events are yielded only once all their chunks are retrieved.
+///
+/// # Example
+///
+/// ```no_run
+/// use foundationdb::{Database, Transaction};
+/// use futures_util::StreamExt;
+/// use foundationdb_profiling::get_raw_datablocks;
+///
+/// async fn example_usage(trx: &Transaction) {
+///     let mut stream = get_raw_datablocks(trx, Some(1), Some(10));
+///     while let Some(event) = stream.next().await {
+///         match event {
+///             Ok(data_block) => {
+///                 println!("Received a data block: {:?}", data_block);
+///             }
+///             Err(e) => {
+///                 eprintln!("Error: {:?}", e);
+///             }
+///         }
+///     }
+/// }
+/// ```
+pub async fn get_raw_datablocks(
+    trx: &Transaction,
+    start_read_version: Option<u64>,
+    end_read_version: Option<u64>,
+) -> impl Stream<Item = Result<RawTransactionProfilingBlock, FdbBindingError>> + use<'_> {
+    // build the start prefix of the range
+    let start_key = if let Some(start_version) = start_read_version {
+        let mut key = PROFILE_PREFIX.to_vec();
+        key.extend_from_slice(&start_version.to_be_bytes());
+        // the start_version is a read version on 8 bytes
+        // to build the VersionStamp the batch version must be added
+        // as we don't know it, we append 2 0x0 bytes
+        // https://github.com/apple/foundationdb/blob/main/contrib/transaction_profiling_analyzer/transaction_profiling_analyzer.py#L463
+        key.extend_from_slice(b"\x00\x00");
+        key
+    } else {
+        // If there is no start_version, then the scan begins
+        // at the beginning of the Profiling Keyspace
+        PROFILE_PREFIX.to_vec()
+    };
+
+    let end_key = if let Some(end_version) = end_read_version {
+        let mut key = PROFILE_PREFIX.to_vec();
+        key.extend_from_slice(&end_version.to_be_bytes());
+        key.extend_from_slice(b"\x00\x00");
+        key
+    } else {
+        // If there is no end_version, then the scan ends
+        // at the very last key of the Profiling Keyspace
+        let mut key = PROFILE_PREFIX.to_vec();
+        key.extend_from_slice(b"\xff");
+        key
+    };
+
+    // Create an async iterator which yields completed DataBlock
+    async_stream::try_stream! {
+        // Get an iterator over the range inside the Profiling Keyspace
+        let profiling_events_raw_key_value_stream = trx
+        .get_ranges_keyvalues(RangeOption::from((start_key, end_key)), true);
+
+        // stream must be pinned to be moveable out of the function
+        let mut profiling_events_raw_key_value_stream = pin!(profiling_events_raw_key_value_stream);
+
+        // Keeps track of the actual Datablock in progress
+        let mut in_progress_datablock = None;
+
+        loop {
+            // Get a key/value
+            let raw_key_value = profiling_events_raw_key_value_stream
+                .try_next()
+                .await
+                .map_err(FdbBindingError::from)?;
+
+            // Take decision on raw data
+            match raw_key_value {
+                // end of the range, no more raw keys
+                None => {
+                    break
+                }
+                // available raw key
+                Some(data) => {
+                    // Try to parse the raw data as a ParsedKey
+                    let parsed_key = parse_key(data.key())
+                        .await
+                        .map_err(FdbBindingError::new_custom_error)?;
+
+                    // Take decision on what doing with the ParsedKey
+                    match in_progress_datablock {
+                        // No DataBlock in progress
+                        None => {
+                            // Create a new Datablock from current ParsedKey
+                            let mut datablock = RawTransactionProfilingBlock::new(parsed_key.transaction_id, parsed_key.total_chunk);
+                            // Accumulate the first data chunk
+                            datablock.add_chunk(data.value());
+                            // If the DataBlock is whole
+                            if datablock.is_complete() {
+                                // yield a DataBlock
+                                yield datablock
+                            } else {
+                                // Set the DataBlock as new in progress to
+                                // accumulate more data chunks
+                                in_progress_datablock = Some(datablock)
+                            }
+
+                        }
+                        // If DataBlock is progressing
+                        Some(ref mut event) => {
+                            // Add the new data chunk
+                            event.add_chunk(data.value());
+                            // Yield DataBlock if complete
+                            if event.is_complete() {
+                                // 'take()' reset the `in_progress_datablock` state
+                                if let Some(event) = in_progress_datablock.take() {
+                                    yield event
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/foundationdb-profiling/src/parse.rs
+++ b/foundationdb-profiling/src/parse.rs
@@ -1,0 +1,106 @@
+use crate::errors::ParseError;
+use crate::scanner::Scanner;
+use core::mem::size_of;
+use std::error::Error;
+
+/// Various datatype bytes space
+const DOUBLE_BYTES_SIZE: usize = size_of::<f64>();
+const INTEGER_BYTES_SIZE: usize = size_of::<u32>();
+const LONG_BYTES_SIZE: usize = size_of::<u64>();
+const SHORT_BYTES_SIZE: usize = size_of::<u8>();
+
+/// This module provides parsing traits `Parse` and `ParseWithProtocolVersion`
+/// for asynchronous deserialization of various data types from a `Scanner`,
+/// utilizing custom implementations and macros for efficient byte buffer processing.
+#[async_trait::async_trait]
+pub trait Parse: Sized {
+    async fn parse(scanner: &mut Scanner<'_>) -> Result<Self, Box<dyn Error + Send + Sync>>;
+}
+
+/// A macro for implementing the `Parse` trait for a given type.
+///
+/// This macro simplifies the implementation of the `Parse` trait for types
+/// that can be deserialized from a fixed-size byte buffer using the `Scanner`.
+///
+/// # Parameters
+///
+/// - `$x`: The type for which the `Parse` trait will be implemented (e.g., `f64`, `u32`).
+/// - `$type`: The type whose `from_le_bytes` function will be used to perform
+///   the deserialization from the byte buffer.
+/// - `$size`: The number of bytes required to represent the type in memory.
+///
+/// # Behavior
+///
+/// The macro generates the implementation so that:
+/// 1. It allocates a buffer of `$size` bytes.
+/// 2. Extracts the bytes from the `Scanner`'s remaining data.
+/// 3. Advances the `Scanner`'s internal cursor by `$size`.
+/// 4. Converts the buffer into the target type `$x` using `$type::from_le_bytes()`.
+///
+/// # Errors
+///
+/// If the `Scanner` does not have enough remaining bytes to extract `$size` bytes,
+/// the implementation will panic or exhibit undefined behavior due to bounds violations.
+macro_rules! impl_parse {
+    ($x: ty, $type: ident, $size: expr) => {
+        #[async_trait::async_trait]
+        impl Parse for $x {
+            async fn parse(
+                scanner: &mut Scanner<'_>,
+            ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+                let mut buf = [0_u8; $size];
+                buf.copy_from_slice(&scanner.remaining()[..$size]);
+                scanner.bump_by($size);
+                Ok($type::from_le_bytes(buf))
+            }
+        }
+    };
+}
+
+#[async_trait::async_trait]
+impl<T: Parse> Parse for Option<T> {
+    async fn parse(scanner: &mut Scanner<'_>) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        Ok(Some(T::parse(scanner).await?))
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: Parse + Send> Parse for Vec<T> {
+    async fn parse(scanner: &mut Scanner<'_>) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let size = u32::parse(scanner).await? as usize;
+        let mut result = Vec::with_capacity(size);
+        for _ in 0..size {
+            result.push(scanner.parse().await?);
+        }
+        Ok(result)
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: Parse + Copy, const N: usize> Parse for [T; N] {
+    async fn parse(scanner: &mut Scanner<'_>) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let result = [T::parse(scanner).await?; N];
+        Ok(result)
+    }
+}
+
+#[async_trait::async_trait]
+impl Parse for bool {
+    async fn parse(scanner: &mut Scanner<'_>) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        Ok(u8::parse(scanner).await? != 0)
+    }
+}
+
+#[async_trait::async_trait]
+impl Parse for String {
+    async fn parse(scanner: &mut Scanner<'_>) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let size = u32::parse(scanner).await? as usize;
+        Ok(String::from_utf8(scanner.remaining()[..size].to_vec())
+            .map_err(ParseError::Utf8Decode)?)
+    }
+}
+
+impl_parse!(f64, f64, DOUBLE_BYTES_SIZE);
+impl_parse!(u32, u32, INTEGER_BYTES_SIZE);
+impl_parse!(u64, u64, LONG_BYTES_SIZE);
+impl_parse!(u8, u8, SHORT_BYTES_SIZE);

--- a/foundationdb-profiling/src/parsed_key.rs
+++ b/foundationdb-profiling/src/parsed_key.rs
@@ -1,0 +1,193 @@
+use crate::parse::Parse;
+use crate::scanner::Scanner;
+use crate::PROFILE_PREFIX;
+use foundationdb::tuple::{Bytes, Versionstamp};
+use futures_util::AsyncReadExt;
+use std::error::Error;
+use std::fmt::{Debug, Formatter};
+
+/// Define the number of bytes taken by the '/'
+/// separator, so 1 byte
+const SEPARATOR_BYTES_SIZE: usize = 1;
+
+/// VersionStamp is defined as Big endian 10-byte integer.
+/// First/high 8 bytes are a database version, next two are batch version.
+/// For a total of 10 bytes
+const VERSIONSTAMP_BYTES_SIZE: usize = 10;
+
+/// Transaction ID is defined as 16 bytes identifier
+const TRANSACTION_ID_BYTES_SIZE: usize = 16;
+
+/// Chunk number or total chunk number are
+/// defined as BigEndian 4 bytes integer
+const CHUNK_FIELD_SIZE: usize = 4;
+
+/// The `TransactionId` struct encapsulates the unique 16-byte identifier for a
+/// transaction used in FoundationDB's profiling system.
+///
+/// This identifier is part of the database key structure and is used to group
+/// events associated with a specific transaction. The structure is parsed from
+/// the raw key data as part of the profiling analyzer.
+///
+/// # Internal Representation
+/// Internally, this struct wraps a `Vec<u8>` which contains exactly 16 bytes.
+/// The fixed-size representation ensures compatibility with FoundationDB's
+/// schema for profiling-related keys.
+pub struct TransactionId(Vec<u8>);
+
+impl Debug for TransactionId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let transaction_id = Bytes::from(&self.0[..]);
+        write!(f, "{transaction_id}")
+    }
+}
+
+#[async_trait::async_trait]
+impl Parse for TransactionId {
+    async fn parse(scanner: &mut Scanner<'_>) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let mut buf = [0_u8; TRANSACTION_ID_BYTES_SIZE];
+        scanner.read_exact(&mut buf).await?;
+        Ok(TransactionId(buf.to_vec()))
+    }
+}
+
+/// A struct representing a chunk field of a parsed key.
+/// Can be either a total chunk number or a chunk number
+struct ChunkField(usize);
+
+#[async_trait::async_trait]
+impl Parse for ChunkField {
+    async fn parse(scanner: &mut Scanner<'_>) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let mut buf = [0_u8; CHUNK_FIELD_SIZE];
+        scanner.read_exact(&mut buf).await?;
+        let data = u32::from_be_bytes(buf) as usize;
+        Ok(ChunkField(data))
+    }
+}
+
+/// A struct that represents a logical version, encapsulating a `Versionstamp`.
+struct Version(Versionstamp);
+
+impl Debug for Version {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let version = self.0.transaction_version()[..8].to_vec();
+        let version = u64::from_be_bytes(version.try_into().map_err(|_err| std::fmt::Error)?);
+        write!(f, "{version}")
+    }
+}
+
+#[async_trait::async_trait]
+impl Parse for Version {
+    async fn parse(scanner: &mut Scanner<'_>) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let mut buffer = [0_u8; VERSIONSTAMP_BYTES_SIZE];
+        scanner.read_exact(&mut buffer).await?;
+        Ok(Version(Versionstamp::complete(buffer, 0)))
+    }
+}
+
+/// ProfilingParsedKey represents a structured result of a key parsed from the database.
+///
+/// # Fields
+/// - `transaction_id`: The unique identifier for the transaction.
+/// - `version`: The version of the database associated with the key.
+/// - `current_chunk`: The current chunk index part of the parsed key.
+/// - `total_chunk`: The total number of chunks related to the key.
+pub struct ProfilingParsedKey {
+    pub transaction_id: TransactionId,
+    version: Version,
+    current_chunk: usize,
+    pub total_chunk: usize,
+}
+
+impl ProfilingParsedKey {
+    fn new(
+        version: Version,
+        transaction_id: TransactionId,
+        current_chunk: usize,
+        total_chunk: usize,
+    ) -> Self {
+        ProfilingParsedKey {
+            version,
+            transaction_id,
+            current_chunk,
+            total_chunk,
+        }
+    }
+}
+
+impl Debug for ProfilingParsedKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ParsedKey")
+            .field("version", &self.version)
+            .field("transaction_id", &self.transaction_id)
+            .field("chunk_id", &self.current_chunk)
+            .field("chunk_total", &self.total_chunk)
+            .finish()
+    }
+}
+
+/// Parses a database key into a `ParsedKey` structure.
+///
+/// # Arguments
+///
+/// - `key`: The raw byte slice representing the database key.
+///
+/// # Returns
+///
+/// A `Result` containing a `ParsedKey` if parsing is successful, or an error
+/// if the parsing fails.
+///
+/// The function expects the key to follow the specific format:
+///    - A prefix (`PROFILE_PREFIX`) which is skipped.
+///    - A `Version` field parsed from the key.
+///    - A separator (`/`), accounted for by a single byte (defined by `SEPARATOR_BYTES_SIZE`).
+///    - A `TransactionId` field.
+///    - Another separator (`/`).
+///    - Two `ChunkField`s representing chunk number and total chunks.
+///    - A final separator (`/`).
+/// Parsing converts this data into a `ParsedKey` structure which represents
+/// the fields and their respective values in a structured format.
+///
+/// # Errors
+///
+/// This function can return errors in cases such as:
+/// - Invalid format of the provided key.
+/// - Failure to read the key's fields due to incorrect key length or content.
+pub async fn parse_key(key: &[u8]) -> Result<ProfilingParsedKey, Box<dyn Error + Send + Sync>> {
+    let mut scanner = Scanner::new(key);
+    scanner.bump_by(PROFILE_PREFIX.len());
+    let version = Version::parse(&mut scanner).await?;
+    scanner.bump_by(SEPARATOR_BYTES_SIZE);
+    let transaction_id = TransactionId::parse(&mut scanner).await?;
+    scanner.bump_by(SEPARATOR_BYTES_SIZE);
+    let chunk_number = ChunkField::parse(&mut scanner).await?.0;
+    let chunk_total = ChunkField::parse(&mut scanner).await?.0;
+    scanner.bump_by(SEPARATOR_BYTES_SIZE);
+
+    let parsed_key = ProfilingParsedKey::new(version, transaction_id, chunk_number, chunk_total);
+
+    Ok(parsed_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[tokio::test]
+    async fn test_parse_key() {
+        let key = b"\xff\x02/fdbClientInfo/client_latency/\x19\x5a\x63\xa7\x00\x2f\x3b\xa1\xd8\x00/\x5a\x0c\xd7\xad\x1f\x66\x2c\xb4\xa6\x72\xdb\x45\x3a\x68\xf5\xc1/\x00\x00\x00\x01\x00\x00\x00\x03";
+        let parsed_key = parse_key(key).await.expect("Unable to parse key");
+        assert_eq!(
+            parsed_key.transaction_id.0,
+            [
+                0x5a, 0x0c, 0xd7, 0xad, 0x1f, 0x66, 0x2c, 0xb4, 0xa6, 0x72, 0xdb, 0x45, 0x3a, 0x68,
+                0xf5, 0xc1
+            ]
+        );
+        assert_eq!(
+            parsed_key.version.0.transaction_version(),
+            b"\x19\x5a\x63\xa7\x00\x2f\x3b\xa1\xd8\x00"
+        );
+        assert_eq!(parsed_key.current_chunk, 1);
+        assert_eq!(parsed_key.total_chunk, 3);
+    }
+}

--- a/foundationdb-profiling/src/raw_transaction_profiling_block.rs
+++ b/foundationdb-profiling/src/raw_transaction_profiling_block.rs
@@ -1,0 +1,83 @@
+use crate::parsed_key::TransactionId;
+use foundationdb::tuple::Bytes;
+use std::fmt::{Debug, Formatter};
+
+/// A structure that represents a block of data associated with a specific transaction.
+/// This structure provides functionality to manage and track progress as data chunks
+/// are added until a target chunk count is reached.
+///
+/// # Overview
+/// `RawTransactionProfilingBlock` is designed to aggregate data chunks that belong to the same transaction.
+/// It keeps track of the progress and allows checking when all chunks are accumulated.
+///
+/// # Fields
+/// - `transaction_id`: A unique identifier for the transaction.
+/// - `buffer`: A vector of bytes that stores the accumulated data chunks.
+/// - `target_chunks`: The total number of chunks expected to complete the data block.
+/// - `accumulated_chunks`: The number of chunks added so far.
+///
+/// # Usage
+/// Use the methods provided by `RawTransactionProfilingBlock` to manipulate its data:
+/// - Create a new instance using the `new` method.
+/// - Add data chunks using the `add_chunk` method.
+/// - Verify if the data block is complete with the `is_complete` method.
+/// - Retrieve the collected data using the `get_data` method.
+///
+/// # Example
+/// ```ignore
+///
+/// let transaction_id = TransactionId::new();
+/// let mut data_block = RawTransactionProfilingBlock::new(transaction_id, 3);
+///
+/// data_block.add_chunk(b"chunk1");
+/// data_block.add_chunk(b"chunk2");
+/// data_block.add_chunk(b"chunk3");
+///
+/// assert!(data_block.is_complete());
+/// assert_eq!(data_block.get_data(), b"chunk1chunk2chunk3");
+/// ```
+pub struct RawTransactionProfilingBlock {
+    transaction_id: TransactionId,
+    buffer: Vec<u8>,
+    target_chunks: usize,
+    accumulated_chunks: usize,
+}
+
+impl Debug for RawTransactionProfilingBlock {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let buffer = Bytes::from(&self.buffer[..]);
+
+        f.debug_struct("RawTransactionProfilingBlock")
+            .field("transaction_id", &self.transaction_id)
+            .field(
+                "progress",
+                &format!("{}/{}", self.accumulated_chunks, self.target_chunks),
+            )
+            .field("buffer", &buffer)
+            .finish()
+    }
+}
+
+impl RawTransactionProfilingBlock {
+    pub fn new(transaction_id: TransactionId, target_chunks: usize) -> Self {
+        Self {
+            transaction_id,
+            buffer: vec![],
+            target_chunks,
+            accumulated_chunks: 0,
+        }
+    }
+
+    pub fn add_chunk(&mut self, chunk: &[u8]) {
+        self.buffer.extend_from_slice(chunk);
+        self.accumulated_chunks += 1;
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.accumulated_chunks == self.target_chunks
+    }
+
+    pub fn get_data(&self) -> &[u8] {
+        &self.buffer
+    }
+}

--- a/foundationdb-profiling/src/scanner.rs
+++ b/foundationdb-profiling/src/scanner.rs
@@ -1,0 +1,109 @@
+use crate::parse::Parse;
+use futures_util::io::Cursor;
+use std::error::Error;
+use std::ops::{Deref, DerefMut};
+
+/// A `Scanner` provides an abstraction over a cursor for scanning through a byte slice.
+///
+/// # Example
+///
+/// ```ignore
+/// use crate::Scanner;
+///
+/// let data = b"Hello, world!";
+/// let mut scanner = Scanner::new(data);
+///
+/// // Access remaining bytes
+/// assert_eq!(scanner.remaining(), b"Hello, world!");
+///
+/// // Advance the cursor by 7 bytes
+/// scanner.bump_by(7);
+///
+/// // Remaining bytes after advancing
+/// assert_eq!(scanner.remaining(), b"world!");
+/// ```
+pub(crate) struct Scanner<'a> {
+    cursor: Cursor<&'a [u8]>,
+}
+
+impl<'a> Scanner<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        Scanner {
+            cursor: Cursor::new(data),
+        }
+    }
+
+    /// Advances the cursor by a specified number of bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The number of bytes to advance the cursor.
+    pub fn bump_by(&mut self, size: usize) {
+        self.cursor
+            .set_position(self.cursor.position() + size as u64)
+    }
+
+    /// Returns the remaining bytes in the cursor.
+    ///
+    /// This method provides a slice of the byte array starting at the
+    /// current cursor position and continuing to the end of the data.
+    ///
+    /// # Returns
+    ///
+    /// A slice containing the remaining bytes from the cursor position onward.
+    pub fn remaining(&self) -> &[u8] {
+        &self.cursor.get_ref()[(self.cursor.position() as usize)..]
+    }
+}
+
+impl<'a> Deref for Scanner<'a> {
+    type Target = Cursor<&'a [u8]>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cursor
+    }
+}
+/// This implementation provides a blanket `Deref` trait for the `Scanner` struct,
+/// allowing seamless access to its inner `Cursor<&[u8]>` methods.
+///
+/// By implementing `Deref`, all methods available on the `Cursor` type
+/// can be accessed directly via the `Scanner` instance. This removes
+/// the need to explicitly reference the `cursor` field, streamlining the API usage.
+///
+/// # Example
+///
+/// ```ignore
+/// use crate::Scanner;
+/// use std::io::Seek;
+///
+/// let data = b"Example seamless access";
+/// let scanner = Scanner::new(data);
+///
+/// // Accessing a Cursor method directly via the Scanner instance
+/// assert_eq!(scanner.position(), 0);
+/// ```
+
+impl<'a> DerefMut for Scanner<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.cursor
+    }
+}
+
+impl<'a> Scanner<'a> {
+    pub async fn parse<T: Parse>(&mut self) -> Result<T, Box<dyn Error + Send + Sync>> {
+        T::parse(self).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_scanner() {
+        let data = b"Hello, world!";
+        let mut scanner = Scanner::new(data);
+        assert_eq!(scanner.remaining(), b"Hello, world!");
+        scanner.bump_by(7);
+        assert_eq!(scanner.remaining(), b"world!");
+    }
+}

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -55,7 +55,6 @@ foundationdb-sys = { version = "0.9.1", path = "../foundationdb-sys", default-fe
 foundationdb-macros = { version = "0.3.2", path = "../foundationdb-macros" }
 foundationdb-tuple = { version = "0.9.1", path = "../foundationdb-tuple" }
 futures = "0.3.31"
-memchr = "2.7.4"
 rand = { version = "0.8.5", features = ["default", "small_rng"] }
 static_assertions = "1.1.0"
 uuid = { version = "1.11.1", optional = true }
@@ -63,14 +62,13 @@ num-bigint = { version = "0.4.6", optional = true }
 async-trait = "0.1.84"
 async-recursion = "1.1.1"
 # Required to deserialize tenant info
-serde = { version = "1.0.217", features = ["derive"], optional = true}
-serde_json = { version = "1.0.132", optional = true}
-serde_bytes = { version = "0.11.15", optional = true}
+serde = { version = "1.0.217", features = ["derive"], optional = true }
+serde_json = { version = "1.0.132", optional = true }
+serde_bytes = { version = "0.11.15", optional = true }
 
 [dev-dependencies]
 byteorder = "1.5.0"
 lazy_static = "1.5.0"
-log = "0.4.22"
 tokio = { version = "1.43.0", features = ["full"] }
 ring = "0.17.8"
 data-encoding = "2.6.0"

--- a/foundationdb/src/error.rs
+++ b/foundationdb/src/error.rs
@@ -8,15 +8,14 @@
 
 //! Error types for the Fdb crate
 
-use std::ffi::CStr;
-use std::fmt;
-use std::fmt::{Debug, Display, Formatter};
-
 use crate::directory::DirectoryError;
 use crate::options;
 use crate::tuple::hca::HcaError;
 use crate::tuple::PackError;
 use foundationdb_sys as fdb_sys;
+use std::ffi::CStr;
+use std::fmt;
+use std::fmt::{Debug, Display, Formatter};
 
 pub(crate) fn eval(error_code: fdb_sys::fdb_error_t) -> FdbResult<()> {
     let rust_code: i32 = error_code;


### PR DESCRIPTION
This PR resolves https://github.com/foundationdb-rs/foundationdb-rs/issues/204

It introduces a new crate in the workspace called `foundationdb-profiling`, the crate creation is motivated by three arguments:
- some crates pulled to achieve the task can be heavy like "async-stream"
- the profiling won't be used as daily usage but reserved to very specific tasks
- this PR only introduce the raw datablock profiling retrieving, not its actual parse, thus the crate once completed will be much larger and introduces a fuzzer to check the corectness of the parsing.

The ~~get_raw_datablocks is intentionally private because it is not intended to be the frontend of the library~~. For the same reason, the API takes read version instead of timestamp.

The  https://github.com/foundationdb-rs/foundationdb-rs/issues/205 will expose the real public API.