### PR TITLE
Simplify bindings updates

### DIFF
--- a/foundationdb-sys/src/lib.rs
+++ b/foundationdb-sys/src/lib.rs
@@ -3,3 +3,207 @@
 #![allow(non_snake_case)]
 #![allow(clippy::unreadable_literal)]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+/// Defines the FDB_API_VERSION constant and generates the `if_cfg_api_versions` macro
+/// from a list of (name, number) versions.
+///
+/// `if_cfg_api_versions` has one branch for all possible version combinations:
+/// - (min = ...)
+/// - (max = ...)
+/// - (min = ..., max = ...) with min < max
+///
+/// For macro expansion reasons, we need to generate all the branches in a single expansion,
+/// so this macro uses accumulators to gather all branch data before expanding it in one go.
+/// In short, this is a combinatorial generator. Given `[0, 1, 2, 3]` it generates branches for:
+/// - (min = 0)
+/// - (min = 1)
+/// - (min = 2)
+/// - (min = 3)
+/// - (max = 0)
+/// - (max = 1)
+/// - (max = 2)
+/// - (max = 3)
+/// - (min = 0, max = 1)
+/// - (min = 0, max = 2)
+/// - (min = 0, max = 3)
+/// - (min = 1, max = 2)
+/// - (min = 1, max = 3)
+/// - (min = 2, max = 3)
+macro_rules! versions_expand {
+    ($(($version_name:tt, $version:tt)),+ $(,)?) => {
+        // Entry point: start with a list of (version_name, version_number)
+        // define the FDB_API_VERSION constant
+        $(
+            #[cfg(feature = $version_name)]
+            pub const FDB_API_VERSION: u32 = $version;
+        )*
+        // Call the "@pre" phase with:
+        // - visited_versions: []
+        // - remaining_versions: versions
+        // - acc2: [] (will store min branches)
+        // - acc3: [] (will store max branches)
+        versions_expand!(@pre [][$(($version_name, $version))+][][]);
+    };
+    (@pre [$($max:tt)*][$min:tt $($other:tt)*][$(($($acc2:tt)*))*][$(($($acc3:tt)*))*]) => {
+        // "@pre" phase generates (min = ...) and (max = ...) branches
+        // While remaining_versions is not empty:
+        // - move one version from remaining to visited
+        // - add one "min" branch to acc2
+        // - add one "max" branch to acc3
+        versions_expand!(@pre [$($max)* $min][$($other)*][$(($($acc2)*))* ($min $($other)*)][$(($($acc3)*))* ($min $($max)*)]);
+    };
+    (@pre [$min:tt $($version:tt)*][] $acc2:tt $acc3:tt) => {
+        // remaining_versions is empty: end of "@pre" phase
+        // Call the "@mid" phase with:
+        // - min_range: [versions[0]]
+        // - max_range: versions[1..]
+        // - acc1: [] (will store min-max combination branches)
+        // - acc2: min_branches
+        // - acc3: max_branches
+        versions_expand!(@mid [$min][$($version)*][] $acc2 $acc3);
+    };
+    (@mid [$min:tt $($version:tt)*][$max:tt $($other:tt)*][$(($($acc1:tt)*))*] $acc2:tt $acc3:tt) => {
+        // "@mid" phase generates all (min = ..., max = ...) branches
+        // This step generates all pairs for the current min
+        // While the max_range is not empty:
+        // - let max be the smallest version in max_range
+        // - add the "min max" branch to acc1
+        // - move max to the min_range
+        versions_expand!(@mid [$min $($version)* $max][$($other)*][$(($($acc1)*))* ($min $max $($version)*)] $acc2 $acc3);
+    };
+    (@mid [$drop:tt $min:tt $($version:tt)*][] $acc1:tt $acc2:tt $acc3:tt) => {
+        // max_range is empty: end of inner "@mid" loop
+        // - drop current min
+        // - set the second smallest version in min_range as new min
+        // - set all remaining versions as the max_range
+        versions_expand!(@mid [$min][$($version)*] $acc1 $acc2 $acc3);
+    };
+    (@mid [$drop:tt][] $acc1:tt $acc2:tt $acc3:tt) => {
+        // min_range is empty: end of "@mid" phase
+        // Call the "@end" phase with:
+        // - the $ sign so it can use it as a symbol in the macro
+        // - acc1: min_max_branches
+        // - acc2: min_branches
+        // - acc3: max_branches
+        versions_expand!(@end ($) $acc1 $acc2 $acc3);
+    };
+    (@end ($d:tt)
+        [$((($min_name1:tt, $min1:tt) ($max_name1:tt, $max1:tt) $(($version_name1:tt, $version1:tt))*))*]
+        [$((($min_name2:tt, $min2:tt) $(($version_name2:tt, $version2:tt))*))*]
+        [$((($max_name3:tt, $max3:tt) $(($version_name3:tt, $version3:tt))*))*]
+    ) => {
+        // "@end" phase generates the macro in one expansion
+        // For each branch type, generates the appropriate cfg attributes
+
+        /// Similar to `cfg_api_versions` proc-macro, but as a regular macro.
+        /// Can be used on expressions and non-inlined modules, unlike proc-macros which are unstable in this position.
+        ///
+        /// Any feature after the "min" and "max" arguments will be joined in the "any" predicate.
+        ///
+        /// This macro has two "flavors" which behave slightly differently.
+        ///
+        /// ### "if else" form
+        /// ```rs
+        /// if_cfg_api_versions!(condition => { block1 } else { block2 });
+        /// let result = if_cfg_api_versions!(condition => { block1 } else { block2 });
+        /// ```
+        /// Expects two blocks, behaves like an expression returning the result of the active block.
+        /// Example:
+        /// ```rs
+        /// let result = if_cfg_api_versions!(max = 520 => {
+        ///     println!("5.x");
+        ///     true
+        /// } else {
+        ///     println!("6.0+");
+        ///     false
+        /// });
+        /// // expands to:
+        /// let result = {
+        ///     #[cfg(any(feature = "fdb-5_1", feature = "fdb-5_2"))]
+        ///     {
+        ///         println!("5.x");
+        ///         true
+        ///     }
+        ///     #[cfg(not(any(feature = "fdb-5_1", feature = "fdb-5_2")))]
+        ///     {
+        ///         println!("6.0+");
+        ///         false
+        ///     }
+        /// };
+        /// ```
+        ///
+        /// ### "if" form
+        /// ```rs
+        /// if_cfg_api_versions!(condition => statement);
+        /// ```
+        /// Expects a single statement, only puts a guard over it without any wrapping.
+        /// Useful for non-inline modules.
+        /// Example:
+        /// ```rs
+        /// if_cfg_api_versions!(min = 520, max = 600, feature = "foo" =>
+        ///     pub mod bar;
+        /// );
+        /// // expands to:
+        /// #[cfg(any(feature = "fdb-5_2", feature = "fdb-6_0", feature = "foo"))]
+        /// pub mod bar;
+        /// ```
+        #[macro_export]
+        macro_rules! if_cfg_api_versions {
+            // malformed branch
+            ($d($k:tt = $v:tt),+ => $a:stmt;$d($b:stmt);+ $d(;)?) => {
+                MULTIPLE_STATEMENTS_IN_IF_FORM__PLEASE_USE_A_BLOCK_OR_DUPLICATE_THE_MACRO
+            };
+            // min-max branches
+            $(
+                (min=$min1, max=$max1 $d(,feature = $feature:literal)* => {$d($then:tt)*} else {$d($else:tt)*}) => {{
+                    #[cfg(any(feature=$min_name1 $(,feature=$version_name1)* ,feature=$max_name1 $d(,feature=$feature)*))]
+                    { $d($then)* }
+                    #[cfg(not(any(feature=$min_name1 $(,feature=$version_name1)* ,feature=$max_name1 $d(,feature=$feature)*)))]
+                    { $d($else)* }
+                }};
+                (min=$min1, max=$max1 $d(,feature = $feature:literal)* => $d($then:tt)*) => {
+                    #[cfg(any(feature=$min_name1 $(,feature=$version_name1)* ,feature=$max_name1 $d(,feature=$feature)*))]
+                    $d($then)*
+                };
+            )*
+            // min branches
+            $(
+                (min=$min2 $d(,feature = $feature:literal)* => {$d($then:tt)*} else {$d($else:tt)*}) => {{
+                    #[cfg(any(feature=$min_name2 $(,feature=$version_name2)* $d(,feature=$feature)*))]
+                    { $d($then)* }
+                    #[cfg(not(any(feature=$min_name2 $(,feature=$version_name2)* $d(,feature=$feature)*)))]
+                    { $d($else)* }
+                }};
+                (min=$min2 $d(,feature = $feature:literal)* => $d($then:tt)*) => {
+                    #[cfg(any(feature=$min_name2 $(,feature=$version_name2)* $d(,feature=$feature)*))]
+                    $d($then)*
+                };
+            )*
+            // max branches
+            $(
+                (max=$max3 $d(,feature = $feature:literal)* => {$d($then:tt)*} else {$d($else:tt)*}) => {{
+                    #[cfg(any($(feature=$version_name3,)* feature=$max_name3 $d(,feature=$feature)*))]
+                    { $d($then)* }
+                    #[cfg(not(any($(feature=$version_name3,)* feature=$max_name3 $d(,feature=$feature)*)))]
+                    { $d($else)* }
+                }};
+                (max=$max3 $d(,feature = $feature:literal)* => $d($then:tt)*) => {
+                    #[cfg(any($(feature=$version_name3,)* feature=$max_name3 $d(,feature=$feature)*))]
+                    $d($then)*
+                };
+            )*
+        }
+    };
+}
+
+versions_expand![
+    ("fdb-5_1", 510),
+    ("fdb-5_2", 520),
+    ("fdb-6_0", 600),
+    ("fdb-6_1", 610),
+    ("fdb-6_2", 620),
+    ("fdb-6_3", 630),
+    ("fdb-7_0", 700),
+    ("fdb-7_1", 710),
+    ("fdb-7_3", 730),
+];

