### PR TITLE
Replace ManuallyDrop<Database> with Arc<Database> in RustWorkload

### DIFF
--- a/foundationdb-simulation/README.md
+++ b/foundationdb-simulation/README.md
@@ -98,9 +98,9 @@ FoundationDB workloads are defined by implementing the `RustWorkload` trait:
 
 ```rust
 pub trait RustWorkload {
-    fn setup(&mut self, db: Database);
-    fn start(&mut self, db: Database);
-    fn check(&mut self, db: Database);
+    async fn setup(&mut self, db: SimDatabase);
+    async fn start(&mut self, db: SimDatabase);
+    async fn check(&mut self, db: SimDatabase);
     fn get_metrics(&self, out: Metrics);
     fn get_check_timeout(&self) -> f64;
 }
@@ -258,6 +258,6 @@ fn get_metrics(&self, out: Metrics) {
 
 * **Using pointers or references after a phase ends.** After each phase, the simulator may move or
   deallocate memory. Any pointers or references to FoundationDB objects become invalid. You must
-  use the fresh `&mut self` and `db` references passed to the next phase. Storing `Database`,
+  use the fresh `&mut self` and `db` references passed to the next phase. Storing `SimDatabase`,
   `Transaction`, or `Future` objects across phases will lead to segmentation faults or other
   undefined behavior.

--- a/foundationdb-simulation/examples/atomic/lib.rs
+++ b/foundationdb-simulation/examples/atomic/lib.rs
@@ -1,10 +1,10 @@
-use foundationdb::FdbBindingError;
 use foundationdb::{
     options::{MutationType, TransactionOption},
     tuple::Subspace,
+    FdbBindingError,
 };
 use foundationdb_simulation::{
-    details, register_workload, Database, Metric, Metrics, RustWorkload, Severity,
+    details, register_workload, Metric, Metrics, RustWorkload, Severity, SimDatabase,
     SingleRustWorkload, WorkloadContext,
 };
 
@@ -37,10 +37,10 @@ impl SingleRustWorkload for AtomicWorkload {
 }
 
 impl RustWorkload for AtomicWorkload {
-    async fn setup(&mut self, _db: Database) {
+    async fn setup(&mut self, _db: SimDatabase) {
         println!("rust_setup({})", self.client_id);
     }
-    async fn start(&mut self, db: Database) {
+    async fn start(&mut self, db: SimDatabase) {
         println!("rust_start({})", self.client_id);
         // Only use a single client
         if self.client_id == 0 {
@@ -85,7 +85,7 @@ impl RustWorkload for AtomicWorkload {
             }
         }
     }
-    async fn check(&mut self, db: Database) {
+    async fn check(&mut self, db: SimDatabase) {
         println!("rust_check({})", self.client_id);
         if self.client_id == 0 {
             // even if buggify is off in checks, transactions can failed because of the randomized knob,

--- a/foundationdb-simulation/examples/noop/lib.rs
+++ b/foundationdb-simulation/examples/noop/lib.rs
@@ -1,5 +1,5 @@
 use foundationdb_simulation::{
-    register_factory, Database, Metric, Metrics, RustWorkload, RustWorkloadFactory, Severity,
+    register_factory, Metric, Metrics, RustWorkload, RustWorkloadFactory, Severity, SimDatabase,
     WorkloadContext, WrappedWorkload,
 };
 
@@ -10,7 +10,7 @@ struct NoopWorkload {
 }
 
 impl RustWorkload for NoopWorkload {
-    async fn setup(&mut self, _db: Database) {
+    async fn setup(&mut self, _db: SimDatabase) {
         println!("rust_setup({}_{})", self.name, self.client_id);
         self.context.trace(
             Severity::Debug,
@@ -18,7 +18,7 @@ impl RustWorkload for NoopWorkload {
             &[("Layer", "Rust"), ("Stage", "Setup")],
         );
     }
-    async fn start(&mut self, _db: Database) {
+    async fn start(&mut self, _db: SimDatabase) {
         println!("rust_start({}_{})", self.name, self.client_id);
         self.context.trace(
             Severity::Debug,
@@ -26,7 +26,7 @@ impl RustWorkload for NoopWorkload {
             &[("Layer", "Rust"), ("Stage", "Start")],
         );
     }
-    async fn check(&mut self, _db: Database) {
+    async fn check(&mut self, _db: SimDatabase) {
         println!("rust_check({}_{})", self.name, self.client_id);
         self.context.trace(
             Severity::Debug,


### PR DESCRIPTION
Replace `ManuallyDrop<Database>` with `Arc<Database>` in `RustWorkload`.
It is both a cleaner, more "standard" type to use, and allows for runtime escaping reference detection between each phase.