### PR TITLE
feat(recipes): add ranked register

### DIFF
--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -47,8 +47,9 @@ fdb-7_1 = ["foundationdb-sys/fdb-7_1", "foundationdb-gen/fdb-7_1", "serde", "ser
 fdb-7_3 = ["foundationdb-sys/fdb-7_3", "foundationdb-gen/fdb-7_3", "serde", "serde_json", "serde_bytes"]
 fdb-7_4 = ["foundationdb-sys/fdb-7_4", "foundationdb-gen/fdb-7_4", "serde", "serde_json", "serde_bytes"]
 tenant-experimental = []
-recipes = ["recipes-leader-election"]
+recipes = ["recipes-leader-election", "recipes-ranked-register"]
 recipes-leader-election = []
+recipes-ranked-register = []
 trace = ["tracing"]
 
 [build-dependencies]

--- a/foundationdb/src/recipes/mod.rs
+++ b/foundationdb/src/recipes/mod.rs
@@ -32,3 +32,7 @@
 /// Leader election recipe for distributed consensus
 #[cfg(feature = "recipes-leader-election")]
 pub mod leader_election;
+
+/// Ranked register recipe for Paxos-style ballot fencing
+#[cfg(feature = "recipes-ranked-register")]
+pub mod ranked_register;

--- a/foundationdb/src/recipes/ranked_register/algorithm.rs
+++ b/foundationdb/src/recipes/ranked_register/algorithm.rs
@@ -1,0 +1,141 @@
+// Copyright 2024 foundationdb-rs developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Ranked register algorithm
+//!
+//! Implements the core read/write/value operations from Chockler & Malkhi's
+//! "Active Disk Paxos with infinitely many processes" (PODC 2002, Section 5.1, Figure 3).
+//!
+//! All functions operate within a FoundationDB transaction for atomicity.
+
+use crate::{
+    tuple::{pack, unpack, Subspace},
+    Transaction,
+};
+use std::ops::Deref;
+
+use super::{errors::Result, keys, types::*};
+
+// ============================================================================
+// STATE HELPERS
+// ============================================================================
+
+/// Read the register state from FoundationDB
+///
+/// Returns `Default` (zero ranks, no value) if the key is absent,
+/// which represents the bottom/uninitialized state.
+async fn read_state<T>(txn: &T, key: &[u8]) -> Result<RegisterState>
+where
+    T: Deref<Target = Transaction>,
+{
+    let data = match txn.get(key, false).await? {
+        Some(d) => d,
+        None => return Ok(RegisterState::default()),
+    };
+
+    // Unpack tuple: (max_read_rank, max_write_rank, has_value, value)
+    let tuple: (u64, u64, bool, Vec<u8>) = unpack(&data)?;
+
+    let value = if tuple.2 { Some(tuple.3) } else { None };
+
+    Ok(RegisterState {
+        max_read_rank: Rank::from(tuple.0),
+        max_write_rank: Rank::from(tuple.1),
+        value,
+    })
+}
+
+/// Write the register state to FoundationDB
+fn write_state<T>(txn: &T, key: &[u8], state: &RegisterState)
+where
+    T: Deref<Target = Transaction>,
+{
+    let has_value = state.value.is_some();
+    let value = state.value.as_deref().unwrap_or(&[]);
+
+    let data = (
+        state.max_read_rank.as_u64(),
+        state.max_write_rank.as_u64(),
+        has_value,
+        value,
+    );
+    let packed = pack(&data);
+    txn.set(key, &packed);
+}
+
+// ============================================================================
+// CORE OPERATIONS (Paper Section 5.1, Figure 3)
+// ============================================================================
+
+/// Perform a ranked read on the register
+///
+/// Updates `max_read_rank` if the given rank is higher than the current one,
+/// effectively installing a fence that prevents lower-ranked writes.
+/// Returns the current write rank and value.
+///
+/// This is used by the leader before writing to ensure no concurrent
+/// higher-ranked process has written.
+pub async fn read<T>(txn: &T, subspace: &Subspace, rank: Rank) -> Result<ReadResult>
+where
+    T: Deref<Target = Transaction>,
+{
+    let key = keys::state_key(subspace);
+    let mut state = read_state(txn, &key).await?;
+
+    // Update max_read_rank if our rank is higher
+    if rank > state.max_read_rank {
+        state.max_read_rank = rank;
+        write_state(txn, &key, &state);
+    }
+
+    Ok(ReadResult {
+        write_rank: state.max_write_rank,
+        value: state.value,
+    })
+}
+
+/// Perform a ranked write on the register
+///
+/// Commits the value only if:
+/// - `rank >= max_read_rank` (no higher-ranked read has installed a fence)
+/// - `rank > max_write_rank` (no equal-or-higher-ranked write has occurred)
+///
+/// Returns `Committed` if the write succeeds, `Aborted` otherwise.
+pub async fn write<T>(txn: &T, subspace: &Subspace, rank: Rank, value: &[u8]) -> Result<WriteResult>
+where
+    T: Deref<Target = Transaction>,
+{
+    let key = keys::state_key(subspace);
+    let mut state = read_state(txn, &key).await?;
+
+    // Check rank conditions (paper Section 5.1)
+    if rank < state.max_read_rank || rank <= state.max_write_rank {
+        return Ok(WriteResult::Aborted);
+    }
+
+    // Commit the write
+    state.max_write_rank = rank;
+    state.value = Some(value.to_vec());
+    write_state(txn, &key, &state);
+
+    Ok(WriteResult::Committed)
+}
+
+/// Read the current value without updating ranks
+///
+/// This is a plain read for followers/observers. It does NOT update
+/// `max_read_rank`, so it won't interfere with the leader's writes.
+///
+/// Safe to call from any process at any time.
+pub async fn value<T>(txn: &T, subspace: &Subspace) -> Result<Option<Vec<u8>>>
+where
+    T: Deref<Target = Transaction>,
+{
+    let key = keys::state_key(subspace);
+    let state = read_state(txn, &key).await?;
+    Ok(state.value)
+}

--- a/foundationdb/src/recipes/ranked_register/errors.rs
+++ b/foundationdb/src/recipes/ranked_register/errors.rs
@@ -1,0 +1,50 @@
+// Copyright 2024 foundationdb-rs developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Error types for the ranked register
+
+use crate::tuple::PackError;
+use crate::FdbError;
+use std::fmt;
+
+/// Ranked register specific errors
+#[derive(Debug)]
+pub enum RankedRegisterError {
+    /// Database error
+    Fdb(FdbError),
+    /// Serialization error
+    PackError(PackError),
+    /// Invalid state encountered in the register
+    InvalidState(String),
+}
+
+impl fmt::Display for RankedRegisterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Fdb(e) => write!(f, "Database error: {e}"),
+            Self::PackError(e) => write!(f, "Pack error: {e:?}"),
+            Self::InvalidState(msg) => write!(f, "Invalid state: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for RankedRegisterError {}
+
+impl From<FdbError> for RankedRegisterError {
+    fn from(error: FdbError) -> Self {
+        Self::Fdb(error)
+    }
+}
+
+impl From<PackError> for RankedRegisterError {
+    fn from(error: PackError) -> Self {
+        Self::PackError(error)
+    }
+}
+
+/// Result type for ranked register operations
+pub type Result<T> = std::result::Result<T, RankedRegisterError>;

--- a/foundationdb/src/recipes/ranked_register/keys.rs
+++ b/foundationdb/src/recipes/ranked_register/keys.rs
@@ -1,0 +1,31 @@
+// Copyright 2024 foundationdb-rs developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Key management for the ranked register
+//!
+//! Single key stores the entire register state (ranks + value).
+//!
+//! # Key Schema
+//!
+//! ```text
+//! <subspace>/state  -> (max_read_rank: u64, max_write_rank: u64, has_value: bool, value: Bytes)
+//! ```
+
+use crate::tuple::Subspace;
+
+/// Key prefix for register state
+const STATE_PREFIX: &str = "state";
+
+/// Generate the key for the register state
+///
+/// Returns the single key where all register state is stored.
+///
+/// # Key Structure
+/// `<subspace>/state`
+pub fn state_key(subspace: &Subspace) -> Vec<u8> {
+    subspace.pack(&(STATE_PREFIX,))
+}

--- a/foundationdb/src/recipes/ranked_register/mod.rs
+++ b/foundationdb/src/recipes/ranked_register/mod.rs
@@ -1,0 +1,145 @@
+// Copyright 2024 foundationdb-rs developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! # Ranked Register for FoundationDB
+//!
+//! A shared memory abstraction that encapsulates Paxos ballots, based on
+//! Chockler & Malkhi's "Active Disk Paxos with infinitely many processes"
+//! (PODC 2002). A ranked register is a mutable register with conflict detection
+//! via ranks, supporting unbounded processes with finite storage.
+//!
+//! ## Operations
+//!
+//! | Operation | Who | Effect |
+//! |-----------|-----|--------|
+//! | [`read(rank)`](RankedRegister::read) | Leader | Updates max_read_rank (installs fence), returns current value |
+//! | [`write(rank, value)`](RankedRegister::write) | Leader | Commits only if rank is high enough |
+//! | [`value()`](RankedRegister::value) | Followers | Plain read, no fence installed |
+//!
+//! ## Composing with Leader Election
+//!
+//! The ranked register is designed to work with the leader election recipe.
+//! The leader election's ballot serves as the rank for register operations,
+//! providing automatic fencing against stale leaders.
+//!
+//! ```rust,no_run
+//! # fn example() {
+//! use foundationdb::recipes::leader_election::LeaderElection;
+//! use foundationdb::recipes::ranked_register::{RankedRegister, Rank};
+//! use foundationdb::tuple::Subspace;
+//!
+//! let election = LeaderElection::new(Subspace::all().subspace(&"my-election"));
+//! let register = RankedRegister::new(Subspace::all().subspace(&"my-state"));
+//!
+//! // In the leader's main loop:
+//! // db.run(|txn, _| async move {
+//! //     let result = election.run_election_cycle(&txn, process_id, priority, now).await?;
+//! //     match result {
+//! //         ElectionResult::Leader(state) => {
+//! //             let rank = Rank::from(state.ballot);
+//! //             // Read current state (installs fence at this ballot)
+//! //             let current = register.read(&txn, rank).await?;
+//! //             // Mutate and write back
+//! //             register.write(&txn, rank, b"new_value").await?;
+//! //         }
+//! //         ElectionResult::Follower(_) => {
+//! //             // Safe read — doesn't interfere with leader's writes
+//! //             let current = register.value(&txn).await?;
+//! //         }
+//! //     }
+//! //     Ok(())
+//! // }).await?;
+//! # }
+//! ```
+//!
+//! ### Why This Works
+//!
+//! - Leader election's ballot is monotonically increasing
+//! - A deposed leader has a lower ballot than the new leader
+//! - `read(rank)` installs a fence at the ballot value
+//! - Any write with a lower rank is automatically rejected
+//! - `value()` is safe for followers — it never installs a fence
+
+mod algorithm;
+mod errors;
+mod keys;
+mod types;
+
+pub use errors::{RankedRegisterError, Result};
+pub use types::{Rank, ReadResult, RegisterState, WriteResult};
+
+use crate::{tuple::Subspace, Transaction};
+use std::ops::Deref;
+
+/// A ranked register backed by FoundationDB
+///
+/// Provides a mutable register with conflict detection via ranks.
+/// No initialization is needed — an absent key represents the bottom state
+/// (zero ranks, no value).
+///
+/// # Thread Safety
+///
+/// `RankedRegister` is [`Clone`], [`Send`], and [`Sync`]. It holds only a
+/// [`Subspace`] and can be safely shared across tasks.
+#[derive(Clone, Debug)]
+pub struct RankedRegister {
+    subspace: Subspace,
+}
+
+impl RankedRegister {
+    /// Create a new ranked register instance
+    ///
+    /// The subspace isolates this register from other data in the database.
+    /// No initialization step is required — the register starts in the
+    /// bottom state (zero ranks, no value) until the first write.
+    pub fn new(subspace: Subspace) -> Self {
+        Self { subspace }
+    }
+
+    /// Returns a reference to the underlying subspace
+    pub fn subspace(&self) -> &Subspace {
+        &self.subspace
+    }
+
+    /// Perform a ranked read
+    ///
+    /// Updates `max_read_rank` if the given rank is higher, installing a fence
+    /// that prevents lower-ranked writes. Returns the current write rank and value.
+    ///
+    /// Used by the leader before writing to ensure consistency.
+    pub async fn read<T>(&self, txn: &T, rank: Rank) -> Result<ReadResult>
+    where
+        T: Deref<Target = Transaction>,
+    {
+        algorithm::read(txn, &self.subspace, rank).await
+    }
+
+    /// Perform a ranked write
+    ///
+    /// Commits the value only if:
+    /// - `rank >= max_read_rank` (no higher fence)
+    /// - `rank > max_write_rank` (no equal-or-higher write)
+    ///
+    /// Returns [`WriteResult::Committed`] or [`WriteResult::Aborted`].
+    pub async fn write<T>(&self, txn: &T, rank: Rank, value: &[u8]) -> Result<WriteResult>
+    where
+        T: Deref<Target = Transaction>,
+    {
+        algorithm::write(txn, &self.subspace, rank, value).await
+    }
+
+    /// Read the current value without updating ranks
+    ///
+    /// Safe for followers and observers — does not install a fence,
+    /// so it won't interfere with the leader's writes.
+    pub async fn value<T>(&self, txn: &T) -> Result<Option<Vec<u8>>>
+    where
+        T: Deref<Target = Transaction>,
+    {
+        algorithm::value(txn, &self.subspace).await
+    }
+}

--- a/foundationdb/src/recipes/ranked_register/types.rs
+++ b/foundationdb/src/recipes/ranked_register/types.rs
@@ -1,0 +1,145 @@
+// Copyright 2024 foundationdb-rs developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Core data structures for the ranked register
+//!
+//! Implements the ranked register abstraction from Chockler & Malkhi's
+//! "Active Disk Paxos with infinitely many processes" (PODC 2002).
+
+use std::fmt;
+
+/// A rank value for ordering register operations
+///
+/// Encodes both a process identifier and a sequence number into a single `u64`.
+/// The high 32 bits hold the sequence number, and the low 32 bits hold the
+/// process ID. This ensures that ranks from the same process are ordered by
+/// sequence, and ties between different processes are broken by process ID.
+///
+/// # Encoding
+///
+/// ```text
+/// |--- sequence (32 bits) ---|--- process_id (32 bits) ---|
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Rank(u64);
+
+impl Rank {
+    /// The zero rank, representing the bottom/uninitialized state
+    pub const ZERO: Rank = Rank(0);
+
+    /// Create a new rank from a process ID and sequence number
+    ///
+    /// The sequence occupies the high 32 bits and the process ID the low 32 bits,
+    /// so ranks are ordered primarily by sequence, then by process ID.
+    pub fn new(process_id: u32, sequence: u32) -> Self {
+        Self((sequence as u64) << 32 | process_id as u64)
+    }
+
+    /// Returns the process ID component of this rank
+    pub fn process_id(&self) -> u32 {
+        self.0 as u32
+    }
+
+    /// Returns the sequence number component of this rank
+    pub fn sequence(&self) -> u32 {
+        (self.0 >> 32) as u32
+    }
+
+    /// Returns the raw `u64` representation
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for Rank {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl fmt::Display for Rank {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Rank(seq={}, pid={})",
+            self.sequence(),
+            self.process_id()
+        )
+    }
+}
+
+/// Internal state of the ranked register as stored in FoundationDB
+///
+/// Tracks the maximum read and write ranks alongside the current value.
+/// Private fields enforce invariants through the algorithm module.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RegisterState {
+    pub(crate) max_read_rank: Rank,
+    pub(crate) max_write_rank: Rank,
+    pub(crate) value: Option<Vec<u8>>,
+}
+
+impl RegisterState {
+    /// Returns the highest rank that has performed a read
+    pub fn max_read_rank(&self) -> Rank {
+        self.max_read_rank
+    }
+
+    /// Returns the highest rank that has successfully written
+    pub fn max_write_rank(&self) -> Rank {
+        self.max_write_rank
+    }
+
+    /// Returns the current value, if any
+    pub fn value(&self) -> Option<&[u8]> {
+        self.value.as_deref()
+    }
+}
+
+/// Result of a ranked read operation
+///
+/// Contains the write rank and value at the time of the read.
+/// The read also installs a fence at the given rank, preventing
+/// lower-ranked writes from succeeding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadResult {
+    pub(crate) write_rank: Rank,
+    pub(crate) value: Option<Vec<u8>>,
+}
+
+impl ReadResult {
+    /// Returns the rank of the last successful write
+    pub fn write_rank(&self) -> Rank {
+        self.write_rank
+    }
+
+    /// Returns a reference to the current value, if any
+    pub fn value(&self) -> Option<&[u8]> {
+        self.value.as_deref()
+    }
+
+    /// Consumes self and returns the value
+    pub fn into_value(self) -> Option<Vec<u8>> {
+        self.value
+    }
+}
+
+/// Result of a ranked write operation
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteResult {
+    /// The write was accepted (rank was high enough)
+    Committed,
+    /// The write was rejected (rank too low)
+    Aborted,
+}
+
+impl WriteResult {
+    /// Returns `true` if the write was committed
+    pub fn is_committed(&self) -> bool {
+        matches!(self, WriteResult::Committed)
+    }
+}

