### PR TITLE
build(deps): bump dependencies and migrate to rand 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,12 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +215,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,12 +345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,12 +359,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foundationdb"
@@ -552,27 +545,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
- "wasip3",
+ "rand_core",
 ]
 
 [[package]]
@@ -582,51 +562,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
-]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -691,12 +632,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -856,15 +791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,38 +842,26 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1004,12 +918,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1278,12 +1186,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,7 +1197,7 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1311,24 +1213,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1376,40 +1260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,100 +1275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "xml"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,26 +1287,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3a56132a0d6ecbe77352edc10232f788fc4ceefefff4cab784a98e0e16b6b51"
 dependencies = [
  "xml",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/foundationdb-bindingtester/Cargo.toml
+++ b/foundationdb-bindingtester/Cargo.toml
@@ -27,6 +27,6 @@ env_logger = "0.11.10"
 foundationdb = { path = "../foundationdb", features = ["uuid", "num-bigint", "fdb-7_4", "embedded-fdb-include", "tenant-experimental"], default-features = false }
 foundationdb-sys = { version = "0.10.0", path = "../foundationdb-sys", features = ["embedded-fdb-include", "fdb-7_4"], default-features = false }
 futures = "0.3.32"
-log = "0.4.30"
+log = "0.4.33"
 num-bigint = "0.4.6"
 async-trait = "0.1.89"

--- a/foundationdb-macros/Cargo.toml
+++ b/foundationdb-macros/Cargo.toml
@@ -22,7 +22,7 @@ keywords = ["foundationdb", "proc-macro"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.117", features = ["full"] }
+syn = { version = "2.0.118", features = ["full"] }
 proc-macro2 = "1.0.106"
 try_map = "0.3.1"
-quote = "1.0.45"
+quote = "1.0.46"

--- a/foundationdb-profiling/Cargo.toml
+++ b/foundationdb-profiling/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 async-stream = "0.3.6"
 async-trait = "0.1.89"
 foundationdb = { version = "0.10.0", path = "../foundationdb", default-features = false, features = ["fdb-7_4"] }
-futures-util = "0.3.31"
+futures-util = "0.3.32"
 thiserror = "2.0.18"
 
 [dev-dependencies]

--- a/foundationdb-simulation/Cargo.toml
+++ b/foundationdb-simulation/Cargo.toml
@@ -23,11 +23,11 @@ foundationdb = { version = "0.10.0", path = "../foundationdb", default-features 
 foundationdb-sys = { version = "0.10.0", path = "../foundationdb-sys", default-features = false }
 
 [build-dependencies]
-cc = "1.2.62"
+cc = "1.2.65"
 bindgen = "0.72.1"
 
 [dev-dependencies]
-futures-util = "0.3.31"
+futures-util = "0.3.32"
 
 [features]
 default = ["embedded-fdb-include"]

--- a/foundationdb-tuple/Cargo.toml
+++ b/foundationdb-tuple/Cargo.toml
@@ -31,6 +31,6 @@ codecov = { repository = "foundationdb-rs/foundationdb-rs", branch = "main", ser
 default = ["uuid"]
 
 [dependencies]
-memchr = "2.8.0"
-uuid = { version = "1.23.1", optional = true }
+memchr = "2.8.2"
+uuid = { version = "1.23.3", optional = true }
 num-bigint = { version = "0.4.6", optional = true }

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -60,9 +60,9 @@ foundationdb-sys = { version = "0.10.0", path = "../foundationdb-sys", default-f
 foundationdb-macros = { version = "0.3.3", path = "../foundationdb-macros" }
 foundationdb-tuple = { version = "0.10.0", path = "../foundationdb-tuple" }
 futures = "0.3.32"
-rand = { version = "0.9.4", features = ["default", "small_rng"] }
+rand = { version = "0.10.1", features = ["default"] }
 static_assertions = "1.1.0"
-uuid = { version = "1.23.1", optional = true }
+uuid = { version = "1.23.3", optional = true }
 num-bigint = { version = "0.4.6", optional = true }
 async-trait = "0.1.89"
 async-recursion = "1.1.1"
@@ -78,7 +78,7 @@ lazy_static = "1.5.0"
 tokio = { version = "1.52.3", features = ["full"] }
 sha2 = "0.11.0"
 data-encoding = "2.11.0"
-bytesize = "2.3"
-uuid = { version = "1.23.1", features = ["v4"] }
-futures-util = "0.3.31"
+bytesize = "2.4"
+uuid = { version = "1.23.3", features = ["v4"] }
+futures-util = "0.3.32"
 tracing-subscriber = "0.3.23"

--- a/foundationdb/examples/blob.rs
+++ b/foundationdb/examples/blob.rs
@@ -2,7 +2,7 @@ use foundationdb::tuple::Subspace;
 use foundationdb::{Database, RangeOption};
 use futures::TryStreamExt;
 use rand::distr::Uniform;
-use rand::Rng;
+use rand::RngExt;
 
 /// The goal of this example is to store blob data as chunk of 1kB
 /// Retrieve these data then verify correctness

--- a/foundationdb/examples/micro-queue.rs
+++ b/foundationdb/examples/micro-queue.rs
@@ -3,7 +3,7 @@ use std::error;
 
 use foundationdb::{future::FdbValue, tuple::Subspace, Database, FdbBindingError, RangeOption};
 use futures::StreamExt;
-use rand::{rngs::SmallRng, RngCore, SeedableRng};
+use rand::{rngs::SmallRng, Rng};
 
 /// Clears subspaces of a database.
 ///
@@ -54,7 +54,7 @@ impl MicroQueue {
         Ok(Self {
             db,
             queue,
-            rng: SmallRng::from_os_rng(),
+            rng: rand::make_rng(),
         })
     }
 

--- a/foundationdb/src/tuple_ext/hca.rs
+++ b/foundationdb/src/tuple_ext/hca.rs
@@ -28,7 +28,7 @@ use std::fmt;
 use std::sync::{Mutex, PoisonError};
 
 use futures::future;
-use rand::{self, rngs::SmallRng, Rng, SeedableRng};
+use rand::{rngs::SmallRng, RngExt};
 
 use crate::options::{ConflictRangeType, MutationType, TransactionOption};
 use crate::tuple::{PackError, Subspace};
@@ -114,7 +114,7 @@ impl HighContentionAllocator {
             reverse: true,
             ..RangeOption::default()
         };
-        let mut rng = SmallRng::from_rng(&mut rand::rng());
+        let mut rng: SmallRng = rand::make_rng();
 
         loop {
             let kvs = trx.get_range(&counters_range, 1, true).await?;

--- a/foundationdb/tests/common/mod.rs
+++ b/foundationdb/tests/common/mod.rs
@@ -1,6 +1,6 @@
 use foundationdb as fdb;
 use rand::distr::Alphanumeric;
-use rand::Rng;
+use rand::RngExt;
 
 /// generate random string. Foundationdb watch only fires when value changed, so updating with same
 /// value twice will not fire watches. To make examples work over multiple run, we use random


### PR DESCRIPTION
## Summary

Bumps workspace dependencies and migrates `foundationdb` to `rand 0.10`.

Routine patch/minor bumps: `syn 2.0.118`, `quote 1.0.46`, `futures-util 0.3.32`, `cc 1.2.65`, `memchr 2.8.2`, `log 0.4.33`, `uuid 1.23.3`, `bytesize 2.4`.

`rand 0.9 -> 0.10` is a breaking release and needed a code migration:

| Old (0.9) | New (0.10) |
|---|---|
| `rand::Rng` (ext trait: `random_range`, `sample_iter`) | `rand::RngExt` |
| `rand::RngCore` (core: `fill_bytes`) | `rand::Rng` |
| `SmallRng::from_rng(&mut rand::rng())` | `rand::make_rng()` |
| `SmallRng::from_os_rng()` | `rand::make_rng()` |
| `small_rng` feature | removed (`SmallRng` always available) |

`make_rng::<SmallRng>()` expands internally to `SmallRng::from_rng(&mut rng())`, so the seeding behavior is unchanged. `rand` is an internal implementation detail (HCA, tests, examples), not part of the public API, so this is not a breaking change for consumers.

## Files touched

- `foundationdb/Cargo.toml`: `rand = "0.10.1"`, drop `small_rng` feature
- `foundationdb/src/tuple_ext/hca.rs`: `RngExt`, `make_rng()`
- `foundationdb/tests/common/mod.rs`, `foundationdb/examples/blob.rs`: `Rng` -> `RngExt`
- `foundationdb/examples/micro-queue.rs`: `RngCore` -> `Rng`, `from_os_rng()` -> `make_rng()`

## Verification

- `cargo check -p foundationdb --features embedded-fdb-include,fdb-7_4 --all-targets`: compiles (lib, tests, examples, benches)
- `cargo clippy ... --all-targets`: no new warnings from the change
- `cargo fmt`: clean

Integration tests were not run (they require a live FDB cluster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
