### PR TITLE
Override libc's getrandom to make RandomState deterministic

### DIFF
--- a/foundationdb-simulation/Cargo.toml
+++ b/foundationdb-simulation/Cargo.toml
@@ -20,7 +20,8 @@ cc = "1.2.29"
 bindgen = "0.72.0"
 
 [features]
-default = ["embedded-fdb-include"]
+default = ["embedded-fdb-include", "mock-getrandom"]
+mock-getrandom = []
 cpp-abi = []
 fdb-7_1 = ["foundationdb/fdb-7_1", "foundationdb-sys/fdb-7_1", "cpp-abi"]
 fdb-7_3 = ["foundationdb/fdb-7_3", "foundationdb-sys/fdb-7_3", "cpp-abi"]

--- a/foundationdb-simulation/build.rs
+++ b/foundationdb-simulation/build.rs
@@ -28,6 +28,10 @@ fn main() {
         _api_version = 740;
     }
 
+    if cfg!(feature = "mock-getrandom") {
+        println!("cargo:rustc-link-arg=-Wl,--wrap=getrandom");
+    }
+
     #[cfg(feature = "cpp-abi")]
     {
         if cfg!(feature = "fdb-docker") {

--- a/foundationdb-simulation/src/bindings.rs
+++ b/foundationdb-simulation/src/bindings.rs
@@ -23,6 +23,17 @@ use raw_bindings::{
 };
 
 // -----------------------------------------------------------------------------
+// Libc override
+
+/// Override symbol used by RandomState to call libc
+#[no_mangle]
+extern "C" fn __wrap_getrandom(ptr: *mut u8, len: usize, _flags: u32) -> usize {
+    let buf = unsafe { std::slice::from_raw_parts_mut(ptr, len) };
+    buf.fill(0x42);
+    len
+}
+
+// -----------------------------------------------------------------------------
 // String conversions
 
 #[doc(hidden)]


### PR DESCRIPTION
Fix for #329.
This overrides libc's `getrandom` symbol to ensure `RandomState` is always initialized with the same state.
Note that `RandomState` is initialized once per thread and is scrambled each time it is accessed. Every client of a workload runs on the same thread, so each client will get a different `RandomState`, but it will be the same across simulations.
I had to use linker arg `--wrap` because defining a strong symbol wasn't enough: fdbserver's libc gets priority.
I put the `getrandom` implementation under the `mock-getrandom` feature flag, in case a specific workload needs the original `getrandom` (but it is not recommended).
The deterministic implementation is as simple as it gets: it returns a constant array. Since `getrandom` is primarily used to seed pseudo-random generators, not as a random generator directly, it should be enough.