### PR TITLE
fix(simulation): Recover simulation trace public api breaking change

### DIFF
--- a/foundationdb-simulation/src/bindings.rs
+++ b/foundationdb-simulation/src/bindings.rs
@@ -100,16 +100,18 @@ impl WorkloadContext {
     }
 
     /// Add a log entry in the FoundationDB logs
-    pub fn trace<S>(&self, severity: Severity, name: S, details: &[(&str, &str)])
+    pub fn trace<S, S2, S3>(&self, severity: Severity, name: S, details: &[(S2, S3)])
     where
         S: Into<Vec<u8>>,
+        S2: AsRef<str>,
+        S3: AsRef<str>,
     {
         let name = str_for_c(name);
         let details_storage = details
             .iter()
             .map(|(key, val)| {
-                let key = str_for_c(*key);
-                let val = str_for_c(*val);
+                let key = str_for_c(key.as_ref());
+                let val = str_for_c(val.as_ref());
                 (key, val)
             })
             .collect::<Vec<_>>();


### PR DESCRIPTION
**Description**

[Before](https://github.com/foundationdb-rs/foundationdb-rs/blob/02794b10c9eb75185917afd881e3f20523eb81ef/foundationdb-simulation/src/fdb_wrapper.rs#L180) reworking the public API of the simulation trace method was 

```rust
pub fn trace<S>(&self, severity: Severity, name: S, details: Vec<(String, String)>)
```

The [actual](https://github.com/foundationdb-rs/foundationdb-rs/blob/c140c81174dcced5a3c2f6f80efe008a9894ed89/foundationdb-simulation/src/bindings.rs#L103) is:

```rust
 pub fn trace<S>(&self, severity: Severity, name: S, details: &[(&str, &str)])
```

This PR restores the legacy public API and extends its ability to use a mix of allocated and non allocated key/value.