### PR TITLE
fix(foundationdb-sys): link required system libraries on Linux

### DIFF
--- a/foundationdb-sys/build.rs
+++ b/foundationdb-sys/build.rs
@@ -60,6 +60,17 @@ fn main() {
     // Link against fdb_c.
     println!("cargo:rustc-link-lib=fdb_c");
 
+    // On Linux, link the libraries required by libfdb_c.so.
+    // libdl is needed for dlsym(RTLD_NEXT, ...) used in flow/SignalSafeUnwind.cpp.
+    // See: https://apple.github.io/foundationdb/api-c.html
+    #[cfg(target_os = "linux")]
+    {
+        println!("cargo:rustc-link-lib=dl");
+        println!("cargo:rustc-link-lib=m");
+        println!("cargo:rustc-link-lib=pthread");
+        println!("cargo:rustc-link-lib=rt");
+    }
+
     if let Ok(lib_path) = env::var("FDB_CLIENT_LIB_PATH") {
         println!("cargo:rustc-link-search=native={lib_path}");
     }


### PR DESCRIPTION
libfdb_c.so requires libm, libpthread, librt, and libdl on Linux per the official FDB C API documentation. Without libdl, libfdb_c.so's SignalSafeUnwind fails to resolve dl_iterate_phdr via dlsym(RTLD_NEXT, ...) at startup and calls criticalError(FDB_EXIT_ERROR), terminating the process.

See: https://apple.github.io/foundationdb/api-c.html