--- a/foundationdb/tests/ranked_register.rs
+++ b/foundationdb/tests/ranked_register.rs
@@ -1,0 +1,331 @@
+// Copyright 2024 foundationdb-rs developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+mod common;
+
+#[cfg(feature = "recipes-ranked-register")]
+mod ranked_register_tests {
+    use foundationdb::{
+        recipes::ranked_register::{Rank, RankedRegister, WriteResult},
+        tuple::Subspace,
+        Database, FdbBindingError,
+    };
+
+    #[test]
+    fn test_ranked_register() {
+        let _guard = unsafe { foundationdb::boot() };
+        futures::executor::block_on(test_basic_write_and_read()).expect("failed to run");
+        futures::executor::block_on(test_rank_fencing()).expect("failed to run");
+        futures::executor::block_on(test_write_ordering()).expect("failed to run");
+        futures::executor::block_on(test_stale_write_rejected()).expect("failed to run");
+        futures::executor::block_on(test_follower_value_read()).expect("failed to run");
+        futures::executor::block_on(test_empty_register()).expect("failed to run");
+    }
+
+    async fn setup_test(db: &Database, test_name: &str) -> Result<RankedRegister, FdbBindingError> {
+        let subspace = Subspace::all().subspace(&test_name);
+        let (from, to) = subspace.range();
+
+        let from_ref = &from;
+        let to_ref = &to;
+        db.run(|txn, _| async move {
+            txn.clear_range(from_ref, to_ref);
+            Ok(())
+        })
+        .await?;
+
+        Ok(RankedRegister::new(subspace))
+    }
+
+    async fn test_basic_write_and_read() -> Result<(), FdbBindingError> {
+        let db = crate::common::database().await?;
+        let rr = setup_test(&db, "test_basic_write_and_read").await?;
+
+        // Write with rank 1
+        let rr_ref = &rr;
+        let result = db
+            .run(|txn, _| async move {
+                let r = rr_ref
+                    .write(&txn, Rank::from(1u64), b"hello")
+                    .await
+                    .map_err(|e| {
+                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                    })?;
+                Ok(r)
+            })
+            .await?;
+        assert_eq!(result, WriteResult::Committed);
+
+        // Read with rank 2 should return the value
+        let rr_ref = &rr;
+        let read_result = db
+            .run(|txn, _| async move {
+                let r = rr_ref.read(&txn, Rank::from(2u64)).await.map_err(|e| {
+                    foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                })?;
+                Ok((r.write_rank(), r.into_value()))
+            })
+            .await?;
+        assert_eq!(read_result.0, Rank::from(1u64));
+        assert_eq!(read_result.1.as_deref(), Some(b"hello".as_slice()));
+
+        Ok(())
+    }
+
+    async fn test_rank_fencing() -> Result<(), FdbBindingError> {
+        let db = crate::common::database().await?;
+        let rr = setup_test(&db, "test_rank_fencing").await?;
+
+        // Read with rank 10 installs a fence
+        let rr_ref = &rr;
+        db.run(|txn, _| async move {
+            rr_ref
+                .read(&txn, Rank::from(10u64))
+                .await
+                .map_err(|e| foundationdb::FdbBindingError::CustomError(e.to_string().into()))?;
+            Ok(())
+        })
+        .await?;
+
+        // Write with rank 5 should be aborted (below the fence)
+        let rr_ref = &rr;
+        let result = db
+            .run(|txn, _| async move {
+                let r = rr_ref
+                    .write(&txn, Rank::from(5u64), b"blocked")
+                    .await
+                    .map_err(|e| {
+                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                    })?;
+                Ok(r)
+            })
+            .await?;
+        assert_eq!(result, WriteResult::Aborted);
+
+        // Write with rank 10 should succeed (equal to fence)
+        let rr_ref = &rr;
+        let result = db
+            .run(|txn, _| async move {
+                let r = rr_ref
+                    .write(&txn, Rank::from(10u64), b"accepted")
+                    .await
+                    .map_err(|e| {
+                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                    })?;
+                Ok(r)
+            })
+            .await?;
+        assert_eq!(result, WriteResult::Committed);
+
+        Ok(())
+    }
+
+    async fn test_write_ordering() -> Result<(), FdbBindingError> {
+        let db = crate::common::database().await?;
+        let rr = setup_test(&db, "test_write_ordering").await?;
+
+        // Write rank 1 value "A"
+        let rr_ref = &rr;
+        let result = db
+            .run(|txn, _| async move {
+                let r = rr_ref
+                    .write(&txn, Rank::from(1u64), b"A")
+                    .await
+                    .map_err(|e| {
+                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                    })?;
+                Ok(r)
+            })
+            .await?;
+        assert_eq!(result, WriteResult::Committed);
+
+        // Write rank 2 value "B"
+        let rr_ref = &rr;
+        let result = db
+            .run(|txn, _| async move {
+                let r = rr_ref
+                    .write(&txn, Rank::from(2u64), b"B")
+                    .await
+                    .map_err(|e| {
+                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                    })?;
+                Ok(r)
+            })
+            .await?;
+        assert_eq!(result, WriteResult::Committed);
+
+        // Read should return "B"
+        let rr_ref = &rr;
+        let read_result = db
+            .run(|txn, _| async move {
+                let r = rr_ref.read(&txn, Rank::from(3u64)).await.map_err(|e| {
+                    foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                })?;
+                Ok(r.into_value())
+            })
+            .await?;
+        assert_eq!(read_result.as_deref(), Some(b"B".as_slice()));
+
+        // Write rank 1 value "C" should be aborted (max_write_rank is 2)
+        let rr_ref = &rr;
+        let result = db
+            .run(|txn, _| async move {
+                let r = rr_ref
+                    .write(&txn, Rank::from(1u64), b"C")
+                    .await
+                    .map_err(|e| {
+                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                    })?;
+                Ok(r)
+            })
+            .await?;
+        assert_eq!(result, WriteResult::Aborted);
+
+        Ok(())
+    }
+
+    async fn test_stale_write_rejected() -> Result<(), FdbBindingError> {
+        let db = crate::common::database().await?;
+        let rr = setup_test(&db, "test_stale_write_rejected").await?;
+
+        // Write with rank 5
+        let rr_ref = &rr;
+        let result = db
+            .run(|txn, _| async move {
+                let r = rr_ref
+                    .write(&txn, Rank::from(5u64), b"initial")
+                    .await
+                    .map_err(|e| {
+                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                    })?;
+                Ok(r)
+            })
+            .await?;
+        assert_eq!(result, WriteResult::Committed);
+
+        // Read with rank 10 installs fence
+        let rr_ref = &rr;
+        db.run(|txn, _| async move {
+            rr_ref
+                .read(&txn, Rank::from(10u64))
+                .await
+                .map_err(|e| foundationdb::FdbBindingError::CustomError(e.to_string().into()))?;
+            Ok(())
+        })
+        .await?;
+
+        // Write with rank 7 should be aborted even though 7 > 5,
+        // because max_read_rank is 10
+        let rr_ref = &rr;
+        let result = db
+            .run(|txn, _| async move {
+                let r = rr_ref
+                    .write(&txn, Rank::from(7u64), b"stale")
+                    .await
+                    .map_err(|e| {
+                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                    })?;
+                Ok(r)
+            })
+            .await?;
+        assert_eq!(result, WriteResult::Aborted);
+
+        Ok(())
+    }
+
+    async fn test_follower_value_read() -> Result<(), FdbBindingError> {
+        let db = crate::common::database().await?;
+        let rr = setup_test(&db, "test_follower_value_read").await?;
+
+        // Write with rank 5
+        let rr_ref = &rr;
+        db.run(|txn, _| async move {
+            rr_ref
+                .write(&txn, Rank::from(5u64), b"X")
+                .await
+                .map_err(|e| foundationdb::FdbBindingError::CustomError(e.to_string().into()))?;
+            Ok(())
+        })
+        .await?;
+
+        // value() returns "X"
+        let rr_ref = &rr;
+        let val = db
+            .run(|txn, _| async move {
+                let v = rr_ref.value(&txn).await.map_err(|e| {
+                    foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                })?;
+                Ok(v)
+            })
+            .await?;
+        assert_eq!(val.as_deref(), Some(b"X".as_slice()));
+
+        // Write with rank 10 should succeed (value() didn't install a fence)
+        let rr_ref = &rr;
+        let result = db
+            .run(|txn, _| async move {
+                let r = rr_ref
+                    .write(&txn, Rank::from(10u64), b"Y")
+                    .await
+                    .map_err(|e| {
+                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                    })?;
+                Ok(r)
+            })
+            .await?;
+        assert_eq!(result, WriteResult::Committed);
+
+        Ok(())
+    }
+
+    async fn test_empty_register() -> Result<(), FdbBindingError> {
+        let db = crate::common::database().await?;
+        let rr = setup_test(&db, "test_empty_register").await?;
+
+        // Read on fresh register
+        let rr_ref = &rr;
+        let read_result = db
+            .run(|txn, _| async move {
+                let r = rr_ref.read(&txn, Rank::from(1u64)).await.map_err(|e| {
+                    foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                })?;
+                Ok((r.write_rank(), r.into_value()))
+            })
+            .await?;
+        assert_eq!(read_result.0, Rank::ZERO);
+        assert_eq!(read_result.1, None);
+
+        // value() on fresh register
+        let rr_ref = &rr;
+        let val = db
+            .run(|txn, _| async move {
+                let v = rr_ref.value(&txn).await.map_err(|e| {
+                    foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                })?;
+                Ok(v)
+            })
+            .await?;
+        assert_eq!(val, None);
+
+        // Write with rank 1 should succeed
+        let rr_ref = &rr;
+        let result = db
+            .run(|txn, _| async move {
+                let r = rr_ref
+                    .write(&txn, Rank::from(1u64), b"first")
+                    .await
+                    .map_err(|e| {
+                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
+                    })?;
+                Ok(r)
+            })
+            .await?;
+        assert_eq!(result, WriteResult::Committed);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

- Add ranked register recipe: a Paxos ballot-fenced register (Chockler & Malkhi, PODC 2002)
- Three operations: `read(rank)` (fence + read), `write(rank, value)` (conditional write), `value()` (plain read for followers)
- Designed to compose with leader election — ballot = rank, stale leaders auto-rejected
- Feature-gated behind `recipes-ranked-register`

Closes #435

## Test plan

- [x] `cargo check --features recipes-ranked-register` compiles
- [x] `cargo clippy --features recipes-ranked-register -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test --features recipes-ranked-register ranked_register` (requires running FDB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)