### PR TITLE
chore(docs/examples): clarify infinite-retry behavior and add timeout/retry safeguards (fixes #449)

### DIFF
--- a/foundationdb/examples/atomic-op-counter.rs
+++ b/foundationdb/examples/atomic-op-counter.rs
@@ -1,6 +1,6 @@
 use byteorder::ByteOrder;
 use foundationdb::tuple::Subspace;
-use foundationdb::{options, Database, FdbError, Transaction};
+use foundationdb::{options, Database, FdbBindingError, FdbResult, Transaction};
 
 #[tokio::main]
 async fn main() {
@@ -8,29 +8,57 @@ async fn main() {
     let db = Database::new_compat(None)
         .await
         .expect("failed to get database");
+    db.set_option(options::DatabaseOption::TransactionTimeout(5000))
+        .expect("failed to set transaction timeout");
+    db.set_option(options::DatabaseOption::TransactionRetryLimit(3))
+        .expect("failed to set transaction retry limit");
 
     let counter_key = Subspace::all().subspace(&"stats").pack(&"my_counter");
 
     // write initial value
-    let trx = db.create_trx().expect("could not create transaction");
-    increment(&trx, &counter_key, 1);
-    trx.commit().await.expect("could not commit");
+    db.run(|trx, _maybe_committed| {
+        let counter_key = counter_key.clone();
+        async move {
+            increment(&trx, &counter_key, 1);
+            Ok::<(), FdbBindingError>(())
+        }
+    })
+    .await
+    .expect("could not commit");
 
     // read counter
-    let trx = db.create_trx().expect("could not create transaction");
-    let v1 = read_counter(&trx, &counter_key)
+    let v1 = db
+        .run(|trx, _maybe_committed| {
+            let counter_key = counter_key.clone();
+            async move { 
+                let val = read_counter(&trx, &counter_key).await?;
+                Ok::<_, FdbBindingError>(val)
+            }
+        })
         .await
         .expect("could not read counter");
     dbg!(v1);
     assert!(v1 > 0);
 
     // decrement
-    let trx = db.create_trx().expect("could not create transaction");
-    increment(&trx, &counter_key, -1);
-    trx.commit().await.expect("could not commit");
+    db.run(|trx, _maybe_committed| {
+        let counter_key = counter_key.clone();
+        async move {
+            increment(&trx, &counter_key, -1);
+            Ok::<(), FdbBindingError>(())
+        }
+    })
+    .await
+    .expect("could not commit");
 
-    let trx = db.create_trx().expect("could not create transaction");
-    let v2 = read_counter(&trx, &counter_key)
+    let v2 = db
+        .run(|trx, _maybe_committed| {
+            let counter_key = counter_key.clone();
+            async move { 
+                let val = read_counter(&trx, &counter_key).await?;
+                Ok::<_, FdbBindingError>(val)
+            }
+        })
         .await
         .expect("could not read counter");
     dbg!(v2);
@@ -45,12 +73,8 @@ fn increment(trx: &Transaction, key: &[u8], incr: i64) {
     trx.atomic_op(key, &buf, options::MutationType::Add);
 }
 
-async fn read_counter(trx: &Transaction, key: &[u8]) -> Result<i64, FdbError> {
-    let raw_counter = trx
-        .get(key, true)
-        .await
-        .expect("could not read key")
-        .expect("no value found");
+async fn read_counter(trx: &Transaction, key: &[u8]) -> FdbResult<i64> {
+    let raw_counter = trx.get(key, true).await?.expect("no value found");
 
     let counter = byteorder::LE::read_i64(raw_counter.as_ref());
     Ok(counter)

--- a/foundationdb/examples/atomic-op-counter.rs
+++ b/foundationdb/examples/atomic-op-counter.rs
@@ -1,6 +1,6 @@
 use byteorder::ByteOrder;
 use foundationdb::tuple::Subspace;
-use foundationdb::{options, Database, FdbBindingError, FdbResult, Transaction};
+use foundationdb::{options, Database, FdbResult, Transaction};
 
 #[tokio::main]
 async fn main() {
@@ -20,7 +20,7 @@ async fn main() {
         let counter_key = counter_key.clone();
         async move {
             increment(&trx, &counter_key, 1);
-            Ok::<(), FdbBindingError>(())
+            Ok(())
         }
     })
     .await
@@ -30,9 +30,9 @@ async fn main() {
     let v1 = db
         .run(|trx, _maybe_committed| {
             let counter_key = counter_key.clone();
-            async move { 
+            async move {
                 let val = read_counter(&trx, &counter_key).await?;
-                Ok::<_, FdbBindingError>(val)
+                Ok(val)
             }
         })
         .await
@@ -45,7 +45,7 @@ async fn main() {
         let counter_key = counter_key.clone();
         async move {
             increment(&trx, &counter_key, -1);
-            Ok::<(), FdbBindingError>(())
+            Ok(())
         }
     })
     .await
@@ -54,9 +54,9 @@ async fn main() {
     let v2 = db
         .run(|trx, _maybe_committed| {
             let counter_key = counter_key.clone();
-            async move { 
+            async move {
                 let val = read_counter(&trx, &counter_key).await?;
-                Ok::<_, FdbBindingError>(val)
+                Ok(val)
             }
         })
         .await

--- a/foundationdb/examples/blob-with-manifest.rs
+++ b/foundationdb/examples/blob-with-manifest.rs
@@ -104,16 +104,17 @@ use uuid::Uuid;
 /// 4 - Read bytes from database
 /// 5 - Compute checksum of output data and verify correctness
 async fn clear_subspace(db: &Database, subspaces: Vec<&Subspace>) {
-    let transaction = db.create_trx().expect("Unable to create transaction");
-
-    for subspace in subspaces {
-        transaction.clear_subspace_range(subspace)
-    }
-
-    transaction
-        .commit()
-        .await
-        .expect("Unable to commit transaction");
+    db.run(|transaction, _| {
+        let subspaces = subspaces.clone();
+        async move {
+            for subspace in subspaces {
+                transaction.clear_subspace_range(subspace)
+            }
+            Ok::<(), foundationdb::FdbBindingError>(())
+        }
+    })
+    .await
+    .expect("Unable to commit transaction");
 }
 
 fn sha256_hex_digest<R: Read>(mut reader: R) -> String {
@@ -161,13 +162,12 @@ async fn write_data(db: &Database, subspace: &Subspace, data: &Vec<u8>) {
         return;
     }
 
-    let transaction = db.create_trx().expect("Unable to create transaction");
-
-    transaction.set(subspace.bytes(), data.as_slice());
-    transaction
-        .commit()
-        .await
-        .expect("Unable to commit transaction");
+    db.run(|transaction, _| async move {
+        transaction.set(subspace.bytes(), data.as_slice());
+        Ok::<(), foundationdb::FdbBindingError>(())
+    })
+    .await
+    .expect("Unable to commit transaction");
 }
 
 /// Writes to database a slice of data chunked with to the given subspace
@@ -182,50 +182,42 @@ async fn write_blob(
         return 0;
     }
 
-    let transaction = db.create_trx().expect("Unable to create transaction");
+    db.run(|transaction, _| async move {
+        let chunk_size = chunk_size.unwrap_or(CHUNK_SIZE);
 
-    let chunk_size = chunk_size.unwrap_or(CHUNK_SIZE);
+        let mut chunk_number = 0;
+        data.chunks(chunk_size).for_each(|chunk| {
+            let start = chunk_number * chunk_size;
+            let end = start + chunk.len();
 
-    let mut chunk_number = 0;
-    data.chunks(chunk_size).for_each(|chunk| {
-        let start = chunk_number * chunk_size;
-        let end = start + chunk.len();
+            let key = subspace.pack(&(chunk_number));
+            transaction.set(&key, &data[start..end]);
+            chunk_number += 1;
+        });
 
-        let key = subspace.pack(&(chunk_number));
-        transaction.set(&key, &data[start..end]);
-        chunk_number += 1;
-    });
-
-    transaction
-        .commit()
-        .await
-        .expect("Unable to commit transaction");
-
-    chunk_number
+        Ok::<usize, foundationdb::FdbBindingError>(chunk_number)
+    })
+    .await
+    .expect("Unable to commit transaction")
 }
 
 /// Read data from database
 async fn read_data(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
-    let transaction = db.create_trx().expect("Unable to create transaction");
-
-    let get_result = transaction.get(subspace.bytes(), false).await;
-
-    if let Ok(Some(data)) = get_result {
-        return Some(data.to_vec());
-    }
-
-    None
+    db.run(|transaction, _| async move {
+        let get_result = transaction.get(subspace.bytes(), false).await?;
+        Ok::<_, foundationdb::FdbBindingError>(get_result.map(|data| data.to_vec()))
+    })
+    .await
+    .ok()
+    .flatten()
 }
 
 /// Gets data from database from the given subspace with specified key name.
 async fn read_blob(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
-    let transaction = db.create_trx().expect("Unable to create transaction");
+    db.run(|transaction, _| async move {
+        let range = RangeOption::from(subspace.range());
+        let results = transaction.get_range(&range, 1_024, false).await?;
 
-    let range = RangeOption::from(subspace.range());
-
-    let get_result = transaction.get_range(&range, 1_024, false).await;
-
-    if let Ok(results) = get_result {
         let mut data: Vec<u8> = vec![];
 
         for result in results {
@@ -233,10 +225,11 @@ async fn read_blob(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
             data.extend(value.iter());
         }
 
-        return Some(data);
-    }
-
-    None
+        Ok::<Option<Vec<u8>>, foundationdb::FdbBindingError>(Some(data))
+    })
+    .await
+    .ok()
+    .flatten()
 }
 
 struct FileManifest {
@@ -386,6 +379,14 @@ async fn main() {
     let db = Database::new_compat(None)
         .await
         .expect("Unable to create database");
+    db.set_option(foundationdb::options::DatabaseOption::TransactionTimeout(
+        5000,
+    ))
+    .expect("failed to set transaction timeout");
+    db.set_option(foundationdb::options::DatabaseOption::TransactionRetryLimit(
+        3,
+    ))
+    .expect("failed to set transaction retry limit");
 
     // Create the subspace handling image data
     let images_subspace = Subspace::all().subspace(&("images"));

--- a/foundationdb/examples/blob-with-manifest.rs
+++ b/foundationdb/examples/blob-with-manifest.rs
@@ -110,7 +110,7 @@ async fn clear_subspace(db: &Database, subspaces: Vec<&Subspace>) {
             for subspace in subspaces {
                 transaction.clear_subspace_range(subspace)
             }
-            Ok::<(), foundationdb::FdbBindingError>(())
+            Ok(())
         }
     })
     .await
@@ -164,7 +164,7 @@ async fn write_data(db: &Database, subspace: &Subspace, data: &Vec<u8>) {
 
     db.run(|transaction, _| async move {
         transaction.set(subspace.bytes(), data.as_slice());
-        Ok::<(), foundationdb::FdbBindingError>(())
+        Ok(())
     })
     .await
     .expect("Unable to commit transaction");
@@ -195,7 +195,7 @@ async fn write_blob(
             chunk_number += 1;
         });
 
-        Ok::<usize, foundationdb::FdbBindingError>(chunk_number)
+        Ok(chunk_number)
     })
     .await
     .expect("Unable to commit transaction")
@@ -205,7 +205,7 @@ async fn write_blob(
 async fn read_data(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
     db.run(|transaction, _| async move {
         let get_result = transaction.get(subspace.bytes(), false).await?;
-        Ok::<_, foundationdb::FdbBindingError>(get_result.map(|data| data.to_vec()))
+        Ok(get_result.map(|data| data.to_vec()))
     })
     .await
     .ok()
@@ -213,7 +213,7 @@ async fn read_data(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
 }
 
 /// Gets data from database from the given subspace with specified key name.
-async fn read_blob(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
+async fn read_blob(db: &Database, subspace: &Subspace) -> Vec<u8> {
     db.run(|transaction, _| async move {
         let range = RangeOption::from(subspace.range());
         let results = transaction.get_range(&range, 1_024, false).await?;
@@ -225,11 +225,10 @@ async fn read_blob(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
             data.extend(value.iter());
         }
 
-        Ok::<Option<Vec<u8>>, foundationdb::FdbBindingError>(Some(data))
+        Ok(data)
     })
     .await
-    .ok()
-    .flatten()
+    .expect("Unable to read blob")
 }
 
 struct FileManifest {
@@ -364,7 +363,7 @@ async fn check_data_stored(db: &Database, files_subspaces: Vec<Subspace>) {
 
         let data_from_database = read_blob(db, &data_subspace).await;
 
-        let data_from_database = Cursor::new(data_from_database.unwrap());
+        let data_from_database = Cursor::new(data_from_database);
         let digest_data_from_database = sha256_hex_digest(data_from_database);
 
         println!("{manifest}");
@@ -383,10 +382,8 @@ async fn main() {
         5000,
     ))
     .expect("failed to set transaction timeout");
-    db.set_option(foundationdb::options::DatabaseOption::TransactionRetryLimit(
-        3,
-    ))
-    .expect("failed to set transaction retry limit");
+    db.set_option(foundationdb::options::DatabaseOption::TransactionRetryLimit(3))
+        .expect("failed to set transaction retry limit");
 
     // Create the subspace handling image data
     let images_subspace = Subspace::all().subspace(&("images"));

--- a/foundationdb/examples/blob.rs
+++ b/foundationdb/examples/blob.rs
@@ -1,47 +1,43 @@
 use foundationdb::tuple::Subspace;
-use foundationdb::{Database, RangeOption};
+use foundationdb::{Database, FdbBindingError, RangeOption};
 use rand::distr::Uniform;
 use rand::Rng;
 
 /// The goal of this example is to store blob data as chunk of 1kB
 /// Retrieve these data then verify correctness
 async fn clear_subspace(db: &Database, subspace: &Subspace) {
-    let transaction = db.create_trx().expect("Unable to create transaction");
-    transaction.clear_subspace_range(subspace);
-    transaction
-        .commit()
-        .await
-        .expect("Unable to commit transaction");
+    db.run(|trx, _maybe_committed| async move {
+        trx.clear_subspace_range(subspace);
+        Ok::<(), FdbBindingError>(())
+    })
+    .await
+    .expect("Unable to commit transaction");
 }
 
 static CHUNK_SIZE: usize = 1024;
 async fn write_blob(db: &Database, subspace: &Subspace, data: &[u8]) {
-    let transaction = db.create_trx().expect("Unable to create transaction");
+    db.run(|trx, _maybe_committed| async move {
+        let mut chunk_number = 0;
+        data.chunks(CHUNK_SIZE).for_each(|chunk| {
+            let start = chunk_number * CHUNK_SIZE;
+            let end = start + chunk.len();
 
-    let mut chunk_number = 0;
-    data.to_vec().chunks(CHUNK_SIZE).for_each(|chunk| {
-        let start = chunk_number * CHUNK_SIZE;
-        let end = start + chunk.len();
-
-        let key = subspace.pack(&(start));
-        transaction.set(&key, &data[start..end]);
-        chunk_number += 1;
-    });
-
-    transaction
-        .commit()
-        .await
-        .expect("Unable to commit transaction");
+            let key = subspace.pack(&(start));
+            trx.set(&key, &data[start..end]);
+            chunk_number += 1;
+        });
+        Ok::<(), FdbBindingError>(())
+    })
+    .await
+    .expect("Unable to commit transaction");
 }
 
 async fn read_blob(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
-    let transaction = db.create_trx().expect("Unable to create transaction");
+    db.run(|trx, _maybe_committed| async move {
+        let range = RangeOption::from(subspace.range());
 
-    let range = RangeOption::from(subspace.range());
+        let results = trx.get_range(&range, 1_024, false).await?;
 
-    let get_result = transaction.get_range(&range, 1_024, false).await;
-
-    if let Ok(results) = get_result {
         let mut data: Vec<u8> = vec![];
 
         for result in results {
@@ -49,10 +45,13 @@ async fn read_blob(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
             data.extend(value.iter());
         }
 
-        return Some(data);
-    }
-    None
+        Ok::<Option<Vec<u8>>, FdbBindingError>(Some(data))
+    })
+    .await
+    .ok()
+    .flatten()
 }
+
 
 async fn test_blob_storing(db: &Database, subspace: &Subspace, iteration: usize) {
     // Generate random 10k bytes
@@ -83,6 +82,14 @@ async fn main() {
     let db = Database::new_compat(None)
         .await
         .expect("Unable to create database");
+    db.set_option(foundationdb::options::DatabaseOption::TransactionTimeout(
+        5000,
+    ))
+    .expect("failed to set transaction timeout");
+    db.set_option(foundationdb::options::DatabaseOption::TransactionRetryLimit(
+        3,
+    ))
+    .expect("failed to set transaction retry limit");
 
     let subspace = Subspace::all().subspace(&("example-blob"));
     clear_subspace(&db, &subspace).await;

--- a/foundationdb/examples/blob.rs
+++ b/foundationdb/examples/blob.rs
@@ -1,5 +1,5 @@
 use foundationdb::tuple::Subspace;
-use foundationdb::{Database, FdbBindingError, RangeOption};
+use foundationdb::{Database, RangeOption};
 use rand::distr::Uniform;
 use rand::Rng;
 
@@ -8,7 +8,7 @@ use rand::Rng;
 async fn clear_subspace(db: &Database, subspace: &Subspace) {
     db.run(|trx, _maybe_committed| async move {
         trx.clear_subspace_range(subspace);
-        Ok::<(), FdbBindingError>(())
+        Ok(())
     })
     .await
     .expect("Unable to commit transaction");
@@ -26,13 +26,13 @@ async fn write_blob(db: &Database, subspace: &Subspace, data: &[u8]) {
             trx.set(&key, &data[start..end]);
             chunk_number += 1;
         });
-        Ok::<(), FdbBindingError>(())
+        Ok(())
     })
     .await
     .expect("Unable to commit transaction");
 }
 
-async fn read_blob(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
+async fn read_blob(db: &Database, subspace: &Subspace) -> Vec<u8> {
     db.run(|trx, _maybe_committed| async move {
         let range = RangeOption::from(subspace.range());
 
@@ -45,13 +45,11 @@ async fn read_blob(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
             data.extend(value.iter());
         }
 
-        Ok::<Option<Vec<u8>>, FdbBindingError>(Some(data))
+        Ok(data)
     })
     .await
-    .ok()
-    .flatten()
+    .expect("Unable to read blob")
 }
-
 
 async fn test_blob_storing(db: &Database, subspace: &Subspace, iteration: usize) {
     // Generate random 10k bytes
@@ -68,9 +66,7 @@ async fn test_blob_storing(db: &Database, subspace: &Subspace, iteration: usize)
     write_blob(db, &subspace, &data).await;
 
     // Read data
-    let result = read_blob(db, &subspace)
-        .await
-        .expect("Unable to read data from database");
+    let result = read_blob(db, &subspace).await;
 
     // Check correctness
     assert_eq!(&data, &result);
@@ -86,10 +82,8 @@ async fn main() {
         5000,
     ))
     .expect("failed to set transaction timeout");
-    db.set_option(foundationdb::options::DatabaseOption::TransactionRetryLimit(
-        3,
-    ))
-    .expect("failed to set transaction retry limit");
+    db.set_option(foundationdb::options::DatabaseOption::TransactionRetryLimit(3))
+        .expect("failed to set transaction retry limit");
 
     let subspace = Subspace::all().subspace(&("example-blob"));
     clear_subspace(&db, &subspace).await;

--- a/foundationdb/examples/class-scheduling.rs
+++ b/foundationdb/examples/class-scheduling.rs
@@ -13,34 +13,38 @@ use std::borrow::Cow;
 use std::ops::Deref;
 use std::thread;
 
-use futures::prelude::*;
 use rand::rngs::ThreadRng;
 
 use rand::prelude::IndexedRandom;
 
 use foundationdb as fdb;
 use foundationdb::tuple::{pack, unpack, Subspace};
-use foundationdb::{Database, FdbError, RangeOption, TransactError, TransactOption, Transaction};
+use foundationdb::{
+    Database, FdbBindingError, FdbResult, RangeOption, Transaction,
+};
 
-type Result<T> = std::result::Result<T, Error>;
+type Result<T> = std::result::Result<T, FdbBindingError>;
+
+#[derive(Debug, Clone, Copy)]
 enum Error {
-    Internal(FdbError),
     NoRemainingSeats,
     TooManyClasses,
 }
 
-impl From<FdbError> for Error {
-    fn from(err: FdbError) -> Self {
-        Error::Internal(err)
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::NoRemainingSeats => write!(f, "No remaining seats"),
+            Error::TooManyClasses => write!(f, "Too many classes"),
+        }
     }
 }
 
-impl TransactError for Error {
-    fn try_into_fdb_error(self) -> std::result::Result<FdbError, Self> {
-        match self {
-            Error::Internal(err) => Ok(err),
-            _ => Err(self),
-        }
+impl std::error::Error for Error {}
+
+impl From<Error> for FdbBindingError {
+    fn from(err: Error) -> Self {
+        FdbBindingError::CustomError(Box::new(err))
     }
 }
 
@@ -96,55 +100,50 @@ fn init_classes(trx: &Transaction, all_classes: &[String]) {
 }
 
 async fn init(db: &Database, all_classes: &[String]) {
-    let trx = db.create_trx().expect("could not create transaction");
-    trx.clear_subspace_range(&"attends".into());
-    trx.clear_subspace_range(&"class".into());
-    init_classes(&trx, all_classes);
-
-    trx.commit().await.expect("failed to initialize data");
+    db.run(|trx, _maybe_committed| async move {
+        trx.clear_subspace_range(&"attends".into());
+        trx.clear_subspace_range(&"class".into());
+        init_classes(&trx, all_classes);
+        Ok(())
+    })
+    .await
+    .expect("failed to initialize data");
 }
 
 async fn get_available_classes(db: &Database) -> Vec<String> {
-    let trx = db.create_trx().expect("could not create transaction");
+    db.run(|trx, _maybe_committed| async move {
+        let range = RangeOption::from(&Subspace::from("class"));
 
-    let range = RangeOption::from(&Subspace::from("class"));
+        let got_range = trx.get_range(&range, 1_024, false).await?;
+        let mut available_classes = Vec::<String>::new();
 
-    let got_range = trx
-        .get_range(&range, 1_024, false)
-        .await
-        .expect("failed to get classes");
-    let mut available_classes = Vec::<String>::new();
+        for key_value in got_range.iter() {
+            let count: i64 = unpack(key_value.value()).expect("failed to decode count");
 
-    for key_value in got_range.iter() {
-        let count: i64 = unpack(key_value.value()).expect("failed to decode count");
-
-        if count > 0 {
-            let class: String = unpack(key_value.key()).expect("failed to decode class");
-            available_classes.push(class);
+            if count > 0 {
+                let class: String = unpack(key_value.key()).expect("failed to decode class");
+                available_classes.push(class);
+            }
         }
-    }
 
-    available_classes
+        Ok(available_classes)
+    })
+    .await
+    .expect("failed to get classes")
 }
 
-async fn ditch_trx(trx: &Transaction, student: &str, class: &str) {
+async fn ditch_trx(trx: &Transaction, student: &str, class: &str) -> FdbResult<()> {
     let attends_key = pack(&("attends", student, class));
 
     // TODO: should get take an &Encode? current impl does encourage &[u8] reuse...
-    if trx
-        .get(&attends_key, true)
-        .await
-        .expect("get failed")
-        .is_none()
-    {
-        return;
+    if trx.get(&attends_key, true).await?.is_none() {
+        return Ok(());
     }
 
     let class_key = pack(&("class", class));
     let available_seats = trx
         .get(&class_key, true)
-        .await
-        .expect("get failed")
+        .await?
         .expect("class seats were not initialized");
     let available_seats: i64 =
         unpack::<i64>(available_seats.deref()).expect("failed to decode i64") + 1;
@@ -152,25 +151,24 @@ async fn ditch_trx(trx: &Transaction, student: &str, class: &str) {
     //println!("{} ditching class: {}", student, class);
     trx.set(&class_key, &pack(&available_seats));
     trx.clear(&attends_key);
+    Ok(())
 }
 
 async fn ditch(db: &Database, student: String, class: String) -> Result<()> {
-    db.transact_boxed_local(
-        (student, class),
-        move |trx, (student, class)| ditch_trx(trx, student, class).map(|_| Ok(())).boxed_local(),
-        fdb::TransactOption::default(),
-    )
+    db.run(move |trx, _maybe_committed| {
+        let student = student.clone();
+        let class = class.clone();
+        async move {
+            ditch_trx(&trx, &student, &class).await?;
+            Ok(())
+        }
+    })
     .await
 }
 
 async fn signup_trx(trx: &Transaction, student: &str, class: &str) -> Result<()> {
     let attends_key = pack(&("attends", student, class));
-    if trx
-        .get(&attends_key, true)
-        .await
-        .expect("get failed")
-        .is_some()
-    {
+    if trx.get(&attends_key, true).await?.is_some() {
         //println!("{} already taking class: {}", student, class);
         return Ok(());
     }
@@ -178,25 +176,18 @@ async fn signup_trx(trx: &Transaction, student: &str, class: &str) -> Result<()>
     let class_key = pack(&("class", class));
     let available_seats: i64 = unpack(
         &trx.get(&class_key, true)
-            .await
-            .expect("get failed")
+            .await?
             .expect("class seats were not initialized"),
     )
     .expect("failed to decode i64");
 
     if available_seats <= 0 {
-        return Err(Error::NoRemainingSeats);
+        return Err(Error::NoRemainingSeats.into());
     }
 
     let attends_range = RangeOption::from(&("attends", &student).into());
-    if trx
-        .get_range(&attends_range, 1_024, false)
-        .await
-        .expect("get_range failed")
-        .len()
-        >= 5
-    {
-        return Err(Error::TooManyClasses);
+    if trx.get_range(&attends_range, 1_024, false).await?.len() >= 5 {
+        return Err(Error::TooManyClasses.into());
     }
 
     //println!("{} taking class: {}", student, class);
@@ -207,11 +198,11 @@ async fn signup_trx(trx: &Transaction, student: &str, class: &str) -> Result<()>
 }
 
 async fn signup(db: &Database, student: String, class: String) -> Result<()> {
-    db.transact_boxed_local(
-        (student, class),
-        |trx, (student, class)| signup_trx(trx, student, class).boxed_local(),
-        TransactOption::default(),
-    )
+    db.run(move |trx, _maybe_committed| {
+        let student = student.clone();
+        let class = class.clone();
+        async move { signup_trx(&trx, &student, &class).await }
+    })
     .await
 }
 
@@ -221,24 +212,16 @@ async fn switch_classes(
     old_class: String,
     new_class: String,
 ) -> Result<()> {
-    async fn switch_classes_body(
-        trx: &Transaction,
-        student_id: &str,
-        old_class: &str,
-        new_class: &str,
-    ) -> Result<()> {
-        ditch_trx(trx, student_id, old_class).await;
-        signup_trx(trx, student_id, new_class).await?;
-        Ok(())
-    }
-
-    db.transact_boxed_local(
-        (student_id, old_class, new_class),
-        move |trx, (student_id, old_class, new_class)| {
-            switch_classes_body(trx, student_id, old_class, new_class).boxed_local()
-        },
-        TransactOption::default(),
-    )
+    db.run(move |trx, _maybe_committed| {
+        let student_id = student_id.clone();
+        let old_class = old_class.clone();
+        let new_class = new_class.clone();
+        async move {
+            ditch_trx(&trx, &student_id, &old_class).await?;
+            signup_trx(&trx, &student_id, &new_class).await?;
+            Ok(())
+        }
+    })
     .await
 }
 
@@ -289,6 +272,10 @@ async fn simulate_students(student_id: usize, num_ops: usize) {
     let db = Database::new_compat(None)
         .await
         .expect("failed to get database");
+    db.set_option(fdb::options::DatabaseOption::TransactionTimeout(5000))
+        .expect("failed to set transaction timeout");
+    db.set_option(fdb::options::DatabaseOption::TransactionRetryLimit(3))
+        .expect("failed to set transaction retry limit");
 
     let student_id = format!("s{student_id}");
     let mut rng = rand::rng();
@@ -345,21 +332,28 @@ async fn run_sim(db: &Database, students: usize, ops_per_student: usize) {
         thread.join().expect("failed to join thread");
 
         let student_id = format!("s{id}");
-        let attends_range = RangeOption::from(&("attends", &student_id).into());
+        
+        let student_id_clone = student_id.clone();
+        
+        db.run(move |trx, _maybe_committed| {
+            let student_id_inner = student_id_clone.clone();
+            async move {
+                let attends_range = RangeOption::from(&("attends", &student_id_inner).into());
+                let range = trx
+                    .get_range(&attends_range, 1_024, false)
+                    .await?;
+                
+                for key_value in range.iter() {
+                    let (_, s, class) = unpack::<(String, String, String)>(key_value.key()).unwrap();
+                    assert_eq!(student_id_inner, s);
 
-        for key_value in db
-            .create_trx()
-            .unwrap()
-            .get_range(&attends_range, 1_024, false)
-            .await
-            .expect("get_range failed")
-            .iter()
-        {
-            let (_, s, class) = unpack::<(String, String, String)>(key_value.key()).unwrap();
-            assert_eq!(student_id, s);
-
-            println!("{student_id} is taking: {class}");
-        }
+                    println!("{student_id_inner} is taking: {class}");
+                }
+                Ok::<(), foundationdb::FdbBindingError>(())
+            }
+        })
+        .await
+        .expect("get_range failed");
     }
 
     println!("Ran {} transactions", students * ops_per_student);
@@ -371,6 +365,10 @@ async fn main() {
     let db = fdb::Database::new_compat(None)
         .await
         .expect("failed to get database");
+    db.set_option(fdb::options::DatabaseOption::TransactionTimeout(5000))
+        .expect("failed to set transaction timeout");
+    db.set_option(fdb::options::DatabaseOption::TransactionRetryLimit(3))
+        .expect("failed to set transaction retry limit");
     init(&db, &ALL_CLASSES).await;
     println!("Initialized");
     run_sim(&db, 10, 10).await;

--- a/foundationdb/examples/class-scheduling.rs
+++ b/foundationdb/examples/class-scheduling.rs
@@ -19,9 +19,7 @@ use rand::prelude::IndexedRandom;
 
 use foundationdb as fdb;
 use foundationdb::tuple::{pack, unpack, Subspace};
-use foundationdb::{
-    Database, FdbBindingError, FdbResult, RangeOption, Transaction,
-};
+use foundationdb::{Database, FdbBindingError, FdbResult, RangeOption, Transaction};
 
 type Result<T> = std::result::Result<T, FdbBindingError>;
 
@@ -332,24 +330,23 @@ async fn run_sim(db: &Database, students: usize, ops_per_student: usize) {
         thread.join().expect("failed to join thread");
 
         let student_id = format!("s{id}");
-        
+
         let student_id_clone = student_id.clone();
-        
+
         db.run(move |trx, _maybe_committed| {
             let student_id_inner = student_id_clone.clone();
             async move {
                 let attends_range = RangeOption::from(&("attends", &student_id_inner).into());
-                let range = trx
-                    .get_range(&attends_range, 1_024, false)
-                    .await?;
-                
+                let range = trx.get_range(&attends_range, 1_024, false).await?;
+
                 for key_value in range.iter() {
-                    let (_, s, class) = unpack::<(String, String, String)>(key_value.key()).unwrap();
+                    let (_, s, class) =
+                        unpack::<(String, String, String)>(key_value.key()).unwrap();
                     assert_eq!(student_id_inner, s);
 
                     println!("{student_id_inner} is taking: {class}");
                 }
-                Ok::<(), foundationdb::FdbBindingError>(())
+                Ok(())
             }
         })
         .await

--- a/foundationdb/examples/hello-world.rs
+++ b/foundationdb/examples/hello-world.rs
@@ -13,6 +13,16 @@ async fn main() {
 async fn hello_world() -> foundationdb::FdbResult<()> {
     let db = foundationdb::Database::default()?;
 
+    // By default, the FoundationDB C API will retry indefinitely if it cannot reach the cluster
+    // or if DNS resolution fails. To prevent this, you can set a timeout or a retry limit on the
+    // database object.
+    db.set_option(foundationdb::options::DatabaseOption::TransactionTimeout(
+        5000,
+    ))?; // 5 seconds
+    db.set_option(foundationdb::options::DatabaseOption::TransactionRetryLimit(
+        3,
+    ))?;
+
     // write a value in a retryable closure
     match db
         .run(|trx, _maybe_committed| async move {

--- a/foundationdb/examples/hello-world.rs
+++ b/foundationdb/examples/hello-world.rs
@@ -19,9 +19,7 @@ async fn hello_world() -> foundationdb::FdbResult<()> {
     db.set_option(foundationdb::options::DatabaseOption::TransactionTimeout(
         5000,
     ))?; // 5 seconds
-    db.set_option(foundationdb::options::DatabaseOption::TransactionRetryLimit(
-        3,
-    ))?;
+    db.set_option(foundationdb::options::DatabaseOption::TransactionRetryLimit(3))?;
 
     // write a value in a retryable closure
     match db

--- a/foundationdb/examples/multi_version.rs
+++ b/foundationdb/examples/multi_version.rs
@@ -35,6 +35,10 @@ async fn main() {
     let db = Database::new_compat(None)
         .await
         .expect("failed to get database");
+    db.set_option(options::DatabaseOption::TransactionTimeout(5000))
+        .expect("failed to set transaction timeout");
+    db.set_option(options::DatabaseOption::TransactionRetryLimit(3))
+        .expect("failed to set transaction retry limit");
 
     // used to catch the first cluster_version_changed error when using external clients
     // when using external clients, it will throw cluster_version_changed for the first time establish the connection to
@@ -59,19 +63,29 @@ async fn main() {
         .pack(&"multi_version_incr");
 
     // increment or create key with "1"
-    let trx = db.create_trx().expect("could not create transaction");
-    let mut buf = [0u8; 8];
-    byteorder::LE::write_i64(&mut buf, 1);
-    trx.atomic_op(&key, &buf, options::MutationType::Add);
-    trx.commit().await.expect("could not commit");
+    db.run(|trx, _| {
+        let key = key.clone();
+        async move {
+            let mut buf = [0u8; 8];
+            byteorder::LE::write_i64(&mut buf, 1);
+            trx.atomic_op(&key, &buf, options::MutationType::Add);
+            Ok::<(), foundationdb::FdbBindingError>(())
+        }
+    })
+    .await
+    .expect("could not commit");
 
     // read counter value
-    let trx = db.create_trx().expect("could not create transaction");
-    let raw_counter = trx
-        .get(&key, true)
-        .await
-        .expect("could not read key")
-        .expect("no value found");
+    let raw_counter = db.run(|trx, _| {
+        let key = key.clone();
+        async move {
+            let result = trx.get(&key, true).await?;
+            Ok::<_, foundationdb::FdbBindingError>(result)
+        }
+    })
+    .await
+    .expect("could not read key")
+    .expect("no value found");
 
     let counter = byteorder::LE::read_i64(raw_counter.as_ref());
     dbg!(counter);

--- a/foundationdb/examples/multi_version.rs
+++ b/foundationdb/examples/multi_version.rs
@@ -69,23 +69,24 @@ async fn main() {
             let mut buf = [0u8; 8];
             byteorder::LE::write_i64(&mut buf, 1);
             trx.atomic_op(&key, &buf, options::MutationType::Add);
-            Ok::<(), foundationdb::FdbBindingError>(())
+            Ok(())
         }
     })
     .await
     .expect("could not commit");
 
     // read counter value
-    let raw_counter = db.run(|trx, _| {
-        let key = key.clone();
-        async move {
-            let result = trx.get(&key, true).await?;
-            Ok::<_, foundationdb::FdbBindingError>(result)
-        }
-    })
-    .await
-    .expect("could not read key")
-    .expect("no value found");
+    let raw_counter = db
+        .run(|trx, _| {
+            let key = key.clone();
+            async move {
+                let result = trx.get(&key, true).await?;
+                Ok(result)
+            }
+        })
+        .await
+        .expect("could not read key")
+        .expect("no value found");
 
     let counter = byteorder::LE::read_i64(raw_counter.as_ref());
     dbg!(counter);

--- a/foundationdb/examples/simple-index.rs
+++ b/foundationdb/examples/simple-index.rs
@@ -1,5 +1,5 @@
 use foundationdb::tuple::{unpack, Subspace, TuplePack};
-use foundationdb::{Database, FdbResult, RangeOption, Transaction};
+use foundationdb::{Database, FdbBindingError, FdbResult, RangeOption, Transaction};
 use std::fmt::{Display, Formatter};
 
 #[derive(Default)]
@@ -20,18 +20,16 @@ impl Display for User {
 }
 
 /// Cleanup any data from previous run
-async fn clear_subspaces(db: &Database, subspaces: &Vec<Subspace>) {
-    let transaction = db.create_trx().expect("Failed to create transaction");
-
-    // teardown, clear data from previous run
-    for subspace in subspaces {
-        transaction.clear_subspace_range(subspace);
-    }
-
-    transaction
-        .commit()
-        .await
-        .expect("Unable to commit transaction");
+async fn clear_subspaces(db: &Database, subspaces: &[Subspace]) {
+    db.run(|trx, _maybe_committed| async move {
+        // teardown, clear data from previous run
+        for subspace in subspaces {
+            trx.clear_subspace_range(subspace);
+        }
+        Ok::<(), FdbBindingError>(())
+    })
+    .await
+    .expect("Unable to commit transaction");
 }
 
 async fn create_user(
@@ -70,45 +68,42 @@ async fn get_user(
     })
 }
 
+
 async fn search_user_by_zipcode(
     db: &Database,
     user_subspace: &Subspace,
     zipcode_index: &Subspace,
     zipcode: &str,
-) -> Option<Vec<User>> {
-    let transaction = db.create_trx().expect("Unable to create transaction");
+) -> Result<Vec<User>, FdbBindingError> {
+    db.run(|trx, _maybe_committed| async move {
+        // Create scanning zipcode index range
+        let begin = zipcode_index.pack(&(zipcode));
 
-    // Create scanning zipcode index range
-    let begin = zipcode_index.pack(&(zipcode));
+        let mut end = zipcode_index.pack(&(zipcode));
+        end.pop();
+        end.push(255_u8);
 
-    let mut end = zipcode_index.pack(&(zipcode));
-    end.pop();
-    end.push(255_u8);
+        let range = RangeOption::from((begin, end));
 
-    let range = RangeOption::from((begin, end));
+        let results = trx.get_range(&range, 1, false).await?;
 
-    let result_get_index = &transaction.get_range(&range, 1, false).await;
+        let mut users = vec![];
 
-    let mut users = vec![];
+        for result in results {
+            let (zipcode, id): (String, String) = zipcode_index
+                .unpack(result.key())
+                .expect("Unable to unpack value from index");
 
-    match result_get_index {
-        Ok(results) => {
-            for result in results {
-                let (zipcode, id): (String, String) = zipcode_index
-                    .unpack(result.key())
-                    .expect("Unable to unpack value from index");
+            let result_user = get_user(user_subspace, &trx, &id, &zipcode).await;
 
-                let result_user = get_user(user_subspace, &transaction, &id, &zipcode).await;
-
-                if let Ok(user) = result_user {
-                    users.push(user);
-                }
+            if let Ok(user) = result_user {
+                users.push(user);
             }
-
-            Some(users)
         }
-        Err(_err) => None,
-    }
+
+        Ok(users)
+    })
+    .await
 }
 
 #[tokio::main]
@@ -117,13 +112,21 @@ async fn main() {
     let db = Database::new_compat(None)
         .await
         .expect("failed to get database");
+    db.set_option(foundationdb::options::DatabaseOption::TransactionTimeout(
+        5000,
+    ))
+    .expect("failed to set transaction timeout");
+    db.set_option(foundationdb::options::DatabaseOption::TransactionRetryLimit(
+        3,
+    ))
+    .expect("failed to set transaction retry limit");
 
     let user_subspace = Subspace::from_bytes("user");
     let zipcode_index_subspace = Subspace::from_bytes("zipcode_index");
 
     clear_subspaces(
         &db,
-        &vec![user_subspace.clone(), zipcode_index_subspace.clone()],
+        &[user_subspace.clone(), zipcode_index_subspace.clone()],
     )
     .await;
 
@@ -133,8 +136,9 @@ async fn main() {
 
     let users = search_user_by_zipcode(&db, &user_subspace, &zipcode_index_subspace, "205").await;
 
-    if let Some(users) = users {
-        users.iter().for_each(|user| println!("{user}"));
+    match users {
+        Ok(users) => users.iter().for_each(|user| println!("{user}")),
+        Err(e) => eprintln!("Error searching users: {e}"),
     }
 }
 
@@ -142,73 +146,72 @@ async fn populate_users(
     db: &Database,
     user_subspace: &Subspace,
     zipcode_index_subspace: &Subspace,
-) -> FdbResult<()> {
-    let transaction = db.create_trx().expect("Failed to create transaction");
-
-    create_user(
-        &transaction,
-        "001",
-        "20500",
-        "Barack",
-        user_subspace,
-        zipcode_index_subspace,
-    )
-    .await;
-    create_user(
-        &transaction,
-        "002",
-        "20500",
-        "Michelle",
-        user_subspace,
-        zipcode_index_subspace,
-    )
-    .await;
-    create_user(
-        &transaction,
-        "003",
-        "20500",
-        "Sasha",
-        user_subspace,
-        zipcode_index_subspace,
-    )
-    .await;
-    create_user(
-        &transaction,
-        "004",
-        "20500",
-        "Malia",
-        user_subspace,
-        zipcode_index_subspace,
-    )
-    .await;
-    create_user(
-        &transaction,
-        "005",
-        "20500",
-        "Bo",
-        user_subspace,
-        zipcode_index_subspace,
-    )
-    .await;
-    create_user(
-        &transaction,
-        "101",
-        "SW1A 1AA",
-        "Elizabeth",
-        user_subspace,
-        zipcode_index_subspace,
-    )
-    .await;
-    create_user(
-        &transaction,
-        "102",
-        "SW1A 1AA",
-        "Philip",
-        user_subspace,
-        zipcode_index_subspace,
-    )
-    .await;
-
-    transaction.commit().await?;
-    Ok(())
+) -> Result<(), FdbBindingError> {
+    db.run(|trx, _maybe_committed| async move {
+        create_user(
+            &trx,
+            "001",
+            "20500",
+            "Barack",
+            user_subspace,
+            zipcode_index_subspace,
+        )
+        .await;
+        create_user(
+            &trx,
+            "002",
+            "20500",
+            "Michelle",
+            user_subspace,
+            zipcode_index_subspace,
+        )
+        .await;
+        create_user(
+            &trx,
+            "003",
+            "20500",
+            "Sasha",
+            user_subspace,
+            zipcode_index_subspace,
+        )
+        .await;
+        create_user(
+            &trx,
+            "004",
+            "20500",
+            "Malia",
+            user_subspace,
+            zipcode_index_subspace,
+        )
+        .await;
+        create_user(
+            &trx,
+            "005",
+            "20500",
+            "Bo",
+            user_subspace,
+            zipcode_index_subspace,
+        )
+        .await;
+        create_user(
+            &trx,
+            "101",
+            "SW1A 1AA",
+            "Elizabeth",
+            user_subspace,
+            zipcode_index_subspace,
+        )
+        .await;
+        create_user(
+            &trx,
+            "102",
+            "SW1A 1AA",
+            "Philip",
+            user_subspace,
+            zipcode_index_subspace,
+        )
+        .await;
+        Ok(())
+    })
+    .await
 }

--- a/foundationdb/examples/simple-index.rs
+++ b/foundationdb/examples/simple-index.rs
@@ -26,7 +26,7 @@ async fn clear_subspaces(db: &Database, subspaces: &[Subspace]) {
         for subspace in subspaces {
             trx.clear_subspace_range(subspace);
         }
-        Ok::<(), FdbBindingError>(())
+        Ok(())
     })
     .await
     .expect("Unable to commit transaction");
@@ -67,7 +67,6 @@ async fn get_user(
         name,
     })
 }
-
 
 async fn search_user_by_zipcode(
     db: &Database,
@@ -116,10 +115,8 @@ async fn main() {
         5000,
     ))
     .expect("failed to set transaction timeout");
-    db.set_option(foundationdb::options::DatabaseOption::TransactionRetryLimit(
-        3,
-    ))
-    .expect("failed to set transaction retry limit");
+    db.set_option(foundationdb::options::DatabaseOption::TransactionRetryLimit(3))
+        .expect("failed to set transaction retry limit");
 
     let user_subspace = Subspace::from_bytes("user");
     let zipcode_index_subspace = Subspace::from_bytes("zipcode_index");

--- a/foundationdb/examples/versionstamp.rs
+++ b/foundationdb/examples/versionstamp.rs
@@ -1,7 +1,7 @@
 use foundationdb::{
     options,
     tuple::{pack, pack_with_versionstamp, unpack, Subspace, Versionstamp},
-    Database, FdbResult, RangeOption,
+    Database, FdbBindingError, RangeOption,
 };
 use futures::StreamExt;
 
@@ -20,20 +20,27 @@ async fn main() {
     drop(network);
 }
 
-async fn run_versionstamp_key_example() -> FdbResult<()> {
+async fn run_versionstamp_key_example() -> Result<(), FdbBindingError> {
     println!("running example for setting versionstamped keys");
     // Using versionstamps in order to create a sequential path.
     let db = Database::default()?;
+    db.set_option(options::DatabaseOption::TransactionTimeout(5000))?;
+    db.set_option(options::DatabaseOption::TransactionRetryLimit(3))?;
 
     let subspace = Subspace::all().subspace(&"versionstamp_example");
     let (from, to) = subspace.range();
-    let trx_clear = db.create_trx()?;
-    trx_clear.clear_range(&from, &to);
-    trx_clear.commit().await?;
+    db.run(|trx, _maybe_committed| {
+        let from = from.clone();
+        let to = to.clone();
+        async move {
+            trx.clear_range(&from, &to);
+            Ok(())
+        }
+    })
+    .await?;
 
     // We can create two interleaved transactions, each creating a versionstamped key.
     // The first to commit will be the one to get the lowest versionstamp value.
-    let trx_1 = db.create_trx()?;
 
     // versionstamps allow user ordering too, which can be set as the user version when creating an
     // incomplete versionstamp. While these two keys will be committed in the same transaction,
@@ -44,44 +51,54 @@ async fn run_versionstamp_key_example() -> FdbResult<()> {
     let value_1_1 = "value_1_1";
     let value_1_2 = "value_1_2";
 
-    // Creating versionstamped keys is an atomic op.
-    trx_1.atomic_op(
-        &key_1_1,
-        &pack(&value_1_1),
-        options::MutationType::SetVersionstampedKey,
-    );
-    trx_1.atomic_op(
-        &key_1_2,
-        &pack(&value_1_2),
-        options::MutationType::SetVersionstampedKey,
-    );
-
     // We can create a second set of kvs in a new transaction
-    let trx_2 = db.create_trx()?;
-
     let key_2_1 = subspace.pack_with_versionstamp(&("prefix", &Versionstamp::incomplete(1)));
     let key_2_2 = subspace.pack_with_versionstamp(&("prefix", &Versionstamp::incomplete(2)));
 
     let value_2_1 = "value_2_1";
     let value_2_2 = "value_2_2";
 
-    // Creating versionstamped keys is an atomic op.
-    trx_2.atomic_op(
-        &key_2_1,
-        &pack(&value_2_1),
-        options::MutationType::SetVersionstampedKey,
-    );
-    trx_2.atomic_op(
-        &key_2_2,
-        &pack(&value_2_2),
-        options::MutationType::SetVersionstampedKey,
-    );
-
     // The order in which we commit will determine the final ordering.
     // Committing the second transaction first will give us the expected order.
-    trx_2.commit().await?;
+    db.run(|trx, _maybe_committed| {
+        let key_2_1 = key_2_1.clone();
+        let key_2_2 = key_2_2.clone();
+        async move {
+            // Creating versionstamped keys is an atomic op.
+            trx.atomic_op(
+                &key_2_1,
+                &pack(&value_2_1),
+                options::MutationType::SetVersionstampedKey,
+            );
+            trx.atomic_op(
+                &key_2_2,
+                &pack(&value_2_2),
+                options::MutationType::SetVersionstampedKey,
+            );
+            Ok(())
+        }
+    })
+    .await?;
 
-    trx_1.commit().await?;
+    db.run(|trx, _maybe_committed| {
+        let key_1_1 = key_1_1.clone();
+        let key_1_2 = key_1_2.clone();
+        async move {
+            // Creating versionstamped keys is an atomic op.
+            trx.atomic_op(
+                &key_1_1,
+                &pack(&value_1_1),
+                options::MutationType::SetVersionstampedKey,
+            );
+            trx.atomic_op(
+                &key_1_2,
+                &pack(&value_1_2),
+                options::MutationType::SetVersionstampedKey,
+            );
+            Ok(())
+        }
+    })
+    .await?;
 
     // Reading the keys back will give us the expected order.
     // value_2_1
@@ -89,74 +106,103 @@ async fn run_versionstamp_key_example() -> FdbResult<()> {
     // value_1_2
     // value_1_1
 
-    let trx = db.create_trx()?;
-    let range = RangeOption::from((from, to));
-    let mut kvs = trx.get_ranges_keyvalues(range, false);
-    while let Some(kv) = kvs.next().await {
-        let kv = kv?;
-        let (_, v) = subspace
-            .unpack::<(String, Versionstamp)>(kv.key())
-            .expect("failed to unpack key");
-        let value = unpack::<String>(kv.value()).expect("failed to unpack value");
-        println!(
-            "{:?} {}: {}",
-            v.transaction_version(),
-            v.user_version(),
-            value
-        );
-    }
+    db.run(|trx, _maybe_committed| {
+        let from = from.clone();
+        let to = to.clone();
+        let subspace = subspace.clone();
+        async move {
+            let range = RangeOption::from((from, to));
+            let mut kvs = trx.get_ranges_keyvalues(range, false);
+            while let Some(kv) = kvs.next().await {
+                let kv = kv?;
+                let (_, v) = subspace
+                    .unpack::<(String, Versionstamp)>(kv.key())
+                    .expect("failed to unpack key");
+                let value = unpack::<String>(kv.value()).expect("failed to unpack value");
+                println!(
+                    "{:?} {}: {}",
+                    v.transaction_version(),
+                    v.user_version(),
+                    value
+                );
+            }
+            Ok(())
+        }
+    })
+    .await?;
     Ok(())
 }
 
-async fn run_versionstamp_value_example() -> FdbResult<()> {
+async fn run_versionstamp_value_example() -> Result<(), FdbBindingError> {
     println!("running example for setting versionstamped values");
     // You can use versionstamps in values too, for example to point to a versionstamped key.
     let db = Database::default()?;
+    db.set_option(options::DatabaseOption::TransactionTimeout(5000))?;
+    db.set_option(options::DatabaseOption::TransactionRetryLimit(3))?;
 
     let subspace = Subspace::all().subspace(&"versionstamp_example");
     let (from, to) = subspace.range();
-    let trx_clear = db.create_trx()?;
-    trx_clear.clear_range(&from, &to);
-    trx_clear.commit().await?;
+    db.run(|trx, _maybe_committed| {
+        let from = from.clone();
+        let to = to.clone();
+        async move {
+            trx.clear_range(&from, &to);
+            Ok(())
+        }
+    })
+    .await?;
 
     // In our transaction we will create a versionstamped key, and then reference it in another
     // known "index" key.
-    let trx = db.create_trx()?;
-
     let key_tuple = ("data", &Versionstamp::incomplete(0));
     let key = subspace.pack_with_versionstamp(&key_tuple);
     let value = "some value";
 
-    trx.atomic_op(
-        &key,
-        &pack(&value),
-        options::MutationType::SetVersionstampedKey,
-    );
-
     let index_key = subspace.pack(&"index");
-    trx.atomic_op(
-        &index_key,
-        &pack_with_versionstamp(&key_tuple),
-        options::MutationType::SetVersionstampedValue,
-    );
-    trx.commit().await?;
+
+    db.run(|trx, _maybe_committed| {
+        let key = key.clone();
+        let index_key = index_key.clone();
+        async move {
+            trx.atomic_op(
+                &key,
+                &pack(&value),
+                options::MutationType::SetVersionstampedKey,
+            );
+
+            trx.atomic_op(
+                &index_key,
+                &pack_with_versionstamp(&key_tuple),
+                options::MutationType::SetVersionstampedValue,
+            );
+            Ok(())
+        }
+    })
+    .await?;
 
     // Now we created our versionstamped key and a reference to it.
     // We can read the index key and get the versionstamped key back.
-    let trx = db.create_trx()?;
-    let index_kv = trx
-        .get(&index_key, false)
-        .await?
-        .expect("didn't find index");
-    let versionstamped_key =
-        unpack::<(String, Versionstamp)>(&index_kv).expect("failed to unpack value");
+    db.run(|trx, _maybe_committed| {
+        let index_key = index_key.clone();
+        let subspace = subspace.clone();
+        async move {
+            let index_kv = trx
+                .get(&index_key, false)
+                .await?
+                .expect("didn't find index");
+            let versionstamped_key =
+                unpack::<(String, Versionstamp)>(&index_kv).expect("failed to unpack value");
 
-    // notice that we don't pack with versionstamp here because the versionstamp we received is complete.
-    let versionstamped_value = trx
-        .get(&subspace.pack(&versionstamped_key), false)
-        .await?
-        .expect("didn't find reference");
-    let value = unpack::<String>(&versionstamped_value).expect("failed to unpack value");
-    println!("got back value {value}");
+            // notice that we don't pack with versionstamp here because the versionstamp we received is complete.
+            let versionstamped_value = trx
+                .get(&subspace.pack(&versionstamped_key), false)
+                .await?
+                .expect("didn't find reference");
+            let value = unpack::<String>(&versionstamped_value).expect("failed to unpack value");
+            println!("got back value {value}");
+            Ok(())
+        }
+    })
+    .await?;
     Ok(())
 }

--- a/foundationdb/examples/versionstamp.rs
+++ b/foundationdb/examples/versionstamp.rs
@@ -1,7 +1,7 @@
 use foundationdb::{
     options,
     tuple::{pack, pack_with_versionstamp, unpack, Subspace, Versionstamp},
-    Database, FdbBindingError, RangeOption,
+    Database, FdbResult, RangeOption,
 };
 use futures::StreamExt;
 
@@ -20,7 +20,7 @@ async fn main() {
     drop(network);
 }
 
-async fn run_versionstamp_key_example() -> Result<(), FdbBindingError> {
+async fn run_versionstamp_key_example() -> FdbResult<()> {
     println!("running example for setting versionstamped keys");
     // Using versionstamps in order to create a sequential path.
     let db = Database::default()?;
@@ -29,18 +29,13 @@ async fn run_versionstamp_key_example() -> Result<(), FdbBindingError> {
 
     let subspace = Subspace::all().subspace(&"versionstamp_example");
     let (from, to) = subspace.range();
-    db.run(|trx, _maybe_committed| {
-        let from = from.clone();
-        let to = to.clone();
-        async move {
-            trx.clear_range(&from, &to);
-            Ok(())
-        }
-    })
-    .await?;
+    let trx_clear = db.create_trx()?;
+    trx_clear.clear_range(&from, &to);
+    trx_clear.commit().await?;
 
     // We can create two interleaved transactions, each creating a versionstamped key.
     // The first to commit will be the one to get the lowest versionstamp value.
+    let trx_1 = db.create_trx()?;
 
     // versionstamps allow user ordering too, which can be set as the user version when creating an
     // incomplete versionstamp. While these two keys will be committed in the same transaction,
@@ -51,54 +46,44 @@ async fn run_versionstamp_key_example() -> Result<(), FdbBindingError> {
     let value_1_1 = "value_1_1";
     let value_1_2 = "value_1_2";
 
+    // Creating versionstamped keys is an atomic op.
+    trx_1.atomic_op(
+        &key_1_1,
+        &pack(&value_1_1),
+        options::MutationType::SetVersionstampedKey,
+    );
+    trx_1.atomic_op(
+        &key_1_2,
+        &pack(&value_1_2),
+        options::MutationType::SetVersionstampedKey,
+    );
+
     // We can create a second set of kvs in a new transaction
+    let trx_2 = db.create_trx()?;
+
     let key_2_1 = subspace.pack_with_versionstamp(&("prefix", &Versionstamp::incomplete(1)));
     let key_2_2 = subspace.pack_with_versionstamp(&("prefix", &Versionstamp::incomplete(2)));
 
     let value_2_1 = "value_2_1";
     let value_2_2 = "value_2_2";
 
+    // Creating versionstamped keys is an atomic op.
+    trx_2.atomic_op(
+        &key_2_1,
+        &pack(&value_2_1),
+        options::MutationType::SetVersionstampedKey,
+    );
+    trx_2.atomic_op(
+        &key_2_2,
+        &pack(&value_2_2),
+        options::MutationType::SetVersionstampedKey,
+    );
+
     // The order in which we commit will determine the final ordering.
     // Committing the second transaction first will give us the expected order.
-    db.run(|trx, _maybe_committed| {
-        let key_2_1 = key_2_1.clone();
-        let key_2_2 = key_2_2.clone();
-        async move {
-            // Creating versionstamped keys is an atomic op.
-            trx.atomic_op(
-                &key_2_1,
-                &pack(&value_2_1),
-                options::MutationType::SetVersionstampedKey,
-            );
-            trx.atomic_op(
-                &key_2_2,
-                &pack(&value_2_2),
-                options::MutationType::SetVersionstampedKey,
-            );
-            Ok(())
-        }
-    })
-    .await?;
+    trx_2.commit().await?;
 
-    db.run(|trx, _maybe_committed| {
-        let key_1_1 = key_1_1.clone();
-        let key_1_2 = key_1_2.clone();
-        async move {
-            // Creating versionstamped keys is an atomic op.
-            trx.atomic_op(
-                &key_1_1,
-                &pack(&value_1_1),
-                options::MutationType::SetVersionstampedKey,
-            );
-            trx.atomic_op(
-                &key_1_2,
-                &pack(&value_1_2),
-                options::MutationType::SetVersionstampedKey,
-            );
-            Ok(())
-        }
-    })
-    .await?;
+    trx_1.commit().await?;
 
     // Reading the keys back will give us the expected order.
     // value_2_1
@@ -106,34 +91,26 @@ async fn run_versionstamp_key_example() -> Result<(), FdbBindingError> {
     // value_1_2
     // value_1_1
 
-    db.run(|trx, _maybe_committed| {
-        let from = from.clone();
-        let to = to.clone();
-        let subspace = subspace.clone();
-        async move {
-            let range = RangeOption::from((from, to));
-            let mut kvs = trx.get_ranges_keyvalues(range, false);
-            while let Some(kv) = kvs.next().await {
-                let kv = kv?;
-                let (_, v) = subspace
-                    .unpack::<(String, Versionstamp)>(kv.key())
-                    .expect("failed to unpack key");
-                let value = unpack::<String>(kv.value()).expect("failed to unpack value");
-                println!(
-                    "{:?} {}: {}",
-                    v.transaction_version(),
-                    v.user_version(),
-                    value
-                );
-            }
-            Ok(())
-        }
-    })
-    .await?;
+    let trx = db.create_trx()?;
+    let range = RangeOption::from((from, to));
+    let mut kvs = trx.get_ranges_keyvalues(range, false);
+    while let Some(kv) = kvs.next().await {
+        let kv = kv?;
+        let (_, v) = subspace
+            .unpack::<(String, Versionstamp)>(kv.key())
+            .expect("failed to unpack key");
+        let value = unpack::<String>(kv.value()).expect("failed to unpack value");
+        println!(
+            "{:?} {}: {}",
+            v.transaction_version(),
+            v.user_version(),
+            value
+        );
+    }
     Ok(())
 }
 
-async fn run_versionstamp_value_example() -> Result<(), FdbBindingError> {
+async fn run_versionstamp_value_example() -> FdbResult<()> {
     println!("running example for setting versionstamped values");
     // You can use versionstamps in values too, for example to point to a versionstamped key.
     let db = Database::default()?;
@@ -142,67 +119,48 @@ async fn run_versionstamp_value_example() -> Result<(), FdbBindingError> {
 
     let subspace = Subspace::all().subspace(&"versionstamp_example");
     let (from, to) = subspace.range();
-    db.run(|trx, _maybe_committed| {
-        let from = from.clone();
-        let to = to.clone();
-        async move {
-            trx.clear_range(&from, &to);
-            Ok(())
-        }
-    })
-    .await?;
+    let trx_clear = db.create_trx()?;
+    trx_clear.clear_range(&from, &to);
+    trx_clear.commit().await?;
 
     // In our transaction we will create a versionstamped key, and then reference it in another
     // known "index" key.
+    let trx = db.create_trx()?;
+
     let key_tuple = ("data", &Versionstamp::incomplete(0));
     let key = subspace.pack_with_versionstamp(&key_tuple);
     let value = "some value";
 
+    trx.atomic_op(
+        &key,
+        &pack(&value),
+        options::MutationType::SetVersionstampedKey,
+    );
+
     let index_key = subspace.pack(&"index");
-
-    db.run(|trx, _maybe_committed| {
-        let key = key.clone();
-        let index_key = index_key.clone();
-        async move {
-            trx.atomic_op(
-                &key,
-                &pack(&value),
-                options::MutationType::SetVersionstampedKey,
-            );
-
-            trx.atomic_op(
-                &index_key,
-                &pack_with_versionstamp(&key_tuple),
-                options::MutationType::SetVersionstampedValue,
-            );
-            Ok(())
-        }
-    })
-    .await?;
+    trx.atomic_op(
+        &index_key,
+        &pack_with_versionstamp(&key_tuple),
+        options::MutationType::SetVersionstampedValue,
+    );
+    trx.commit().await?;
 
     // Now we created our versionstamped key and a reference to it.
     // We can read the index key and get the versionstamped key back.
-    db.run(|trx, _maybe_committed| {
-        let index_key = index_key.clone();
-        let subspace = subspace.clone();
-        async move {
-            let index_kv = trx
-                .get(&index_key, false)
-                .await?
-                .expect("didn't find index");
-            let versionstamped_key =
-                unpack::<(String, Versionstamp)>(&index_kv).expect("failed to unpack value");
+    let trx = db.create_trx()?;
+    let index_kv = trx
+        .get(&index_key, false)
+        .await?
+        .expect("didn't find index");
+    let versionstamped_key =
+        unpack::<(String, Versionstamp)>(&index_kv).expect("failed to unpack value");
 
-            // notice that we don't pack with versionstamp here because the versionstamp we received is complete.
-            let versionstamped_value = trx
-                .get(&subspace.pack(&versionstamped_key), false)
-                .await?
-                .expect("didn't find reference");
-            let value = unpack::<String>(&versionstamped_value).expect("failed to unpack value");
-            println!("got back value {value}");
-            Ok(())
-        }
-    })
-    .await?;
+    // notice that we don't pack with versionstamp here because the versionstamp we received is complete.
+    let versionstamped_value = trx
+        .get(&subspace.pack(&versionstamped_key), false)
+        .await?
+        .expect("didn't find reference");
+    let value = unpack::<String>(&versionstamped_value).expect("failed to unpack value");
+    println!("got back value {value}");
     Ok(())
 }

--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -445,11 +445,18 @@ impl Database {
     /// transaction. After caller-provided future resolves, the transaction will be committed
     /// automatically.
     ///
-    /// # Warning
+    /// # Warning: Hanging on Network/DNS failures
     ///
-    /// It might retry indefinitely if the transaction is highly contentious. It is recommended to
-    /// set `TransactionOption::RetryLimit` or `TransactionOption::SetTimeout` on the transaction
-    /// if the task need to be guaranteed to finish.
+    /// By default, the FoundationDB C API will retry indefinitely if it cannot reach the cluster
+    /// or if DNS resolution fails. This can cause `transact` to hang forever.
+    /// To prevent this, you should set [`options::DatabaseOption::TransactionTimeout`] or
+    /// [`options::DatabaseOption::TransactionRetryLimit`] on the [`Database`] object, or
+    /// [`options::TransactionOption::Timeout`] or [`options::TransactionOption::RetryLimit`] on the transaction
+    /// itself.
+    ///
+    /// Note that `TransactOption` also provides `retry_limit` and `time_out`, but these are
+    /// Rust-side budgets that are only checked *between* retries. If the C API hangs during a call
+    /// like `commit()` or `on_error()`, these budgets will not be reached.
     ///
     /// Once [Generic Associated Types](https://github.com/rust-lang/rfcs/blob/master/text/1598-generic_associated_types.md)
     /// lands in stable rust, the returned future of f won't need to be boxed anymore, also the
@@ -497,6 +504,21 @@ impl Database {
         }
     }
 
+    /// `transact_boxed` is a version of [`Database::transact`] that accepts a closure returning a
+    /// pinned, boxed future.
+    ///
+    /// # Warning: Hanging on Network/DNS failures
+    ///
+    /// By default, the FoundationDB C API will retry indefinitely if it cannot reach the cluster
+    /// or if DNS resolution fails. This can cause `transact_boxed` to hang forever.
+    /// To prevent this, you should set [`options::DatabaseOption::TransactionTimeout`] or
+    /// [`options::DatabaseOption::TransactionRetryLimit`] on the [`Database`] object, or
+    /// [`options::TransactionOption::Timeout`] or [`options::TransactionOption::RetryLimit`] on the transaction
+    /// itself.
+    ///
+    /// Note that `TransactOption` also provides `retry_limit` and `time_out`, but these are
+    /// Rust-side budgets that are only checked *between* retries. If the C API hangs during a call
+    /// like `commit()` or `on_error()`, these budgets will not be reached.
     pub fn transact_boxed<'trx, F, D, T, E>(
         &'trx self,
         data: D,
@@ -524,6 +546,21 @@ impl Database {
         )
     }
 
+    /// `transact_boxed_local` is a version of [`Database::transact`] that accepts a closure returning a
+    /// pinned, boxed future that is not `Send`.
+    ///
+    /// # Warning: Hanging on Network/DNS failures
+    ///
+    /// By default, the FoundationDB C API will retry indefinitely if it cannot reach the cluster
+    /// or if DNS resolution fails. This can cause `transact_boxed_local` to hang forever.
+    /// To prevent this, you should set [`options::DatabaseOption::TransactionTimeout`] or
+    /// [`options::DatabaseOption::TransactionRetryLimit`] on the [`Database`] object, or
+    /// [`options::TransactionOption::Timeout`] or [`options::TransactionOption::RetryLimit`] on the transaction
+    /// itself.
+    ///
+    /// Note that `TransactOption` also provides `retry_limit` and `time_out`, but these are
+    /// Rust-side budgets that are only checked *between* retries. If the C API hangs during a call
+    /// like `commit()` or `on_error()`, these budgets will not be reached.
     pub fn transact_boxed_local<'trx, F, D, T, E>(
         &'trx self,
         data: D,
@@ -561,6 +598,15 @@ impl Database {
     /// It might retry indefinitely if the transaction is highly contentious. It is recommended to
     /// set [`options::TransactionOption::RetryLimit`] or [`options::TransactionOption::Timeout`] on the transaction
     /// if the task needs to be guaranteed to finish. These options can be safely set on every iteration of the closure.
+    ///
+    /// # Warning: Hanging on Network/DNS failures
+    ///
+    /// By default, the FoundationDB C API will retry indefinitely if it cannot reach the cluster
+    /// or if DNS resolution fails. This can cause `run` to hang forever.
+    /// To prevent this, you should set [`options::DatabaseOption::TransactionTimeout`] or
+    /// [`options::DatabaseOption::TransactionRetryLimit`] on the [`Database`] object, or
+    /// [`options::TransactionOption::Timeout`] or [`options::TransactionOption::RetryLimit`] on the transaction
+    /// itself.
     ///
     /// # Warning: Maybe committed transactions
     ///

--- a/foundationdb/src/directory/mod.rs
+++ b/foundationdb/src/directory/mod.rs
@@ -76,6 +76,16 @@ pub use error::DirectoryError;
 use std::cmp::Ordering;
 
 /// `Directory` represents a subspace of keys in a FoundationDB database, identified by a hierarchical path.
+///
+/// # Warning: Hanging on Network/DNS failures
+///
+/// Directory operations are transactional and rely on the [`Transaction`] passed to them.
+/// By default, the FoundationDB C API will retry indefinitely if it cannot reach the cluster
+/// or if DNS resolution fails. This can cause directory operations to hang forever.
+/// To prevent this, you should set [`crate::options::DatabaseOption::TransactionTimeout`] or
+/// [`crate::options::DatabaseOption::TransactionRetryLimit`] on the [`crate::Database`] object, or
+/// [`crate::options::TransactionOption::Timeout`] or [`crate::options::TransactionOption::RetryLimit`] on the transaction
+/// itself.
 #[async_trait]
 pub trait Directory {
     /// Creates or opens the subdirectory of this Directory located at path (creating parent directories, if necessary).


### PR DESCRIPTION
Issue #449 identified a common footgun: operations can appear to “hang forever” under connectivity/DNS failures unless C-level timeout/retry controls are set. This PR focuses on docs + example parity with recommended FDB usage, without changing core Database::transact semantics.

Specifically, this PR:
1. Addresses the timeout footgun: Updates the rustdocs for transact, run, and directory operations to explicitly warn users about the C API's default infinite-retry behavior. It also updates the examples to explicitly demonstrate how to set TransactionTimeout and TransactionRetryLimit on the Database object to prevent hangs.
2. Modernizes Examples: Migrates the remaining Rust examples from using manual create_trx() to the recommended, closure-based Database::run() API, handling retry logic idiomatically.


