### PR TITLE
Clippy warnings and nitpicks fixes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   codecov:
     name: Code coverage
-    # We are skipping coverage if the PR is coming from dependabot, 
+    # We are skipping coverage if the PR is coming from dependabot,
     # mostly because of https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install cargo-msrv
         run: cargo install cargo-msrv
-      
+
       - name: Find MSRV
         run: cargo msrv find -- cargo check --features num-bigint,embedded-fdb-include,tenant-experimental,fdb-7_4 --no-default-features
         working-directory: ./foundationdb

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can access the `main` branch documentation [here](https://foundationdb-rs.gi
 Supported platforms are listed on the [foundationdb's README](foundationdb/README.md).
 
 ## Develop with Nix
- 
+
 A flake.nix is provided to develop the bindings. We recommend add a cluster-file on the `configuration.nix` file:
 
 ```nix

--- a/foundationdb-profiling/src/lib.rs
+++ b/foundationdb-profiling/src/lib.rs
@@ -51,9 +51,9 @@ pub const PROFILE_PREFIX: &[u8; 32] = b"\xff\x02/fdbClientInfo/client_latency/";
 ///
 /// * `trx` - A reference to the FoundationDB `Transaction` used for fetching data.
 /// * `start_read_version` - An optional lower bound read version. If provided, only events
-///                          occurring at or after this version are fetched.
+///   occurring at or after this version are fetched.
 /// * `end_read_version` - An optional upper bound read version. If provided, only events
-///                        occurring before this version are fetched.
+///   occurring before this version are fetched.
 ///
 /// # Returns
 ///

--- a/foundationdb-profiling/src/parsed_key.rs
+++ b/foundationdb-profiling/src/parsed_key.rs
@@ -145,6 +145,7 @@ impl Debug for ProfilingParsedKey {
 ///    - Another separator (`/`).
 ///    - Two `ChunkField`s representing chunk number and total chunks.
 ///    - A final separator (`/`).
+///
 /// Parsing converts this data into a `ParsedKey` structure which represents
 /// the fields and their respective values in a structured format.
 ///

--- a/foundationdb-profiling/src/scanner.rs
+++ b/foundationdb-profiling/src/scanner.rs
@@ -82,7 +82,6 @@ impl<'a> Deref for Scanner<'a> {
 /// // Accessing a Cursor method directly via the Scanner instance
 /// assert_eq!(scanner.position(), 0);
 /// ```
-
 impl<'a> DerefMut for Scanner<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.cursor

--- a/foundationdb-simulation/README.md
+++ b/foundationdb-simulation/README.md
@@ -279,7 +279,7 @@ Those 3 phases are run in order for all workloads. All workloads have to finish 
 next one to start. Those phases are run asynchronously in the simulator and a workload indicates
 it has finish by sending a boolean in its `done` promise.
 
-An important thing to understand is that **any code you write is blocking**. To ensure that the 
+An important thing to understand is that **any code you write is blocking**. To ensure that the
 simulation is determinist and repeatable, any time your code is running the fdbserver waits.
 In other words, you **have** to hand the execution over to the fdbserver for anything to happen
 on the database. To make it clear, this won't work:
@@ -384,7 +384,7 @@ Indirectly using a pointer to the workload or to the database after resolving `d
 behavior. Resolving `done` should be the very last thing you do in a phase, it indicates to the
 fdbserver that you are finished and many structures may be relocated in memory, so you no longer
 have any garantee on the validity of any object on the Rust side. You must wait for the next phase
-and use the new references to `self` and `db` you are given. For this reason don't try to store 
+and use the new references to `self` and `db` you are given. For this reason don't try to store
 `RustWorkload`, `SimDatabase`, `Promise` instances or any object created through foundation-rs
 bindings (transactions, futures...) as using them accross phases will most certainly result in a
 segmentation fault.

--- a/foundationdb-simulation/docs/fdb_rt.md
+++ b/foundationdb-simulation/docs/fdb_rt.md
@@ -143,7 +143,7 @@ To sum up what happened until now:
   - registers our `Waker` into an `AtomicWaker` (cloning it in the process)
   - set an `fdb_future_callback` as callback and the `AtomicWaker` as argument for the `FdbFutureHandle`
   - returns `Poll::Pending`
-- `fdbwaker_wake` decreases the ref count (because `decrease==true`) and returns 
+- `fdbwaker_wake` decreases the ref count (because `decrease==true`) and returns
 - `fdb_spawn` drops the `Waker`, decreasing the ref count
 
 ```

--- a/foundationdb/README.md
+++ b/foundationdb/README.md
@@ -15,7 +15,7 @@ Support for different platforms ("targets") are organized into three tiers, each
 |----------------|--------|-------------------------------------------------------------------------------------------------------------------------------------|
 | linux x86_64   | 1      |                                                                                                                                     |
 | osx x86_64     | 2      |                                                                                                                                     |
-| osx Silicon 	 | 2      |                                                                                                                                     |
+| osx Silicon    | 2      |                                                                                                                                     |
 | Windows x86_64 | 3      | [Windows build has been officially discontinue, now maintained by the community](https://github.com/apple/foundationdb/issues/5135) |
 
 For more information on the policies for targets at each tier, see the
@@ -130,17 +130,17 @@ async fn hello_world() -> foundationdb::FdbResult<()> {
 
 ## Additional notes
 
-### The class-scheduling tutorial 
+### The class-scheduling tutorial
 
 The official FoundationDB's tutorial is called the [Class Scheduling](https://apple.github.io/foundationdb/class-scheduling.html). You can find the Rust version in the [examples](https://github.com/foundationdb-rs/foundationdb-rs/tree/main/foundationdb/examples).
 
 ### The blob tutorial
 
-The official FoundationDB documentation provides also [another topic](https://apple.github.io/foundationdb/largeval.html#modeling-large-values) 
-which is further discussed inside a [design recipe](https://apple.github.io/foundationdb/blob.html). 
-A Rust implementation can be found [here](https://github.com/foundationdb-rs/foundationdb-rs/tree/main/foundationdb/examples/blob.rs). 
+The official FoundationDB documentation provides also [another topic](https://apple.github.io/foundationdb/largeval.html#modeling-large-values)
+which is further discussed inside a [design recipe](https://apple.github.io/foundationdb/blob.html).
+A Rust implementation can be found [here](https://github.com/foundationdb-rs/foundationdb-rs/tree/main/foundationdb/examples/blob.rs).
 
-Another [example](https://github.com/foundationdb-rs/foundationdb-rs/tree/main/foundationdb/examples/blob-with-manifest.rs), 
+Another [example](https://github.com/foundationdb-rs/foundationdb-rs/tree/main/foundationdb/examples/blob-with-manifest.rs),
 explores how to use subspaces to attach metadata to our blob.
 
 ### Must-read documentations

--- a/foundationdb/examples/blob-with-manifest.rs
+++ b/foundationdb/examples/blob-with-manifest.rs
@@ -71,7 +71,7 @@ use uuid::Uuid;
 ///     \x00 <= 2 < \xff
 ///     ...
 ///     \x00 <= n < \xff
-///     
+///
 ///
 /// Thus foundation DB will retrieve keys/values:
 ///

--- a/foundationdb/src/fdb_keys.rs
+++ b/foundationdb/src/fdb_keys.rs
@@ -155,7 +155,7 @@ impl fmt::Debug for FdbRowKey {
     }
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 /// An FdbKey, owned by a FoundationDB Future
 pub struct FdbKey(fdb_sys::FDBKey);
 

--- a/foundationdb/src/future.rs
+++ b/foundationdb/src/future.rs
@@ -238,7 +238,7 @@ impl AsRef<[FdbAddress]> for FdbAddresses {
 /// can never own a FdbAddress directly, you can only have references to it.
 /// This way, you can never obtain a lifetime greater than the lifetime of the
 /// slice that gave you access to it.
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct FdbAddress {
     c_str: *const c_char,
 }
@@ -446,7 +446,7 @@ impl fmt::Debug for FdbValue {
 /// can never own a FdbKeyValue directly, you can only have references to it.
 /// This way, you can never obtain a lifetime greater than the lifetime of the
 /// slice that gave you access to it.
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct FdbKeyValue(fdb_sys::FDBKeyValue);
 
 impl FdbKeyValue {

--- a/foundationdb/src/mapped_key_values.rs
+++ b/foundationdb/src/mapped_key_values.rs
@@ -67,7 +67,7 @@ impl TryFrom<FdbFutureHandle> for MappedKeyValues {
     }
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 /// A KeyValue produced by a mapped operation, ownder by a Foundation Future.
 pub struct FdbMappedKeyValue(fdb_sys::FDBMappedKeyValue);
 

--- a/foundationdb/src/tuple_ext/hca.rs
+++ b/foundationdb/src/tuple_ext/hca.rs
@@ -16,13 +16,13 @@
 //! Assignment has two stages that are executed in a loop until they both succeed.
 //!
 //! 1. Find the current window. The client scans "counters : *" to get the current "window_start" and how many allocations have been made in the current window.
-//!      If the window is more than half-full (using pre-defined window sizes), the window is advanced: "counters : *" and "recents : *" are both cleared, and a new "counters : window_start + window_size" key is created with a value of 0. (1) is retried
-//!      If the window still has space, it moves to (2).
+//!    If the window is more than half-full (using pre-defined window sizes), the window is advanced: "counters : *" and "recents : *" are both cleared, and a new "counters : window_start + window_size" key is created with a value of 0. (1) is retried
+//!    If the window still has space, it moves to (2).
 //!
 //! 2. Find a candidate value inside that window. The client picks a candidate number between "[window_start, window_start + window_size)" and tries to set the key "recents : candidate".
-//!      If the write succeeds, the candidate is returned as the allocated value. Success!
-//!      If the write fails because the window has been advanced, it repeats (1).
-//!      If the write fails because the value was already set, it repeats (2).
+//!    If the write succeeds, the candidate is returned as the allocated value. Success!
+//!    If the write fails because the window has been advanced, it repeats (1).
+//!    If the write fails because the value was already set, it repeats (2).
 
 use std::fmt;
 use std::sync::{Mutex, PoisonError};


### PR DESCRIPTION
Fixed:
- clippy warnings in packed structs (defaulted to Rust ABI but we want C ABI)
- clippy warnings in docs
- nitpicks on trailing spaces and tabs/spaces mix