### PR TITLE
Fix and run version mapping tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
         run: cargo test -p foundationdb --features num-bigint,embedded-fdb-include,tenant-experimental,fdb-7_4,trace
       - name: Run all tests of foundationdb-tuple
         run: cargo test -p foundationdb-tuple --all-features
+      - name: Run all tests of foundationdb-macros
+        run: cargo test -p foundationdb-macros
 
   lint:
     name: Rustfmt / Clippy

--- a/foundationdb-macros/src/lib.rs
+++ b/foundationdb-macros/src/lib.rs
@@ -173,7 +173,7 @@ mod tests {
         let data = quote!(
             feature = "fdb-7_0",
             feature = "fdb-7_1",
-            feature = "fdb-7_3"
+            feature = "fdb-7_3",
             feature = "fdb-7_4"
         );
 
@@ -224,7 +224,7 @@ mod tests {
             feature = "fdb-6_3",
             feature = "fdb-7_0",
             feature = "fdb-7_1",
-            feature = "fdb-7_3"
+            feature = "fdb-7_3",
             feature = "fdb-7_4"
         );
 


### PR DESCRIPTION
The tests were previously disabled due to a missing comma, this PR adds the missing comma and reenables the tests