--- a/foundationdb/src/future.rs
+++ b/foundationdb/src/future.rs
@@ -36,6 +36,7 @@ pub use crate::fdb_keys::FdbKeys;
 use crate::from_raw_fdb_slice;
 #[cfg_api_versions(min = 710)]
 pub use crate::mapped_key_values::MappedKeyValues;
+use fdb_sys::if_cfg_api_versions;
 use foundationdb_macros::cfg_api_versions;
 use foundationdb_sys as fdb_sys;
 use futures::prelude::*;
@@ -489,26 +490,11 @@ impl TryFrom<FdbFutureHandle> for i64 {
     fn try_from(f: FdbFutureHandle) -> FdbResult<Self> {
         let mut version: i64 = 0;
         error::eval(unsafe {
-            #[cfg(any(
-                feature = "fdb-6_2",
-                feature = "fdb-6_3",
-                feature = "fdb-7_0",
-                feature = "fdb-7_1",
-                feature = "fdb-7_3"
-            ))]
-            {
+            if_cfg_api_versions!(min = 620 => {
                 fdb_sys::fdb_future_get_int64(f.as_ptr(), &mut version)
-            }
-            #[cfg(not(any(
-                feature = "fdb-6_2",
-                feature = "fdb-6_3",
-                feature = "fdb-7_0",
-                feature = "fdb-7_1",
-                feature = "fdb-7_3"
-            )))]
-            {
+            } else {
                 fdb_sys::fdb_future_get_version(f.as_ptr(), &mut version)
-            }
+            })
         })?;
         Ok(version)
     }

