### PR TITLE
Implement `std::error::Error` for `TransactionCommitError`

### DIFF
--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -133,6 +133,8 @@ impl fmt::Display for TransactionCommitError {
     }
 }
 
+impl std::error::Error for TransactionCommitError {}
+
 /// The result of `Transaction::Commit`
 type TransactionResult = Result<TransactionCommitted, TransactionCommitError>;
 


### PR DESCRIPTION
Error handling crates like [anyhow](https://docs.rs/anyhow/latest/anyhow/) make it easy to work with a variety of possible errors, but require that those errors implement `std::error::Error`. `TransactionCommitError` doesn't at the time of writing, but luckily `fmt::Debug` and `fmt::Display` have already been implemented for this error, so all we need to do is say it is implemented and it will be.