### PR TITLE
fix(examples): use get_ranges_keyvalues for complete range reads (fix…

### DIFF
--- a/foundationdb/examples/blob-with-manifest.rs
+++ b/foundationdb/examples/blob-with-manifest.rs
@@ -1,6 +1,7 @@
 use bytesize::ByteSize;
 use foundationdb::tuple::{pack, unpack, PackError, Subspace};
 use foundationdb::{Database, RangeOption};
+use futures::TryStreamExt;
 use sha2::{Digest, Sha256};
 use std::fmt::{Display, Formatter};
 use std::fs::File;
@@ -223,20 +224,13 @@ async fn read_blob(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
 
     let range = RangeOption::from(subspace.range());
 
-    let get_result = transaction.get_range(&range, 1_024, false).await;
-
-    if let Ok(results) = get_result {
-        let mut data: Vec<u8> = vec![];
-
-        for result in results {
-            let value = result.value();
-            data.extend(value.iter());
-        }
-
-        return Some(data);
+    let mut data: Vec<u8> = vec![];
+    let mut stream = transaction.get_ranges_keyvalues(range, false);
+    while let Some(result) = stream.try_next().await.expect("Unable to read blob") {
+        data.extend(result.value().iter());
     }
 
-    None
+    Some(data)
 }
 
 struct FileManifest {

--- a/foundationdb/examples/blob.rs
+++ b/foundationdb/examples/blob.rs
@@ -1,5 +1,6 @@
 use foundationdb::tuple::Subspace;
 use foundationdb::{Database, RangeOption};
+use futures::TryStreamExt;
 use rand::distr::Uniform;
 use rand::Rng;
 
@@ -39,19 +40,13 @@ async fn read_blob(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
 
     let range = RangeOption::from(subspace.range());
 
-    let get_result = transaction.get_range(&range, 1_024, false).await;
-
-    if let Ok(results) = get_result {
-        let mut data: Vec<u8> = vec![];
-
-        for result in results {
-            let value = result.value();
-            data.extend(value.iter());
-        }
-
-        return Some(data);
+    let mut data: Vec<u8> = vec![];
+    let mut stream = transaction.get_ranges_keyvalues(range, false);
+    while let Some(result) = stream.try_next().await.expect("Unable to read blob") {
+        data.extend(result.value().iter());
     }
-    None
+
+    Some(data)
 }
 
 async fn test_blob_storing(db: &Database, subspace: &Subspace, iteration: usize) {

--- a/foundationdb/examples/class-scheduling.rs
+++ b/foundationdb/examples/class-scheduling.rs
@@ -109,13 +109,9 @@ async fn get_available_classes(db: &Database) -> Vec<String> {
 
     let range = RangeOption::from(&Subspace::from("class"));
 
-    let got_range = trx
-        .get_range(&range, 1_024, false)
-        .await
-        .expect("failed to get classes");
     let mut available_classes = Vec::<String>::new();
-
-    for key_value in got_range.iter() {
+    let mut stream = trx.get_ranges_keyvalues(range, false);
+    while let Some(key_value) = stream.try_next().await.expect("failed to get classes") {
         let count: i64 = unpack(key_value.value()).expect("failed to decode count");
 
         if count > 0 {
@@ -189,13 +185,12 @@ async fn signup_trx(trx: &Transaction, student: &str, class: &str) -> Result<()>
     }
 
     let attends_range = RangeOption::from(&("attends", &student).into());
-    if trx
-        .get_range(&attends_range, 1_024, false)
+    let attends: Vec<_> = trx
+        .get_ranges_keyvalues(attends_range, false)
+        .try_collect()
         .await
-        .expect("get_range failed")
-        .len()
-        >= 5
-    {
+        .expect("get_ranges_keyvalues failed");
+    if attends.len() >= 5 {
         return Err(Error::TooManyClasses);
     }
 
@@ -346,14 +341,12 @@ async fn run_sim(db: &Database, students: usize, ops_per_student: usize) {
 
         let student_id = format!("s{id}");
         let attends_range = RangeOption::from(&("attends", &student_id).into());
-
-        for key_value in db
-            .create_trx()
-            .unwrap()
-            .get_range(&attends_range, 1_024, false)
+        let trx = db.create_trx().unwrap();
+        let mut stream = trx.get_ranges_keyvalues(attends_range, false);
+        while let Some(key_value) = stream
+            .try_next()
             .await
-            .expect("get_range failed")
-            .iter()
+            .expect("get_ranges_keyvalues failed")
         {
             let (_, s, class) = unpack::<(String, String, String)>(key_value.key()).unwrap();
             assert_eq!(student_id, s);

--- a/foundationdb/examples/simple-index.rs
+++ b/foundationdb/examples/simple-index.rs
@@ -1,5 +1,6 @@
 use foundationdb::tuple::{unpack, Subspace, TuplePack};
 use foundationdb::{Database, FdbResult, RangeOption, Transaction};
+use futures::TryStreamExt;
 use std::fmt::{Display, Formatter};
 
 #[derive(Default)]
@@ -87,28 +88,21 @@ async fn search_user_by_zipcode(
 
     let range = RangeOption::from((begin, end));
 
-    let result_get_index = &transaction.get_range(&range, 1, false).await;
-
     let mut users = vec![];
+    let mut stream = transaction.get_ranges_keyvalues(range, false);
+    while let Some(result) = stream.try_next().await.expect("Unable to read index range") {
+        let (zipcode, id): (String, String) = zipcode_index
+            .unpack(result.key())
+            .expect("Unable to unpack value from index");
 
-    match result_get_index {
-        Ok(results) => {
-            for result in results {
-                let (zipcode, id): (String, String) = zipcode_index
-                    .unpack(result.key())
-                    .expect("Unable to unpack value from index");
+        let result_user = get_user(user_subspace, &transaction, &id, &zipcode).await;
 
-                let result_user = get_user(user_subspace, &transaction, &id, &zipcode).await;
-
-                if let Ok(user) = result_user {
-                    users.push(user);
-                }
-            }
-
-            Some(users)
+        if let Ok(user) = result_user {
+            users.push(user);
         }
-        Err(_err) => None,
     }
+
+    Some(users)
 }
 
 #[tokio::main]

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -732,6 +732,14 @@ impl Transaction {
     /// equal to the key resolved by the begin key selector and lexicographically less than the key
     /// resolved by the end key selector.
     ///
+    /// <div class="warning">
+    /// This method returns <strong>only a single batch</strong> of results, not necessarily all
+    /// key-value pairs in the range. It is a low-level primitive for manual pagination. Most
+    /// callers should use
+    /// <a href="struct.Transaction.html#method.get_ranges_keyvalues"><code>get_ranges_keyvalues</code></a>,
+    /// which automatically pages through the full range and yields every key-value pair as a stream.
+    /// </div>
+    ///
     /// # Arguments
     ///
     /// * `opt`: the range, limit, target_bytes and mode


### PR DESCRIPTION
…es #72)