### PR TITLE
chore(foundationdb-simulation): Bump cc version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,9 +236,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "shlex",
 ]

--- a/foundationdb-simulation/Cargo.toml
+++ b/foundationdb-simulation/Cargo.toml
@@ -16,7 +16,7 @@ foundationdb = { version = "0.9.2", path = "../foundationdb", default-features =
 foundationdb-sys = { version = "0.9.1", path = "../foundationdb-sys", default-features = false }
 
 [build-dependencies]
-cc = "1.2.32"
+cc = "1.2.34"
 bindgen = "0.72.0"
 
 [features]


### PR DESCRIPTION
Last rustls version has the cc=1.2.34 has transitive dependencies.

Bumping allows to use the simulation along rustls