--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -6,32 +6,35 @@
 // copied, modified, or distributed except according to those terms.
 #![doc = include_str!("../README.md")]
 
+use foundationdb_sys::if_cfg_api_versions;
+
 #[macro_use]
 extern crate static_assertions;
 
 pub mod api;
-#[cfg(any(feature = "fdb-5_1", feature = "fdb-5_2", feature = "fdb-6_0"))]
-pub mod cluster;
+if_cfg_api_versions! {min = 510, max = 600 =>
+    pub mod cluster;
+}
 mod database;
 pub mod directory;
 mod error;
-#[cfg(any(feature = "fdb-7_0", feature = "fdb-7_1", feature = "fdb-7_3"))]
-#[deny(missing_docs)]
-pub mod fdb_keys;
+if_cfg_api_versions! {min = 700 =>
+    #[deny(missing_docs)]
+    pub mod fdb_keys;
+}
 pub mod future;
 mod keyselector;
-#[cfg(any(feature = "fdb-7_1", feature = "fdb-7_3"))]
-#[deny(missing_docs)]
-pub mod mapped_key_values;
+if_cfg_api_versions! {min = 710 =>
+    #[deny(missing_docs)]
+    pub mod mapped_key_values;
+}
 /// Generated configuration types for use with the various `set_option` functions
 #[allow(clippy::all)]
 pub mod options;
