### PR TITLE
fix(foundationdb): Don't log as error all commit errors

### DIFF
--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -446,7 +446,17 @@ impl Database {
                             continue;
                         }
                         Err(non_retryable_error) => {
-                            return Err(FdbBindingError::from(non_retryable_error))
+                            #[cfg(feature = "trace")]
+                            {
+                                let error_code = non_retryable_error.code();
+                                tracing::error!(
+                                    iteration,
+                                    error_code,
+                                    "could not commit, non retryable error"
+                                );
+                            }
+
+                            return Err(FdbBindingError::from(non_retryable_error));
                         }
                     }
                 }

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -914,21 +914,8 @@ impl Transaction {
     pub fn commit(self) -> impl Future<Output = TransactionResult> + Send + Sync + Unpin {
         FdbFuture::<()>::new(unsafe { fdb_sys::fdb_transaction_commit(self.inner.as_ptr()) }).map(
             move |r| match r {
-                Ok(()) => {
-                    #[cfg(feature = "trace")]
-                    tracing::info!("transaction committed");
-
-                    Ok(TransactionCommitted { tr: self })
-                }
-                Err(err) => {
-                    #[cfg(feature = "trace")]
-                    {
-                        let error_code = err.code();
-                        tracing::error!(error_code, "could not commit");
-                    }
-
-                    Err(TransactionCommitError { tr: self, err })
-                }
+                Ok(()) => Ok(TransactionCommitted { tr: self }),
+                Err(err) => Err(TransactionCommitError { tr: self, err }),
             },
         )
     }


### PR DESCRIPTION
**Description**

This PR modify the logging behavior in case on retryable errors. The previous implementation was applying the same error level for both retryable and non-retryable errors.