### PR TITLE
build(deps): replace pretty-bytes with bytesize to remove unmaintaine…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,17 +106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +176,12 @@ name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+
+[[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "cc"
@@ -317,6 +312,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "byteorder",
+ "bytesize",
  "data-encoding",
  "foundationdb-gen",
  "foundationdb-macros",
@@ -326,7 +322,6 @@ dependencies = [
  "futures-util",
  "lazy_static",
  "num-bigint",
- "pretty-bytes",
  "rand",
  "serde",
  "serde_bytes",
@@ -496,15 +491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,15 +507,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -762,16 +739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "pretty-bytes"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009d6edd2c1dbf2e1c0cd48a2f7766e03498d49ada7109a01c6911815c685316"
-dependencies = [
- "atty",
- "getopts",
 ]
 
 [[package]]
@@ -1154,12 +1121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,28 +1208,6 @@ checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -75,7 +75,7 @@ lazy_static = "1.5.0"
 tokio = { version = "1.49.0", features = ["full"] }
 sha2 = "0.10.9"
 data-encoding = "2.9.0"
-pretty-bytes = "0.2.2"
+bytesize = "2.3"
 uuid = { version = "1.19.0", features = ["v4"] }
 futures-util = "0.3.31"
 tracing-subscriber = "0.3.22"

--- a/foundationdb/examples/blob-with-manifest.rs
+++ b/foundationdb/examples/blob-with-manifest.rs
@@ -1,6 +1,6 @@
+use bytesize::ByteSize;
 use foundationdb::tuple::{pack, unpack, PackError, Subspace};
 use foundationdb::{Database, RangeOption};
-use pretty_bytes::converter::convert;
 use sha2::{Digest, Sha256};
 use std::fmt::{Display, Formatter};
 use std::fs::File;
@@ -289,8 +289,8 @@ impl Display for FileManifest {
             self.uuid,
             self.name,
             self.digest,
-            convert(self.size as f64),
-            convert(self.chunk_size.unwrap_or(CHUNK_SIZE) as f64),
+            ByteSize(self.size as u64).display().si(),
+            ByteSize(self.chunk_size.unwrap_or(CHUNK_SIZE) as u64).display().si(),
             self.nb_chunks
         )
     }
@@ -317,7 +317,10 @@ async fn populate_data(
             let subspace_data = subspace_file.subspace(&("_data"));
             let subspace_manifest = subspace_file.subspace(&("_manifest"));
 
-            println!("\twith chunk of {}", convert(*chunk_size as f64));
+            println!(
+                "\twith chunk of {}",
+                ByteSize(*chunk_size as u64).display().si()
+            );
             let nb_chunks = write_blob(db, &subspace_data, &data, Some(*chunk_size)).await;
 
             let manifest = FileManifest {


### PR DESCRIPTION
…d atty

The `atty` crate is unmaintained and has been superseded by `std::io::IsTerminal`. This change replaces `pretty-bytes` (which depended on `atty`) with `bytesize` for human-readable byte formatting in the blob-with-manifest example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)