-#[cfg(any(
-    feature = "fdb-7_1",
-    feature = "fdb-7_3",
-    feature = "tenant-experimental"
-))]
-pub mod tenant;
+if_cfg_api_versions! {min = 710 =>
+    #[cfg(feature = "tenant-experimental")]
+    pub mod tenant;
+}
 pub mod timekeeper;
 mod transaction;
 mod tuple_ext;
@@ -41,8 +44,9 @@ pub mod tuple {
     pub use foundationdb_tuple::*;
 }
 
-#[cfg(any(feature = "fdb-5_1", feature = "fdb-5_2", feature = "fdb-6_0"))]
-pub use crate::cluster::Cluster;
+if_cfg_api_versions! {min = 510, max = 600 =>
+    pub use crate::cluster::Cluster;
+}
 
 pub use crate::database::*;
 pub use crate::error::FdbBindingError;

--- a/foundationdb/tests/database.rs
+++ b/foundationdb/tests/database.rs
@@ -8,12 +8,12 @@ fn test_databse() {
     let _guard = unsafe { foundationdb::boot() };
 
     if_cfg_api_versions!(min = 730 =>
-        futures::executor::block_on(test_status_async()).expect("failed to run");
+        futures::executor::block_on(test_status_async()).expect("failed to run")
     );
 
     if_cfg_api_versions!(min = 710 =>
         futures::executor::block_on(test_get_main_thread_busyness_async())
-            .expect("failed to get busyness");
+            .expect("failed to get busyness")
     );
 }
 

--- a/foundationdb/tests/database.rs
+++ b/foundationdb/tests/database.rs
@@ -1,4 +1,5 @@
 use foundationdb_macros::cfg_api_versions;
+use foundationdb_sys::if_cfg_api_versions;
 
 mod common;
 
@@ -6,12 +7,14 @@ mod common;
 fn test_databse() {
     let _guard = unsafe { foundationdb::boot() };
 
-    #[cfg(feature = "fdb-7_3")]
-    futures::executor::block_on(test_status_async()).expect("failed to run");
+    if_cfg_api_versions!(min = 730 =>
+        futures::executor::block_on(test_status_async()).expect("failed to run");
+    );
 
-    #[cfg(any(feature = "fdb-7_1", feature = "fdb-7_3"))]
-    futures::executor::block_on(test_get_main_thread_busyness_async())
-        .expect("failed to get busyness");
+    if_cfg_api_versions!(min = 710 =>
+        futures::executor::block_on(test_get_main_thread_busyness_async())
+            .expect("failed to get busyness");
+    );
 }
 
 #[cfg_api_versions(min = 730)]

