### PR TITLE
Rewrite fdb_rt to split wakeup and polling phase

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -58,8 +58,14 @@ jobs:
         with:
           toolchain: "stable"
 
-      - name: Build
+      - name: Build atomic workload
         run: cargo build -p foundationdb-simulation --release --example atomic --features fdb-7_4
 
-      - name: Test
+      - name: Build shared workload
+        run: cargo build -p foundationdb-simulation --release --example shared --features fdb-7_4
+
+      - name: Test atomic workload
         run: fdbserver -r simulation -f foundationdb-simulation/examples/atomic/test_file_74.toml -b on --trace-format json
+
+      - name: Test shared workload
+        run: fdbserver -r simulation -f foundationdb-simulation/examples/shared/test_file.toml -b on --trace-format json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,7 @@ dependencies = [
  "cc",
  "foundationdb",
  "foundationdb-sys",
+ "futures-util",
 ]
 
 [[package]]

--- a/foundationdb-simulation/Cargo.toml
+++ b/foundationdb-simulation/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "foundationdb-simulation"
 version = "0.2.3"
+authors = [
+    "Eloi DEMOLIS <eloi.demolis@clever-cloud.com>",
+    "Pierre Zemb <contact@pierrezemb.fr>"
+]
 edition = "2021"
 description = """
 Embed Rust code within FoundationDB's simulation
@@ -22,6 +26,9 @@ foundationdb-sys = { version = "0.10.0", path = "../foundationdb-sys", default-f
 cc = "1.2.51"
 bindgen = "0.72.1"
 
+[dev-dependencies]
+futures-util = "0.3.31"
+
 [features]
 default = ["embedded-fdb-include"]
 cpp-abi = []
@@ -42,4 +49,9 @@ crate-type = ["cdylib"]
 [[example]]
 name = "noop"
 path = "examples/noop/lib.rs"
+crate-type = ["cdylib"]
+
+[[example]]
+name = "shared"
+path = "examples/shared/lib.rs"
 crate-type = ["cdylib"]

--- a/foundationdb-simulation/examples/shared/lib.rs
+++ b/foundationdb-simulation/examples/shared/lib.rs
@@ -1,0 +1,42 @@
+use foundationdb_simulation::{
+    register_workload, Metrics, RustWorkload, SimDatabase, SingleRustWorkload, WorkloadContext,
+};
+use futures_util::FutureExt;
+
+pub struct SharedWorkload {
+    client_id: i32,
+}
+
+impl SingleRustWorkload for SharedWorkload {
+    fn new(_name: String, context: WorkloadContext) -> Self {
+        Self {
+            client_id: context.client_id(),
+        }
+    }
+}
+
+impl RustWorkload for SharedWorkload {
+    async fn setup(&mut self, _db: SimDatabase) {
+        println!("rust_setup({})", self.client_id);
+    }
+    async fn start(&mut self, db: SimDatabase) {
+        println!("rust_start({})", self.client_id);
+        let trx = db.create_trx().expect("Could not create transaction");
+        let future = trx.get_read_version();
+        let shared = future.shared();
+        let version = shared.await;
+        println!("read_version({}) = {version:?}", self.client_id);
+    }
+    async fn check(&mut self, _db: SimDatabase) {
+        println!("rust_check({})", self.client_id);
+    }
+    fn get_metrics(&self, mut _out: Metrics) {
+        println!("rust_get_metrics({})", self.client_id);
+    }
+    fn get_check_timeout(&self) -> f64 {
+        println!("rust_get_check_timeout({})", self.client_id);
+        5000.0
+    }
+}
+
+register_workload!(SharedWorkload);

--- a/foundationdb-simulation/examples/shared/test_file.toml
+++ b/foundationdb-simulation/examples/shared/test_file.toml
@@ -1,0 +1,9 @@
+[[test]]
+testTitle = 'Test_Test'
+
+  [[test.workload]]
+    useCAPI = true
+    testName = 'External'
+    workloadName = 'SharedWorkload'
+    libraryPath = './target/release/examples'
+    libraryName = 'shared'

--- a/foundationdb-simulation/src/lib.rs
+++ b/foundationdb-simulation/src/lib.rs
@@ -174,6 +174,7 @@ impl WrappedWorkload {
 /// Primitives exposed for the registrations hooks, should not be used otherwise
 pub mod internals {
     pub use crate::bindings::{str_from_c, FDBWorkloadContext};
+    pub use crate::fdb_rt::poll_pending_tasks;
 
     #[cfg(feature = "cpp-abi")]
     extern "C" {
@@ -214,6 +215,9 @@ macro_rules! register_factory {
                     .set_runtime_version(version as i32)
                     .build();
                 println!("FDB API version selected: {version}");
+                foundationdb::future::CUSTOM_EXECUTOR_HOOK
+                    .set($crate::internals::poll_pending_tasks)
+                    .unwrap();
             }
             let name = $crate::internals::str_from_c(raw_name);
             let context = $crate::WorkloadContext::new(raw_context);
@@ -247,6 +251,9 @@ macro_rules! register_workload {
                     .set_runtime_version(version as i32)
                     .build();
                 println!("FDB API version selected: {version}");
+                foundationdb::future::CUSTOM_EXECUTOR_HOOK
+                    .set($crate::internals::poll_pending_tasks)
+                    .unwrap();
             }
             let name = $crate::internals::str_from_c(raw_name);
             let context = $crate::WorkloadContext::new(raw_context);


### PR DESCRIPTION
Fix #410.
The additional polling phase must be run from the FDB server callback, so we must expose the hook in `foundationdb/src/future.rs`.
It will remain unset in production and only populated by the simulation.