### PR TITLE
fix(examples): use get_ranges_keyvalues for complete range reads

### DIFF
--- a/foundationdb/examples/blob-with-manifest.rs
+++ b/foundationdb/examples/blob-with-manifest.rs
@@ -1,6 +1,7 @@
 use bytesize::ByteSize;
 use foundationdb::tuple::{pack, unpack, PackError, Subspace};
 use foundationdb::{Database, RangeOption};
+use futures::TryStreamExt;
 use sha2::{Digest, Sha256};
 use std::fmt::{Display, Formatter};
 use std::fs::File;
@@ -216,13 +217,10 @@ async fn read_data(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
 async fn read_blob(db: &Database, subspace: &Subspace) -> Vec<u8> {
     db.run(|transaction, _| async move {
         let range = RangeOption::from(subspace.range());
-        let results = transaction.get_range(&range, 1_024, false).await?;
-
         let mut data: Vec<u8> = vec![];
-
-        for result in results {
-            let value = result.value();
-            data.extend(value.iter());
+        let mut stream = transaction.get_ranges_keyvalues(range, false);
+        while let Some(result) = stream.try_next().await? {
+            data.extend(result.value().iter());
         }
 
         Ok(data)

--- a/foundationdb/examples/blob.rs
+++ b/foundationdb/examples/blob.rs
@@ -1,5 +1,6 @@
 use foundationdb::tuple::Subspace;
 use foundationdb::{Database, RangeOption};
+use futures::TryStreamExt;
 use rand::distr::Uniform;
 use rand::Rng;
 
@@ -36,13 +37,10 @@ async fn read_blob(db: &Database, subspace: &Subspace) -> Vec<u8> {
     db.run(|trx, _maybe_committed| async move {
         let range = RangeOption::from(subspace.range());
 
-        let results = trx.get_range(&range, 1_024, false).await?;
-
         let mut data: Vec<u8> = vec![];
-
-        for result in results {
-            let value = result.value();
-            data.extend(value.iter());
+        let mut stream = trx.get_ranges_keyvalues(range, false);
+        while let Some(result) = stream.try_next().await? {
+            data.extend(result.value().iter());
         }
 
         Ok(data)

--- a/foundationdb/examples/class-scheduling.rs
+++ b/foundationdb/examples/class-scheduling.rs
@@ -20,6 +20,7 @@ use rand::prelude::IndexedRandom;
 use foundationdb as fdb;
 use foundationdb::tuple::{pack, unpack, Subspace};
 use foundationdb::{Database, FdbBindingError, FdbResult, RangeOption, Transaction};
+use futures::TryStreamExt;
 
 type Result<T> = std::result::Result<T, FdbBindingError>;
 
@@ -112,10 +113,9 @@ async fn get_available_classes(db: &Database) -> Vec<String> {
     db.run(|trx, _maybe_committed| async move {
         let range = RangeOption::from(&Subspace::from("class"));
 
-        let got_range = trx.get_range(&range, 1_024, false).await?;
         let mut available_classes = Vec::<String>::new();
-
-        for key_value in got_range.iter() {
+        let mut stream = trx.get_ranges_keyvalues(range, false);
+        while let Some(key_value) = stream.try_next().await? {
             let count: i64 = unpack(key_value.value()).expect("failed to decode count");
 
             if count > 0 {
@@ -184,7 +184,11 @@ async fn signup_trx(trx: &Transaction, student: &str, class: &str) -> Result<()>
     }
 
     let attends_range = RangeOption::from(&("attends", &student).into());
-    if trx.get_range(&attends_range, 1_024, false).await?.len() >= 5 {
+    let attends: Vec<_> = trx
+        .get_ranges_keyvalues(attends_range, false)
+        .try_collect()
+        .await?;
+    if attends.len() >= 5 {
         return Err(Error::TooManyClasses.into());
     }
 
@@ -330,16 +334,14 @@ async fn run_sim(db: &Database, students: usize, ops_per_student: usize) {
         thread.join().expect("failed to join thread");
 
         let student_id = format!("s{id}");
-
         let student_id_clone = student_id.clone();
 
         db.run(move |trx, _maybe_committed| {
             let student_id_inner = student_id_clone.clone();
             async move {
                 let attends_range = RangeOption::from(&("attends", &student_id_inner).into());
-                let range = trx.get_range(&attends_range, 1_024, false).await?;
-
-                for key_value in range.iter() {
+                let mut stream = trx.get_ranges_keyvalues(attends_range, false);
+                while let Some(key_value) = stream.try_next().await? {
                     let (_, s, class) =
                         unpack::<(String, String, String)>(key_value.key()).unwrap();
                     assert_eq!(student_id_inner, s);
@@ -350,7 +352,7 @@ async fn run_sim(db: &Database, students: usize, ops_per_student: usize) {
             }
         })
         .await
-        .expect("get_range failed");
+        .expect("get_ranges_keyvalues failed");
     }
 
     println!("Ran {} transactions", students * ops_per_student);

--- a/foundationdb/examples/simple-index.rs
+++ b/foundationdb/examples/simple-index.rs
@@ -1,5 +1,6 @@
 use foundationdb::tuple::{unpack, Subspace, TuplePack};
 use foundationdb::{Database, FdbBindingError, FdbResult, RangeOption, Transaction};
+use futures::TryStreamExt;
 use std::fmt::{Display, Formatter};
 
 #[derive(Default)]
@@ -84,11 +85,9 @@ async fn search_user_by_zipcode(
 
         let range = RangeOption::from((begin, end));
 
-        let results = trx.get_range(&range, 1, false).await?;
-
         let mut users = vec![];
-
-        for result in results {
+        let mut stream = trx.get_ranges_keyvalues(range, false);
+        while let Some(result) = stream.try_next().await? {
             let (zipcode, id): (String, String) = zipcode_index
                 .unpack(result.key())
                 .expect("Unable to unpack value from index");

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -732,6 +732,14 @@ impl Transaction {
     /// equal to the key resolved by the begin key selector and lexicographically less than the key
     /// resolved by the end key selector.
     ///
+    /// <div class="warning">
+    /// This method returns <strong>only a single batch</strong> of results, not necessarily all
+    /// key-value pairs in the range. It is a low-level primitive for manual pagination. Most
+    /// callers should use
+    /// <a href="struct.Transaction.html#method.get_ranges_keyvalues"><code>get_ranges_keyvalues</code></a>,
+    /// which automatically pages through the full range and yields every key-value pair as a stream.
+    /// </div>
+    ///
     /// # Arguments
     ///
     /// * `opt`: the range, limit, target_bytes and mode


### PR DESCRIPTION
Fixes #72 