--- a/foundationdb/tests/get.rs
+++ b/foundationdb/tests/get.rs
@@ -7,6 +7,7 @@
 
 use foundationdb::*;
 use foundationdb_macros::cfg_api_versions;
+use foundationdb_sys::if_cfg_api_versions;
 use futures::future::*;
 use std::ops::Deref;
 use std::sync::{atomic::*, Arc};
@@ -29,15 +30,9 @@ fn test_get() {
     futures::executor::block_on(test_get_addresses_for_key_async()).expect("failed to run");
     futures::executor::block_on(test_set_raw_option_async()).expect("failed to run");
     futures::executor::block_on(test_fails_to_set_unknown_raw_option()).expect("failed to run");
-    #[cfg(any(
-        feature = "fdb-7_3",
-        feature = "fdb-7_1",
-        feature = "fdb-7_0",
-        feature = "fdb-6_3",
-        feature = "fdb-6_2",
-        feature = "fdb-6_1"
-    ))]
-    futures::executor::block_on(test_metadata_version()).expect("failed to run");
+    if_cfg_api_versions!(min = 610 =>
+        futures::executor::block_on(test_metadata_version()).expect("failed to run");
+    );
 }
 
 async fn test_set_get_async() -> FdbResult<()> {

--- a/foundationdb/tests/get.rs
+++ b/foundationdb/tests/get.rs
@@ -31,7 +31,7 @@ fn test_get() {
     futures::executor::block_on(test_set_raw_option_async()).expect("failed to run");
     futures::executor::block_on(test_fails_to_set_unknown_raw_option()).expect("failed to run");
     if_cfg_api_versions!(min = 610 =>
-        futures::executor::block_on(test_metadata_version()).expect("failed to run");
+        futures::executor::block_on(test_metadata_version()).expect("failed to run")
     );
 }
 

--- a/foundationdb/tests/range.rs
+++ b/foundationdb/tests/range.rs
@@ -10,6 +10,7 @@ use crate::tuple::Subspace;
 
 use foundationdb::*;
 use foundationdb_macros::cfg_api_versions;
+use foundationdb_sys::if_cfg_api_versions;
 use futures::future;
 use futures::prelude::*;
 
@@ -23,24 +24,16 @@ fn test_range() {
     futures::executor::block_on(test_get_range_async()).expect("failed to run");
     futures::executor::block_on(test_range_option_async()).expect("failed to run");
     futures::executor::block_on(test_get_ranges_async()).expect("failed to run");
-    #[cfg(any(
-        feature = "fdb-6_3",
-        feature = "fdb-7_0",
-        feature = "fdb-7_1",
-        feature = "fdb-7_3"
-    ))]
-    {
+    if_cfg_api_versions!(min = 630 =>
         futures::executor::block_on(test_get_estimate_range()).expect("failed to run");
-    }
-    #[cfg(any(feature = "fdb-7_0", feature = "fdb-7_1", feature = "fdb-7_3"))]
-    {
+    );
+    if_cfg_api_versions!(min = 700 =>
         futures::executor::block_on(test_get_range_split_points()).expect("failed to run");
-    }
-    #[cfg(any(feature = "fdb-7_1", feature = "fdb-7_3"))]
-    {
+    );
+    if_cfg_api_versions!(min = 710 => {
         futures::executor::block_on(test_mapped_value()).expect("failed to run");
         futures::executor::block_on(test_mapped_values()).expect("failed to run");
-    }
+    });
 }
 
 async fn test_get_range_async() -> FdbResult<()> {

--- a/foundationdb/tests/range.rs
+++ b/foundationdb/tests/range.rs
@@ -25,15 +25,15 @@ fn test_range() {
     futures::executor::block_on(test_range_option_async()).expect("failed to run");
     futures::executor::block_on(test_get_ranges_async()).expect("failed to run");
     if_cfg_api_versions!(min = 630 =>
-        futures::executor::block_on(test_get_estimate_range()).expect("failed to run");
+        futures::executor::block_on(test_get_estimate_range()).expect("failed to run")
     );
     if_cfg_api_versions!(min = 700 =>
-        futures::executor::block_on(test_get_range_split_points()).expect("failed to run");
+        futures::executor::block_on(test_get_range_split_points()).expect("failed to run")
     );
-    if_cfg_api_versions!(min = 710 => {
-        futures::executor::block_on(test_mapped_value()).expect("failed to run");
-        futures::executor::block_on(test_mapped_values()).expect("failed to run");
-    });
+    if_cfg_api_versions!(min = 710 =>
+            futures::executor::block_on(test_mapped_value()).expect("failed to run");
+            futures::executor::block_on(test_mapped_values()).expect("failed to run")
+    )
 }
 
 async fn test_get_range_async() -> FdbResult<()> {

--- a/foundationdb/tests/tenant.rs
+++ b/foundationdb/tests/tenant.rs
@@ -1,15 +1,16 @@
 mod common;
 
 use foundationdb_macros::cfg_api_versions;
+use foundationdb_sys::if_cfg_api_versions;
 
 #[test]
 fn test_tenant() {
     let _guard = unsafe { foundationdb::boot() };
     #[cfg(feature = "tenant-experimental")]
-    foundationdb_sys::if_cfg_api_versions!(min = 710 => {
+    if_cfg_api_versions!(min = 710 =>
         futures::executor::block_on(test_tenant_management()).expect("failed to run");
-        futures::executor::block_on(test_tenant_run()).expect("failed to run");
-    });
+        futures::executor::block_on(test_tenant_run()).expect("failed to run")
+    );
 }
 
 #[cfg_api_versions(min = 710)]

--- a/foundationdb/tests/tenant.rs
+++ b/foundationdb/tests/tenant.rs
@@ -1,22 +1,19 @@
 mod common;
 
+use foundationdb_macros::cfg_api_versions;
+
 #[test]
 fn test_tenant() {
     let _guard = unsafe { foundationdb::boot() };
-    #[cfg(all(
-        any(feature = "fdb-7_1", feature = "fdb-7_3"),
-        feature = "tenant-experimental"
-    ))]
-    {
+    #[cfg(feature = "tenant-experimental")]
+    foundationdb_sys::if_cfg_api_versions!(min = 710 => {
         futures::executor::block_on(test_tenant_management()).expect("failed to run");
         futures::executor::block_on(test_tenant_run()).expect("failed to run");
-    }
+    });
 }
 
-#[cfg(all(
-    any(feature = "fdb-7_1", feature = "fdb-7_3"),
-    feature = "tenant-experimental"
-))]
+#[cfg_api_versions(min = 710)]
+#[cfg(feature = "tenant-experimental")]
 async fn test_tenant_management() -> foundationdb::FdbResult<()> {
     use foundationdb::tenant::TenantManagement;
 
@@ -63,10 +60,8 @@ async fn test_tenant_management() -> foundationdb::FdbResult<()> {
     Ok(())
 }
 
-#[cfg(all(
-    any(feature = "fdb-7_1", feature = "fdb-7_3"),
-    feature = "tenant-experimental"
-))]
+#[cfg_api_versions(min = 710)]
+#[cfg(feature = "tenant-experimental")]
 async fn test_tenant_run() -> foundationdb::FdbResult<()> {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::SystemTime::UNIX_EPOCH)


### PR DESCRIPTION
- use `cfg_api_versions` proc macro wherever possible
- create `if_cfg_api_versions` standard macro everywhere else
- remove `wrapper.h` in foundationdb-sys/build.rs