### PR TITLE
feat: migrate workspace to Rust 2024 edition (#255)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,3 +8,7 @@ test-fdb-latest = "test -p foundationdb --features embedded-fdb-include,fdb-7_4"
 check-fdb-latest = "check -p foundationdb --features embedded-fdb-include,fdb-7_4"
 clippy-fdb-latest = "clippy -p foundationdb --features embedded-fdb-include,fdb-7_4"
 doc-fdb-latest = "doc -p foundationdb --features embedded-fdb-include,fdb-7_4"
+
+# Lint the whole workspace (all targets and features) and deny warnings.
+# Used by CI; run it before pushing.
+clippy-all = "clippy --all-targets --no-default-features --features num-bigint,embedded-fdb-include,tenant-experimental,fdb-7_4,trace -- -D warnings"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --features num-bigint,embedded-fdb-include,tenant-experimental,fdb-7_4,trace --no-default-features
+        run: cargo clippy-all
 
   audit:
     name: Cargo audit

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776149305,
-        "narHash": "sha256-YsTJK5jRk6oPZvnz3te6QbvSHf7oNadubVMXYjKEwoQ=",
+        "lastModified": 1782312007,
+        "narHash": "sha256-DFr5o8fjyldBE0T3kgyeFVCBnZ/LD0OAEVycFeC0kJ0=",
         "owner": "foundationdb-rs",
         "repo": "overlay",
-        "rev": "1b19055b3d7d91c7bdeb4100bf0409ccfcefd856",
+        "rev": "d25f5f89b413efa1b04c0966623042f830409960",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1782175435,
+        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776136407,
-        "narHash": "sha256-Cp8XrVLGruSDBTRs8L4LmvaEcd76tHHU9esLk7Ysa4E=",
+        "lastModified": 1782271078,
+        "narHash": "sha256-Ukpyd+syDTr+ky+nI+SbUnWySfiqNRzA3gzFZYWepeg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "753568957a87312ed599cba5699e67126eded6c0",
+        "rev": "b7286019daa89e4e192c8913c3ec7002976034d0",
         "type": "github"
       },
       "original": {

--- a/foundationdb-bindingtester/Cargo.toml
+++ b/foundationdb-bindingtester/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Vincent Rouillé <vincent@clikengo.com>",
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
-edition = "2021"
+edition = "2024"
 rust-version = "1.85.1"
 publish = false
 

--- a/foundationdb-bindingtester/src/main.rs
+++ b/foundationdb-bindingtester/src/main.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::thread;
 
 use fdb::options::{ConflictRangeType, DatabaseOption, TransactionOption};
-use fdb::tuple::{pack, pack_into, unpack, Bytes, Element, Subspace, TuplePack};
+use fdb::tuple::{Bytes, Element, Subspace, TuplePack, pack, pack_into, unpack};
 use fdb::*;
 use futures::future;
 use futures::prelude::*;
@@ -1771,32 +1771,36 @@ impl StackMachine {
                 let node_subspace = self.directory_stack.get(index_node_subspace);
                 let content_subspace = self.directory_stack.get(index_content_subspace);
 
-                if node_subspace.is_none() || content_subspace.is_none() {
-                    error!(
-                        "pushing null on the directory list: {}, {}",
-                        node_subspace.is_some(),
-                        content_subspace.is_some()
-                    );
-                    self.directory_stack.push(DirectoryStackItem::Null);
-                } else {
-                    let node_subspace = match node_subspace.unwrap() {
-                        DirectoryStackItem::Subspace(s) => s.to_owned(),
-                        _ => panic!("expecting subspace"),
-                    };
+                match (node_subspace, content_subspace) {
+                    (Some(node_subspace), Some(content_subspace)) => {
+                        let node_subspace = match node_subspace {
+                            DirectoryStackItem::Subspace(s) => s.to_owned(),
+                            _ => panic!("expecting subspace"),
+                        };
 
-                    let content_subspace = match content_subspace.unwrap() {
-                        DirectoryStackItem::Subspace(s) => s.to_owned(),
-                        _ => panic!("expecting subspace"),
-                    };
+                        let content_subspace = match content_subspace {
+                            DirectoryStackItem::Subspace(s) => s.to_owned(),
+                            _ => panic!("expecting subspace"),
+                        };
 
-                    debug!("pushed a directory at index {}", self.directory_stack.len());
+                        debug!("pushed a directory at index {}", self.directory_stack.len());
 
-                    self.directory_stack
-                        .push(DirectoryStackItem::Directory(DirectoryLayer::new(
-                            node_subspace,
-                            content_subspace,
-                            allow_manual_prefixes,
-                        )));
+                        self.directory_stack.push(DirectoryStackItem::Directory(
+                            DirectoryLayer::new(
+                                node_subspace,
+                                content_subspace,
+                                allow_manual_prefixes,
+                            ),
+                        ));
+                    }
+                    (node_subspace, content_subspace) => {
+                        error!(
+                            "pushing null on the directory list: {}, {}",
+                            node_subspace.is_some(),
+                            content_subspace.is_some()
+                        );
+                        self.directory_stack.push(DirectoryStackItem::Null);
+                    }
                 }
             }
 

--- a/foundationdb-gen/Cargo.toml
+++ b/foundationdb-gen/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Vincent Rouillé <vincent@clikengo.com>",
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
-edition = "2021"
+edition = "2024"
 rust-version = "1.85.1"
 
 description = """

--- a/foundationdb-gen/src/lib.rs
+++ b/foundationdb-gen/src/lib.rs
@@ -89,7 +89,7 @@ impl FdbScope {
             "{TAB1}pub unsafe fn apply(&self{first_arg}) -> FdbResult<()> {{"
         )?;
         writeln!(w, "{TAB2}let code = self.code();")?;
-        writeln!(w, "{TAB2}let err = match *self {{")?;
+        writeln!(w, "{TAB2}let err = unsafe {{ match *self {{")?;
 
         let args = if first_arg.is_empty() {
             "code"
@@ -133,7 +133,7 @@ impl FdbScope {
             }
         }
 
-        writeln!(w, "{TAB2}}};")?;
+        writeln!(w, "{TAB2}}} }};")?;
         writeln!(
             w,
             "{TAB2}if err != 0 {{ Err(FdbError::from_code(err)) }} else {{ Ok(()) }}",

--- a/foundationdb-gen/src/lib.rs
+++ b/foundationdb-gen/src/lib.rs
@@ -322,10 +322,8 @@ where
                     options.push(option);
                 }
             }
-            XmlEvent::EndElement { name, .. } => {
-                if name.local_name == "Scope" {
-                    return options;
-                }
+            XmlEvent::EndElement { name, .. } if name.local_name == "Scope" => {
+                return options;
             }
             _ => {}
         }

--- a/foundationdb-macros/Cargo.toml
+++ b/foundationdb-macros/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.3"
 authors = [
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
-edition = "2021"
+edition = "2024"
 rust-version = "1.85.1"
 
 description = """

--- a/foundationdb-profiling/Cargo.toml
+++ b/foundationdb-profiling/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Pierre Zemb <contact@pierrezemb.fr>",
     "Yannick Guern <dev@guern.eu>"
 ]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 async-stream = "0.3.6"

--- a/foundationdb-profiling/src/parse.rs
+++ b/foundationdb-profiling/src/parse.rs
@@ -42,7 +42,7 @@ pub trait Parse: Sized {
 /// If the `Scanner` does not have enough remaining bytes to extract `$size` bytes,
 /// the implementation will panic or exhibit undefined behavior due to bounds violations.
 macro_rules! impl_parse {
-    ($x: ty, $type: ident, $size: expr) => {
+    ($x: ty, $type: ident, $size: expr_2021) => {
         #[async_trait::async_trait]
         impl Parse for $x {
             async fn parse(

--- a/foundationdb-profiling/src/parsed_key.rs
+++ b/foundationdb-profiling/src/parsed_key.rs
@@ -1,6 +1,6 @@
+use crate::PROFILE_PREFIX;
 use crate::parse::Parse;
 use crate::scanner::Scanner;
-use crate::PROFILE_PREFIX;
 use foundationdb::tuple::{Bytes, Versionstamp};
 use futures_util::AsyncReadExt;
 use std::error::Error;

--- a/foundationdb-recipes-simulation/Cargo.toml
+++ b/foundationdb-recipes-simulation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "foundationdb-recipes-simulation"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Simulation workloads for FoundationDB recipes"
 license = "MIT OR Apache-2.0"

--- a/foundationdb-recipes-simulation/src/leader_election/helpers.rs
+++ b/foundationdb-recipes-simulation/src/leader_election/helpers.rs
@@ -3,13 +3,13 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use foundationdb_simulation::{details, Severity};
+use foundationdb_simulation::{Severity, details};
 
-use super::types::{
-    ClientStats, DatabaseSnapshot, LogEntries, OpType, DEFAULT_CLOCK_JITTER_OFFSET,
-    DEFAULT_CLOCK_JITTER_RANGE,
-};
 use super::LeaderElectionWorkload;
+use super::types::{
+    ClientStats, DEFAULT_CLOCK_JITTER_OFFSET, DEFAULT_CLOCK_JITTER_RANGE, DatabaseSnapshot,
+    LogEntries, OpType,
+};
 
 impl LeaderElectionWorkload {
     // ========================================================================

--- a/foundationdb-recipes-simulation/src/leader_election/helpers.rs
+++ b/foundationdb-recipes-simulation/src/leader_election/helpers.rs
@@ -288,11 +288,10 @@ impl LeaderElectionWorkload {
                         client_stats.error_count += 1;
                     }
                 }
-                Some(OpType::Resign) => {
-                    if entry.success {
-                        client_stats.resign_count += 1;
-                    }
+                Some(OpType::Resign) if entry.success => {
+                    client_stats.resign_count += 1;
                 }
+                Some(OpType::Resign) => {}
                 None => {}
             }
         }

--- a/foundationdb-recipes-simulation/src/leader_election/invariants.rs
+++ b/foundationdb-recipes-simulation/src/leader_election/invariants.rs
@@ -24,10 +24,10 @@ use std::collections::BTreeMap;
 
 use foundationdb::tuple::Versionstamp;
 
+use super::LeaderElectionWorkload;
 use super::types::{
     CheckResult, DatabaseSnapshot, LogEntries, OP_REGISTER, OP_RESIGN, OP_TRY_BECOME_LEADER,
 };
-use super::LeaderElectionWorkload;
 
 impl LeaderElectionWorkload {
     /// Invariant 1: Dual-Path Validation (AtomicOps pattern)
@@ -207,13 +207,13 @@ impl LeaderElectionWorkload {
 
         for entry in entries {
             // Track last op_num per client
-            if let Some(last_op) = client_last_op.get(&entry.client_id) {
-                if entry.op_num <= *last_op {
-                    violations.push(format!(
-                        "Client {} op_num {} not greater than previous {}",
-                        entry.client_id, entry.op_num, last_op
-                    ));
-                }
+            if let Some(last_op) = client_last_op.get(&entry.client_id)
+                && entry.op_num <= *last_op
+            {
+                violations.push(format!(
+                    "Client {} op_num {} not greater than previous {}",
+                    entry.client_id, entry.op_num, last_op
+                ));
             }
             client_last_op.insert(entry.client_id, entry.op_num);
 
@@ -228,7 +228,9 @@ impl LeaderElectionWorkload {
         if violations.is_empty() {
             (
                 true,
-                format!("Leadership sequence valid ({clients_with_leadership} clients claimed leadership)"),
+                format!(
+                    "Leadership sequence valid ({clients_with_leadership} clients claimed leadership)"
+                ),
             )
         } else {
             (false, violations.join("; "))
@@ -269,14 +271,18 @@ impl LeaderElectionWorkload {
             let registered_count = registered_clients.len();
             (
                 true,
-                format!("All {leadership_count} clients with leadership have registration entries ({registered_count} total registered)"),
+                format!(
+                    "All {leadership_count} clients with leadership have registration entries ({registered_count} total registered)"
+                ),
             )
         } else {
             let unregistered_count = unregistered_leaders.len();
             let unregistered_list = unregistered_leaders.join(", ");
             (
                 false,
-                format!("VIOLATION: {unregistered_count} clients claimed leadership without registration: {unregistered_list}"),
+                format!(
+                    "VIOLATION: {unregistered_count} clients claimed leadership without registration: {unregistered_list}"
+                ),
             )
         }
     }
@@ -468,23 +474,23 @@ impl LeaderElectionWorkload {
         for entry in entries {
             if entry.op_type == OP_TRY_BECOME_LEADER && entry.success && entry.became_leader {
                 acquire_count += 1;
-                if let Some(prev_holder) = current_holder {
-                    if prev_holder != entry.client_id {
-                        // Different client claiming - previous holder's lease expired
-                        // or was preempted. This is an implicit release.
-                        implicit_releases += 1;
-                    }
+                if let Some(prev_holder) = current_holder
+                    && prev_holder != entry.client_id
+                {
+                    // Different client claiming - previous holder's lease expired
+                    // or was preempted. This is an implicit release.
+                    implicit_releases += 1;
                 }
                 // New leader takes over
                 current_holder = Some(entry.client_id);
             }
-            if entry.op_type == OP_RESIGN && entry.success {
-                if let Some(holder) = current_holder {
-                    if holder == entry.client_id {
-                        release_count += 1;
-                        current_holder = None;
-                    }
-                }
+            if entry.op_type == OP_RESIGN
+                && entry.success
+                && let Some(holder) = current_holder
+                && holder == entry.client_id
+            {
+                release_count += 1;
+                current_holder = None;
             }
         }
 
@@ -567,13 +573,13 @@ impl LeaderElectionWorkload {
                     continue; // Skip ballot 0 (initial state)
                 }
 
-                if let Some(&prev_client) = ballot_to_client.get(&entry.ballot) {
-                    if prev_client != entry.client_id {
-                        violations.push(format!(
-                            "Tenure {}: Ballot {} claimed by client {} and client {}",
-                            tenure_count, entry.ballot, prev_client, entry.client_id
-                        ));
-                    }
+                if let Some(&prev_client) = ballot_to_client.get(&entry.ballot)
+                    && prev_client != entry.client_id
+                {
+                    violations.push(format!(
+                        "Tenure {}: Ballot {} claimed by client {} and client {}",
+                        tenure_count, entry.ballot, prev_client, entry.client_id
+                    ));
                 }
                 ballot_to_client.insert(entry.ballot, entry.client_id);
             }

--- a/foundationdb-recipes-simulation/src/leader_election/workload.rs
+++ b/foundationdb-recipes-simulation/src/leader_election/workload.rs
@@ -8,18 +8,18 @@
 use std::time::Duration;
 
 use foundationdb::{
+    FdbBindingError, RangeOption,
     options::{MutationType, TransactionOption},
     recipes::leader_election::{ElectionConfig, LeaderElection},
-    tuple::{pack, unpack, Versionstamp},
-    FdbBindingError, RangeOption,
+    tuple::{Versionstamp, pack, unpack},
 };
-use foundationdb_simulation::{details, Metric, Metrics, RustWorkload, Severity, SimDatabase};
+use foundationdb_simulation::{Metric, Metrics, RustWorkload, Severity, SimDatabase, details};
 use futures::TryStreamExt;
 
+use super::LeaderElectionWorkload;
 use super::types::{
     LogEntries, LogEntry, OP_HEARTBEAT, OP_REGISTER, OP_RESIGN, OP_TRY_BECOME_LEADER,
 };
-use super::LeaderElectionWorkload;
 
 impl RustWorkload for LeaderElectionWorkload {
     async fn setup(&mut self, db: SimDatabase) {

--- a/foundationdb-simulation/Cargo.toml
+++ b/foundationdb-simulation/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Eloi DEMOLIS <eloi.demolis@clever-cloud.com>",
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
-edition = "2021"
+edition = "2024"
 description = """
 Embed Rust code within FoundationDB's simulation
 """

--- a/foundationdb-simulation/build.rs
+++ b/foundationdb-simulation/build.rs
@@ -50,7 +50,9 @@ fn display_build_warnings() {
     println!("cargo:warning=---------------------");
     println!("cargo:warning=------ Warning ------");
     println!("cargo:warning=---------------------");
-    println!("cargo:warning=Building the C++ bindings without the `fdb-docker` feature will be valid from Rust's perspective but not from C++ and FoundationDB");
+    println!(
+        "cargo:warning=Building the C++ bindings without the `fdb-docker` feature will be valid from Rust's perspective but not from C++ and FoundationDB"
+    );
     println!("cargo:warning=Please follow the instructions in the associated README");
 }
 

--- a/foundationdb-simulation/examples/atomic/lib.rs
+++ b/foundationdb-simulation/examples/atomic/lib.rs
@@ -1,11 +1,11 @@
 use foundationdb::{
+    FdbBindingError,
     options::{MutationType, TransactionOption},
     tuple::Subspace,
-    FdbBindingError,
 };
 use foundationdb_simulation::{
-    details, register_workload, Metric, Metrics, RustWorkload, Severity, SimDatabase,
-    SingleRustWorkload, WorkloadContext,
+    Metric, Metrics, RustWorkload, Severity, SimDatabase, SingleRustWorkload, WorkloadContext,
+    details, register_workload,
 };
 
 pub struct AtomicWorkload {

--- a/foundationdb-simulation/examples/noop/lib.rs
+++ b/foundationdb-simulation/examples/noop/lib.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use foundationdb_simulation::{
-    register_factory, Metric, Metrics, RustWorkload, RustWorkloadFactory, Severity, SimDatabase,
-    WorkloadContext, WrappedWorkload,
+    Metric, Metrics, RustWorkload, RustWorkloadFactory, Severity, SimDatabase, WorkloadContext,
+    WrappedWorkload, register_factory,
 };
 
 struct NoopWorkload {

--- a/foundationdb-simulation/examples/shared/lib.rs
+++ b/foundationdb-simulation/examples/shared/lib.rs
@@ -1,5 +1,5 @@
 use foundationdb_simulation::{
-    register_workload, Metrics, RustWorkload, SimDatabase, SingleRustWorkload, WorkloadContext,
+    Metrics, RustWorkload, SimDatabase, SingleRustWorkload, WorkloadContext, register_workload,
 };
 use futures_util::FutureExt;
 

--- a/foundationdb-simulation/src/bindings.rs
+++ b/foundationdb-simulation/src/bindings.rs
@@ -57,7 +57,7 @@ fn capitalize_first(s: &str) -> Option<String> {
 /// Macro that can be used to create log "details" more easily.
 #[macro_export]
 macro_rules! details {
-    ($($k:expr => $v:expr),* $(,)?) => {
+    ($($k:expr_2021 => $v:expr_2021),* $(,)?) => {
         &[
             $((
                 &$k.to_string(), &$v.to_string()
@@ -109,7 +109,7 @@ pub enum Severity {
 // Implementations
 
 macro_rules! with {
-    ($this:expr=>$method:ident($($args:expr),* $(,)?)) => {
+    ($this:expr_2021=>$method:ident($($args:expr_2021),* $(,)?)) => {
         unsafe { (*$this.vt).$method.unwrap_unchecked()($this.inner $(, $args)*) }
     };
 }
@@ -194,11 +194,7 @@ impl WorkloadContext {
         };
         let value = str_from_c(raw_value.inner);
         with! { raw_value => free() };
-        if value == null {
-            None
-        } else {
-            Some(value)
-        }
+        if value == null { None } else { Some(value) }
     }
     /// Get the client id of the workload
     pub fn client_id(&self) -> i32 {
@@ -216,7 +212,7 @@ impl WorkloadContext {
     pub fn delay(
         &self,
         duration: Duration,
-    ) -> impl std::future::Future<Output = fdb::FdbResult<()>> + Send + Sync + 'static {
+    ) -> impl std::future::Future<Output = fdb::FdbResult<()>> + Send + Sync + 'static + use<> {
         let f = with! { self.0 => delay(duration.as_secs_f64()) };
         fdb::future::FdbFuture::new(f as *mut _)
     }

--- a/foundationdb-simulation/src/fdb_rt.rs
+++ b/foundationdb-simulation/src/fdb_rt.rs
@@ -30,10 +30,10 @@ impl Task {
         let waker = unsafe { Waker::from_raw(self.clone().into_waker()) };
         let cx = &mut Context::from_waker(&waker);
         let slot = unsafe { &mut *self.f.get() };
-        if let Some(mut f) = slot.take() {
-            if f.as_mut().poll(cx).is_pending() {
-                *slot = Some(f);
-            }
+        if let Some(mut f) = slot.take()
+            && f.as_mut().poll(cx).is_pending()
+        {
+            *slot = Some(f);
         }
     }
 
@@ -74,6 +74,10 @@ pub(crate) fn fdb_spawn<F>(future: F)
 where
     F: Future<Output = ()> + 'static,
 {
+    // The simulation executor is single-threaded, but `Waker` requires the task
+    // pointer to be usable as `Send + Sync`, so we use `Arc` (not `Rc`) to uphold the
+    // `RawWaker` safety contract even though `Task` is neither `Send` nor `Sync`.
+    #[allow(clippy::arc_with_non_send_sync)]
     let task = Arc::new(Task {
         f: UnsafeCell::new(Some(Box::pin(future))),
     });

--- a/foundationdb-simulation/src/lib.rs
+++ b/foundationdb-simulation/src/lib.rs
@@ -10,8 +10,8 @@ mod bindings;
 mod fdb_rt;
 
 use bindings::{
-    FDBDatabase, FDBMetrics, FDBPromise, FDBWorkload, FDBWorkload_VT, OpaqueWorkload, Promise,
-    FDB_WORKLOAD_API_VERSION,
+    FDB_WORKLOAD_API_VERSION, FDBDatabase, FDBMetrics, FDBPromise, FDBWorkload, FDBWorkload_VT,
+    OpaqueWorkload, Promise,
 };
 pub use bindings::{Metric, Metrics, Severity, WorkloadContext};
 use fdb_rt::fdb_spawn;
@@ -105,72 +105,86 @@ pub trait SingleRustWorkload: RustWorkload {
 
 fn check_database_ref(database: SimDatabase) {
     if Arc::strong_count(&database) != 1 || Arc::weak_count(&database) != 0 {
-        eprintln!("Reference to Database kept between phases (setup/start/check). All references should be dropped.");
+        eprintln!(
+            "Reference to Database kept between phases (setup/start/check). All references should be dropped."
+        );
         std::process::exit(1);
     }
     std::mem::forget(database);
 }
 
 unsafe fn database_new(raw_database: *mut FDBDatabase) -> SimDatabase {
-    Arc::new(Database::new_from_pointer(NonNull::new_unchecked(
-        raw_database as *mut FDBDatabaseAlias,
-    )))
+    unsafe {
+        Arc::new(Database::new_from_pointer(NonNull::new_unchecked(
+            raw_database as *mut FDBDatabaseAlias,
+        )))
+    }
 }
 unsafe extern "C" fn workload_setup<W: RustWorkload + 'static>(
     raw_workload: *mut OpaqueWorkload,
     raw_database: *mut FDBDatabase,
     raw_promise: FDBPromise,
 ) {
-    let workload = &mut *(raw_workload as *mut W);
-    let database = database_new(raw_database);
-    let done = Promise::new(raw_promise);
-    fdb_spawn(async move {
-        workload.setup(database.clone()).await;
-        check_database_ref(database);
-        done.send(true);
-    });
+    unsafe {
+        let workload = &mut *(raw_workload as *mut W);
+        let database = database_new(raw_database);
+        let done = Promise::new(raw_promise);
+        fdb_spawn(async move {
+            workload.setup(database.clone()).await;
+            check_database_ref(database);
+            done.send(true);
+        });
+    }
 }
 unsafe extern "C" fn workload_start<W: RustWorkload + 'static>(
     raw_workload: *mut OpaqueWorkload,
     raw_database: *mut FDBDatabase,
     raw_promise: FDBPromise,
 ) {
-    let workload = &mut *(raw_workload as *mut W);
-    let database = database_new(raw_database);
-    let done = Promise::new(raw_promise);
-    fdb_spawn(async move {
-        workload.start(database.clone()).await;
-        check_database_ref(database);
-        done.send(true);
-    });
+    unsafe {
+        let workload = &mut *(raw_workload as *mut W);
+        let database = database_new(raw_database);
+        let done = Promise::new(raw_promise);
+        fdb_spawn(async move {
+            workload.start(database.clone()).await;
+            check_database_ref(database);
+            done.send(true);
+        });
+    }
 }
 unsafe extern "C" fn workload_check<W: RustWorkload + 'static>(
     raw_workload: *mut OpaqueWorkload,
     raw_database: *mut FDBDatabase,
     raw_promise: FDBPromise,
 ) {
-    let workload = &mut *(raw_workload as *mut W);
-    let database = database_new(raw_database);
-    let done = Promise::new(raw_promise);
-    fdb_spawn(async move {
-        workload.check(database.clone()).await;
-        check_database_ref(database);
-        done.send(true);
-    });
+    unsafe {
+        let workload = &mut *(raw_workload as *mut W);
+        let database = database_new(raw_database);
+        let done = Promise::new(raw_promise);
+        fdb_spawn(async move {
+            workload.check(database.clone()).await;
+            check_database_ref(database);
+            done.send(true);
+        });
+    }
 }
 unsafe extern "C" fn workload_get_metrics<W: RustWorkload>(
     raw_workload: *mut OpaqueWorkload,
     raw_metrics: FDBMetrics,
 ) {
-    let workload = &*(raw_workload as *mut W);
-    let out = Metrics::new(raw_metrics);
-    workload.get_metrics(out)
+    unsafe {
+        let workload = &*(raw_workload as *mut W);
+        let out = Metrics::new(raw_metrics);
+        workload.get_metrics(out)
+    }
 }
 unsafe extern "C" fn workload_get_check_timeout<W: RustWorkload>(
     raw_workload: *mut OpaqueWorkload,
 ) -> f64 {
-    let workload = &*(raw_workload as *mut W);
-    workload.get_check_timeout()
+    unsafe {
+        let workload = &*(raw_workload as *mut W);
+        workload.get_check_timeout()
+    }
 }
 unsafe extern "C" fn workload_drop<W: RustWorkload>(raw_workload: *mut OpaqueWorkload) {
     unsafe { drop(Box::from_raw(raw_workload as *mut W)) };
@@ -182,11 +196,11 @@ unsafe extern "C" fn workload_drop<W: RustWorkload>(raw_workload: *mut OpaqueWor
 #[doc(hidden)]
 /// Primitives exposed for the registrations hooks, should not be used otherwise
 pub mod internals {
-    pub use crate::bindings::{str_from_c, FDBWorkloadContext};
+    pub use crate::bindings::{FDBWorkloadContext, str_from_c};
     pub use crate::fdb_rt::poll_pending_tasks;
 
     #[cfg(feature = "cpp-abi")]
-    extern "C" {
+    unsafe extern "C" {
         pub fn workloadCppFactory(logger: *const u8) -> *const u8;
     }
 
@@ -208,7 +222,7 @@ pub mod internals {
 #[macro_export]
 macro_rules! register_factory {
     ($name:ident) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "C" fn workloadCFactory(
             raw_name: *const i8,
             raw_context: $crate::internals::FDBWorkloadContext,
@@ -232,7 +246,7 @@ macro_rules! register_factory {
             let context = $crate::WorkloadContext::new(raw_context);
             <$name as $crate::RustWorkloadFactory>::create(name, context)
         }
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "C" fn workloadFactory(logger: *const u8) -> *const u8 {
             unsafe { $crate::internals::workloadCppFactory(logger) }
         }
@@ -244,7 +258,7 @@ macro_rules! register_factory {
 #[macro_export]
 macro_rules! register_workload {
     ($name:ident) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "C" fn workloadCFactory(
             raw_name: *const i8,
             raw_context: $crate::internals::FDBWorkloadContext,
@@ -268,7 +282,7 @@ macro_rules! register_workload {
             let context = $crate::WorkloadContext::new(raw_context);
             $crate::RustWorkload::wrap(<$name as $crate::SingleRustWorkload>::new(name, context))
         }
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "C" fn workloadFactory(logger: *const u8) -> *const u8 {
             unsafe { $crate::internals::workloadCppFactory(logger) }
         }

--- a/foundationdb-sys/Cargo.toml
+++ b/foundationdb-sys/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Vincent Rouillé <vincent@clikengo.com>",
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
-edition = "2021"
+edition = "2024"
 rust-version = "1.85.1"
 
 description = """

--- a/foundationdb-tuple/Cargo.toml
+++ b/foundationdb-tuple/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Vincent Rouillé <vincent@clikengo.com>",
     "Pierre Zemb <contact@pierrezemb.fr>",
 ]
-edition = "2021"
+edition = "2024"
 rust-version = "1.85.1"
 
 description = """

--- a/foundationdb-tuple/src/element.rs
+++ b/foundationdb-tuple/src/element.rs
@@ -154,7 +154,7 @@ impl<'a> Element<'a> {
         }
     }
 
-    pub fn as_bytes(&self) -> Option<&Bytes> {
+    pub fn as_bytes(&self) -> Option<&Bytes<'_>> {
         match self {
             Element::Bytes(v) => Some(v),
             _ => None,

--- a/foundationdb-tuple/src/pack.rs
+++ b/foundationdb-tuple/src/pack.rs
@@ -179,7 +179,7 @@ fn write_bytes<W: io::Write>(w: &mut W, v: &[u8]) -> io::Result<VersionstampOffs
     Ok(VersionstampOffset::None { size })
 }
 
-fn parse_slice(input: &[u8]) -> PackResult<(&[u8], Cow<[u8]>)> {
+fn parse_slice(input: &[u8]) -> PackResult<(&[u8], Cow<'_, [u8]>)> {
     let mut bytes = Vec::new();
     let mut pos = 0;
     for idx in memchr_iter(NIL, input) {
@@ -203,7 +203,7 @@ fn parse_slice(input: &[u8]) -> PackResult<(&[u8], Cow<[u8]>)> {
     Err(PackError::MissingBytes)
 }
 
-fn parse_string(input: &[u8]) -> PackResult<(&[u8], Cow<str>)> {
+fn parse_string(input: &[u8]) -> PackResult<(&[u8], Cow<'_, str>)> {
     let (input, slice) = parse_slice(input)?;
     Ok((
         input,
@@ -314,7 +314,7 @@ macro_rules! sign_bit {
 }
 
 macro_rules! unpack_ux {
-    ($ux: ident, $input: expr, $n: expr) => {{
+    ($ux: ident, $input: expr_2021, $n: expr_2021) => {{
         let (input, bytes) = parse_bytes($input, $n)?;
         let mut arr = [0u8; ::std::mem::size_of::<$ux>()];
         (&mut arr[(::std::mem::size_of::<$ux>() - $n)..]).copy_from_slice(bytes);
@@ -323,7 +323,7 @@ macro_rules! unpack_ux {
 }
 
 macro_rules! unpack_px {
-    ($ix: ident, $ux: ident, $input: expr, $n: expr) => {{
+    ($ix: ident, $ux: ident, $input: expr_2021, $n: expr_2021) => {{
         let (input, bytes) = parse_bytes($input, $n)?;
         let mut arr = [0u8; ::std::mem::size_of::<$ux>()];
         (&mut arr[(::std::mem::size_of::<$ux>() - $n)..]).copy_from_slice(bytes);
@@ -336,7 +336,7 @@ macro_rules! unpack_px {
     }};
 }
 macro_rules! unpack_nx {
-    ($ix: ident, $ux: ident, $input: expr, $n: expr) => {{
+    ($ix: ident, $ux: ident, $input: expr_2021, $n: expr_2021) => {{
         let (input, bytes) = parse_bytes($input, $n)?;
         let mut arr = [0xffu8; ::std::mem::size_of::<$ix>()];
         (&mut arr[(::std::mem::size_of::<$ix>() - $n)..]).copy_from_slice(bytes);
@@ -353,7 +353,7 @@ macro_rules! impl_ux {
     ($ux: ident) => {
         impl_ux!($ux, mem::size_of::<$ux>());
     };
-    ($ux: ident, $max_sz:expr) => {
+    ($ux: ident, $max_sz:expr_2021) => {
         impl TuplePack for $ux {
             fn pack<W: io::Write>(
                 &self,
@@ -405,7 +405,7 @@ macro_rules! impl_ix {
     ($ix: ident, $ux: ident) => {
         impl_ix!($ix, $ux, mem::size_of::<$ix>());
     };
-    ($ix: ident, $ux: ident, $max_sz:expr) => {
+    ($ix: ident, $ux: ident, $max_sz:expr_2021) => {
         impl TuplePack for $ix {
             fn pack<W: io::Write>(
                 &self,
@@ -940,10 +940,10 @@ impl TuplePack for Element<'_> {
             Element::Int(i) => i.pack(w, tuple_depth),
             Element::Float(f) => f.pack(w, tuple_depth),
             Element::Double(f) => f.pack(w, tuple_depth),
-            Element::String(ref c) => c.pack(w, tuple_depth),
-            Element::Bytes(ref b) => b.pack(w, tuple_depth),
-            Element::Versionstamp(ref b) => b.pack(w, tuple_depth),
-            Element::Tuple(ref v) => v.pack(w, tuple_depth),
+            Element::String(c) => c.pack(w, tuple_depth),
+            Element::Bytes(b) => b.pack(w, tuple_depth),
+            Element::Versionstamp(b) => b.pack(w, tuple_depth),
+            Element::Tuple(v) => v.pack(w, tuple_depth),
             #[cfg(feature = "uuid")]
             Element::Uuid(v) => v.pack(w, tuple_depth),
             #[cfg(feature = "num-bigint")]

--- a/foundationdb-tuple/src/subspace.rs
+++ b/foundationdb-tuple/src/subspace.rs
@@ -201,9 +201,11 @@ mod tests {
         let tup_unpack: (Versionstamp, i64) = subspace.unpack(&packed).unwrap();
         assert_eq!(tup, tup_unpack);
 
-        assert!(subspace
-            .unpack::<(i64, Versionstamp, i64)>(&packed)
-            .is_err());
+        assert!(
+            subspace
+                .unpack::<(i64, Versionstamp, i64)>(&packed)
+                .is_err()
+        );
     }
 
     #[test]
@@ -213,9 +215,11 @@ mod tests {
         let packed = subspace.pack_with_versionstamp(&tup);
         let tup_unpack: (Versionstamp, i64) = subspace.unpack(&packed).unwrap();
         assert_eq!(tup, tup_unpack);
-        assert!(subspace
-            .unpack::<(Versionstamp, Versionstamp, i64)>(&packed)
-            .is_err());
+        assert!(
+            subspace
+                .unpack::<(Versionstamp, Versionstamp, i64)>(&packed)
+                .is_err()
+        );
     }
 
     #[test]

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Vincent Rouillé <vincent@clikengo.com>",
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
-edition = "2021"
+edition = "2024"
 rust-version = "1.85.1"
 
 description = """

--- a/foundationdb/examples/atomic-op-counter.rs
+++ b/foundationdb/examples/atomic-op-counter.rs
@@ -1,6 +1,6 @@
 use byteorder::ByteOrder;
 use foundationdb::tuple::Subspace;
-use foundationdb::{options, Database, FdbResult, Transaction};
+use foundationdb::{Database, FdbResult, Transaction, options};
 
 #[tokio::main]
 async fn main() {

--- a/foundationdb/examples/blob-with-manifest.rs
+++ b/foundationdb/examples/blob-with-manifest.rs
@@ -1,5 +1,5 @@
 use bytesize::ByteSize;
-use foundationdb::tuple::{pack, unpack, PackError, Subspace};
+use foundationdb::tuple::{PackError, Subspace, pack, unpack};
 use foundationdb::{Database, RangeOption};
 use futures::TryStreamExt;
 use sha2::{Digest, Sha256};
@@ -280,7 +280,9 @@ impl Display for FileManifest {
             self.name,
             self.digest,
             ByteSize(self.size as u64).display().si(),
-            ByteSize(self.chunk_size.unwrap_or(CHUNK_SIZE) as u64).display().si(),
+            ByteSize(self.chunk_size.unwrap_or(CHUNK_SIZE) as u64)
+                .display()
+                .si(),
             self.nb_chunks
         )
     }
@@ -366,7 +368,10 @@ async fn check_data_stored(db: &Database, files_subspaces: Vec<Subspace>) {
 
         println!("{manifest}");
         assert_eq!(digest_data_from_database, manifest.digest);
-        println!("\t Verify data integrity:\n\t\tfrom database hex digest : {}\n\t\treference hex digest     : {}\n", manifest.digest, digest_data_from_database);
+        println!(
+            "\t Verify data integrity:\n\t\tfrom database hex digest : {}\n\t\treference hex digest     : {}\n",
+            manifest.digest, digest_data_from_database
+        );
     }
 }
 

--- a/foundationdb/examples/blob.rs
+++ b/foundationdb/examples/blob.rs
@@ -1,8 +1,8 @@
 use foundationdb::tuple::Subspace;
 use foundationdb::{Database, RangeOption};
 use futures::TryStreamExt;
-use rand::distr::Uniform;
 use rand::RngExt;
+use rand::distr::Uniform;
 
 /// The goal of this example is to store blob data as chunk of 1kB
 /// Retrieve these data then verify correctness

--- a/foundationdb/examples/class-scheduling.rs
+++ b/foundationdb/examples/class-scheduling.rs
@@ -18,7 +18,7 @@ use rand::rngs::ThreadRng;
 use rand::prelude::IndexedRandom;
 
 use foundationdb as fdb;
-use foundationdb::tuple::{pack, unpack, Subspace};
+use foundationdb::tuple::{Subspace, pack, unpack};
 use foundationdb::{Database, FdbBindingError, FdbResult, RangeOption, Transaction};
 use futures::TryStreamExt;
 

--- a/foundationdb/examples/conflict_reporting.rs
+++ b/foundationdb/examples/conflict_reporting.rs
@@ -6,8 +6,8 @@
 
 use foundationdb::options::TransactionOption;
 use foundationdb::*;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A simple hook implementation that prints each lifecycle event.
 struct PrintHooks;

--- a/foundationdb/examples/micro-queue.rs
+++ b/foundationdb/examples/micro-queue.rs
@@ -1,9 +1,9 @@
 use core::fmt;
 use std::error;
 
-use foundationdb::{future::FdbValue, tuple::Subspace, Database, FdbBindingError, RangeOption};
+use foundationdb::{Database, FdbBindingError, RangeOption, future::FdbValue, tuple::Subspace};
 use futures::StreamExt;
-use rand::{rngs::SmallRng, Rng};
+use rand::{Rng, rngs::SmallRng};
 
 /// Clears subspaces of a database.
 ///

--- a/foundationdb/examples/multi_version.rs
+++ b/foundationdb/examples/multi_version.rs
@@ -2,7 +2,7 @@ use byteorder::ByteOrder;
 use foundationdb::api::FdbApiBuilder;
 use foundationdb::options::NetworkOption;
 use foundationdb::tuple::Subspace;
-use foundationdb::{options, Database, FdbBindingError};
+use foundationdb::{Database, FdbBindingError, options};
 
 /// This example demonstrate usage of multi_version compatibility client.
 ///

--- a/foundationdb/examples/simple-index.rs
+++ b/foundationdb/examples/simple-index.rs
@@ -1,4 +1,4 @@
-use foundationdb::tuple::{unpack, Subspace, TuplePack};
+use foundationdb::tuple::{Subspace, TuplePack, unpack};
 use foundationdb::{Database, FdbBindingError, FdbResult, RangeOption, Transaction};
 use futures::TryStreamExt;
 use std::fmt::{Display, Formatter};

--- a/foundationdb/examples/versionstamp.rs
+++ b/foundationdb/examples/versionstamp.rs
@@ -1,7 +1,6 @@
 use foundationdb::{
-    options,
-    tuple::{pack, pack_with_versionstamp, unpack, Subspace, Versionstamp},
-    Database, FdbResult, RangeOption,
+    Database, FdbResult, RangeOption, options,
+    tuple::{Subspace, Versionstamp, pack, pack_with_versionstamp, unpack},
 };
 use futures::StreamExt;
 

--- a/foundationdb/src/api.rs
+++ b/foundationdb/src/api.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 
 use crate::options::NetworkOption;
-use crate::{error, FdbResult};
+use crate::{FdbResult, error};
 use foundationdb_sys as fdb_sys;
 
 /// Returns the max api version of the underlying Fdb C API Client
@@ -205,16 +205,18 @@ impl NetworkBuilder {
     /// }
     /// ```
     pub unsafe fn boot(self) -> FdbResult<NetworkAutoStop> {
-        let (runner, cond) = self.build()?;
+        unsafe {
+            let (runner, cond) = self.build()?;
 
-        let net_thread = runner.spawn();
+            let net_thread = runner.spawn();
 
-        let network = cond.wait();
+            let network = cond.wait();
 
-        Ok(NetworkAutoStop {
-            handle: Some(net_thread),
-            network: Some(network),
-        })
+            Ok(NetworkAutoStop {
+                handle: Some(net_thread),
+                network: Some(network),
+            })
+        }
     }
 }
 
@@ -252,9 +254,11 @@ impl NetworkRunner {
     }
 
     unsafe fn spawn(self) -> thread::JoinHandle<()> {
-        thread::spawn(move || {
-            self.run().expect("failed to run network thread");
-        })
+        unsafe {
+            thread::spawn(move || {
+                self.run().expect("failed to run network thread");
+            })
+        }
     }
 }
 

--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -23,7 +23,7 @@ use foundationdb_sys as fdb_sys;
 use crate::metrics::{MetricsReport, TransactionMetrics};
 use crate::options;
 use crate::transaction::*;
-use crate::{error, FdbError, FdbResult};
+use crate::{FdbError, FdbResult, error};
 
 use crate::error::FdbBindingError;
 #[cfg_api_versions(min = 710)]
@@ -351,7 +351,8 @@ impl Database {
     /// Retrieve a client-side status information in a JSON format.
     pub fn get_client_status(
         &self,
-    ) -> impl Future<Output = FdbResult<crate::future::FdbSlice>> + Send + Sync + Unpin {
+    ) -> impl Future<Output = FdbResult<crate::future::FdbSlice>> + Send + Sync + Unpin + use<>
+    {
         crate::future::FdbFuture::new(unsafe {
             fdb_sys::fdb_database_get_client_status(self.inner.as_ptr())
         })

--- a/foundationdb/src/directory/directory_layer.rs
+++ b/foundationdb/src/directory/directory_layer.rs
@@ -278,16 +278,13 @@ impl DirectoryLayer {
 
         match layer {
             None => {}
-            Some(layer) => {
-                if !layer.is_empty() {
-                    match compare_slice(layer, &node.layer) {
-                        Ordering::Equal => {}
-                        _ => {
-                            return Err(DirectoryError::IncompatibleLayer);
-                        }
-                    }
+            Some(layer) if !layer.is_empty() => match compare_slice(layer, &node.layer) {
+                Ordering::Equal => {}
+                _ => {
+                    return Err(DirectoryError::IncompatibleLayer);
                 }
-            }
+            },
+            Some(_) => {}
         }
 
         node.get_contents()

--- a/foundationdb/src/directory/directory_layer.rs
+++ b/foundationdb/src/directory/directory_layer.rs
@@ -8,15 +8,15 @@
 
 //! The default Directory implementation.
 
+use crate::RangeOption;
 use crate::directory::directory_partition::DirectoryPartition;
 use crate::directory::directory_subspace::DirectorySubspace;
 use crate::directory::error::DirectoryError;
 use crate::directory::node::Node;
-use crate::directory::{compare_slice, strinc, Directory, DirectoryOutput};
+use crate::directory::{Directory, DirectoryOutput, compare_slice, strinc};
 use crate::future::FdbSlice;
 use crate::tuple::hca::HighContentionAllocator;
 use crate::tuple::{Element, Subspace, TuplePack};
-use crate::RangeOption;
 use crate::{FdbResult, Transaction};
 use async_recursion::async_recursion;
 use async_trait::async_trait;
@@ -482,12 +482,16 @@ impl DirectoryLayer {
                 let patch: u32 = u32::from_le_bytes(arr);
 
                 if major > MAJOR_VERSION {
-                    let msg = format!("cannot load directory with version {major}.{minor}.{patch} using directory layer {MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}");
+                    let msg = format!(
+                        "cannot load directory with version {major}.{minor}.{patch} using directory layer {MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}"
+                    );
                     return Err(DirectoryError::Version(msg));
                 }
 
                 if minor > MINOR_VERSION {
-                    let msg = format!("directory with version {major}.{minor}.{patch} is read-only when opened using directory layer {MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}");
+                    let msg = format!(
+                        "directory with version {major}.{minor}.{patch} is read-only when opened using directory layer {MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}"
+                    );
                     return Err(DirectoryError::Version(msg));
                 }
 
@@ -553,7 +557,7 @@ impl DirectoryLayer {
                         .directory_subspace
                         .directory_layer
                         .list(trx, &node.get_partition_subpath())
-                        .await
+                        .await;
                 }
             };
         }
@@ -682,7 +686,7 @@ impl DirectoryLayer {
                         .directory_subspace
                         .directory_layer
                         .remove_internal(trx, &node.get_partition_subpath(), fail_on_nonexistent)
-                        .await
+                        .await;
                 }
             }
         }

--- a/foundationdb/src/directory/directory_partition.rs
+++ b/foundationdb/src/directory/directory_partition.rs
@@ -8,12 +8,12 @@
 
 //! A resulting Subspace whose prefix is preprended to all of its descendant directories's prefixes.
 
-use crate::directory::directory_layer::{DirectoryLayer, DEFAULT_NODE_PREFIX, PARTITION_LAYER};
+use crate::Transaction;
+use crate::directory::directory_layer::{DEFAULT_NODE_PREFIX, DirectoryLayer, PARTITION_LAYER};
 use crate::directory::directory_subspace::DirectorySubspace;
 use crate::directory::error::DirectoryError;
 use crate::directory::{Directory, DirectoryOutput};
 use crate::tuple::Subspace;
-use crate::Transaction;
 use async_trait::async_trait;
 use std::ops::Deref;
 use std::sync::Arc;

--- a/foundationdb/src/directory/directory_subspace.rs
+++ b/foundationdb/src/directory/directory_subspace.rs
@@ -8,11 +8,11 @@
 
 //! The resulting Subspace generated with a Directory
 
+use crate::Transaction;
 use crate::directory::directory_layer::DirectoryLayer;
 use crate::directory::error::DirectoryError;
 use crate::directory::{Directory, DirectoryOutput};
 use crate::tuple::{PackResult, Subspace, TuplePack, TupleUnpack};
-use crate::Transaction;
 use async_trait::async_trait;
 
 /// A `DirectorySubspace` represents the contents of a directory, but it also remembers

--- a/foundationdb/src/directory/error.rs
+++ b/foundationdb/src/directory/error.rs
@@ -9,8 +9,8 @@
 //! Errors that can be thrown by Directory.
 
 use crate::error;
-use crate::tuple::hca::HcaError;
 use crate::tuple::PackError;
+use crate::tuple::hca::HcaError;
 use std::io;
 
 /// The enumeration holding all possible errors from a Directory.

--- a/foundationdb/src/directory/mod.rs
+++ b/foundationdb/src/directory/mod.rs
@@ -65,8 +65,8 @@ mod directory_subspace;
 mod error;
 mod node;
 
-use crate::tuple::{PackResult, Subspace, TuplePack, TupleUnpack};
 use crate::Transaction;
+use crate::tuple::{PackResult, Subspace, TuplePack, TupleUnpack};
 use async_trait::async_trait;
 use core::cmp;
 pub use directory_layer::DirectoryLayer;
@@ -152,7 +152,7 @@ pub trait Directory {
 
     /// List the subdirectories of this directory at a given subpath.
     async fn list(&self, trx: &Transaction, path: &[String])
-        -> Result<Vec<String>, DirectoryError>;
+    -> Result<Vec<String>, DirectoryError>;
 }
 
 pub(crate) fn compare_slice<T: Ord>(a: &[T], b: &[T]) -> cmp::Ordering {

--- a/foundationdb/src/directory/node.rs
+++ b/foundationdb/src/directory/node.rs
@@ -1,11 +1,11 @@
-use crate::directory::directory_layer::{
-    DirectoryLayer, DEFAULT_SUB_DIRS, LAYER_SUFFIX, PARTITION_LAYER,
-};
-use crate::directory::error::DirectoryError;
-use crate::directory::DirectoryOutput;
-use crate::tuple::Subspace;
 use crate::RangeOption;
 use crate::Transaction;
+use crate::directory::DirectoryOutput;
+use crate::directory::directory_layer::{
+    DEFAULT_SUB_DIRS, DirectoryLayer, LAYER_SUFFIX, PARTITION_LAYER,
+};
+use crate::directory::error::DirectoryError;
+use crate::tuple::Subspace;
 use futures::TryStreamExt;
 
 #[derive(Debug, Clone)]

--- a/foundationdb/src/error.rs
+++ b/foundationdb/src/error.rs
@@ -10,8 +10,8 @@
 
 use crate::directory::DirectoryError;
 use crate::options;
-use crate::tuple::hca::HcaError;
 use crate::tuple::PackError;
+use crate::tuple::hca::HcaError;
 use foundationdb_sys as fdb_sys;
 use std::ffi::CStr;
 use std::fmt;

--- a/foundationdb/src/future.rs
+++ b/foundationdb/src/future.rs
@@ -42,7 +42,7 @@ use foundationdb_sys as fdb_sys;
 use futures::prelude::*;
 use futures::task::{AtomicWaker, Context, Poll};
 
-use crate::{error, FdbError, FdbResult};
+use crate::{FdbError, FdbResult, error};
 
 /// An opaque type that represents a Future in the FoundationDB C API.
 pub struct FdbFutureHandle(NonNull<fdb_sys::FDBFuture>);

--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -94,10 +94,12 @@ pub use crate::transaction::*;
 /// }
 /// ```
 pub unsafe fn boot() -> api::NetworkAutoStop {
-    let network_builder = api::FdbApiBuilder::default()
-        .build()
-        .expect("foundationdb API to be initialized");
-    network_builder.boot().expect("fdb network running")
+    unsafe {
+        let network_builder = api::FdbApiBuilder::default()
+            .build()
+            .expect("foundationdb API to be initialized");
+        network_builder.boot().expect("fdb network running")
+    }
 }
 
 /// Returns the default Fdb cluster configuration file path

--- a/foundationdb/src/mapped_key_values.rs
+++ b/foundationdb/src/mapped_key_values.rs
@@ -116,12 +116,12 @@ impl FdbMappedKeyValue {
     }
 
     /// Retrieves the beginning of the range as a [`KeySelector`]
-    pub fn begin_selector(&self) -> KeySelector {
+    pub fn begin_selector(&self) -> KeySelector<'_> {
         KeySelector::new(Cow::from(self.begin_range()), false, 0)
     }
 
     /// Retrieves the end of the range as a [`KeySelector`]
-    pub fn end_selector(&self) -> KeySelector {
+    pub fn end_selector(&self) -> KeySelector<'_> {
         KeySelector::new(Cow::from(self.end_range()), false, 0)
     }
 

--- a/foundationdb/src/recipes/leader_election/algorithm.rs
+++ b/foundationdb/src/recipes/leader_election/algorithm.rs
@@ -46,9 +46,9 @@
 //! - Candidates exist independently of leadership
 
 use crate::{
-    options::MutationType,
-    tuple::{pack, pack_with_versionstamp, unpack, Subspace, Versionstamp},
     RangeOption, Transaction,
+    options::MutationType,
+    tuple::{Subspace, Versionstamp, pack, pack_with_versionstamp, unpack},
 };
 use futures::StreamExt;
 use std::ops::Deref;

--- a/foundationdb/src/recipes/leader_election/algorithm.rs
+++ b/foundationdb/src/recipes/leader_election/algorithm.rs
@@ -632,7 +632,7 @@ where
     }
 
     // Sort by versionstamp for consistent ordering
-    alive_candidates.sort_by(|a, b| a.versionstamp.cmp(&b.versionstamp));
+    alive_candidates.sort_by_key(|a| a.versionstamp);
 
     Ok(alive_candidates)
 }

--- a/foundationdb/src/recipes/leader_election/errors.rs
+++ b/foundationdb/src/recipes/leader_election/errors.rs
@@ -10,8 +10,8 @@
 //! Defines the error hierarchy for leader election operations,
 //! including election-specific errors and conversions from underlying errors.
 
-use crate::tuple::PackError;
 use crate::FdbError;
+use crate::tuple::PackError;
 use std::fmt;
 
 /// Leader election specific errors

--- a/foundationdb/src/recipes/leader_election/mod.rs
+++ b/foundationdb/src/recipes/leader_election/mod.rs
@@ -116,7 +116,7 @@ mod types;
 pub use errors::{LeaderElectionError, Result};
 pub use types::{CandidateInfo, ElectionConfig, ElectionResult, LeaderState};
 
-use crate::{tuple::Subspace, Transaction};
+use crate::{Transaction, tuple::Subspace};
 use std::ops::Deref;
 use std::time::Duration;
 

--- a/foundationdb/src/recipes/ranked_register/algorithm.rs
+++ b/foundationdb/src/recipes/ranked_register/algorithm.rs
@@ -13,8 +13,8 @@
 //! All functions operate within a FoundationDB transaction for atomicity.
 
 use crate::{
-    tuple::{pack, unpack, Subspace},
     Transaction,
+    tuple::{Subspace, pack, unpack},
 };
 use std::ops::Deref;
 

--- a/foundationdb/src/recipes/ranked_register/errors.rs
+++ b/foundationdb/src/recipes/ranked_register/errors.rs
@@ -7,8 +7,8 @@
 
 //! Error types for the ranked register
 
-use crate::tuple::PackError;
 use crate::FdbError;
+use crate::tuple::PackError;
 use std::fmt;
 
 /// Ranked register specific errors

--- a/foundationdb/src/recipes/ranked_register/mod.rs
+++ b/foundationdb/src/recipes/ranked_register/mod.rs
@@ -72,7 +72,7 @@ mod types;
 pub use errors::{RankedRegisterError, Result};
 pub use types::{Rank, ReadResult, RegisterState, WriteResult};
 
-use crate::{tuple::Subspace, Transaction};
+use crate::{Transaction, tuple::Subspace};
 use std::ops::Deref;
 
 /// A ranked register backed by FoundationDB

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -21,13 +21,13 @@ use crate::keyselector::*;
 use crate::metrics::{FdbCommand, TransactionMetrics};
 use crate::options;
 
-use crate::{error, FdbError, FdbResult};
+use crate::{FdbError, FdbResult, error};
 use foundationdb_macros::cfg_api_versions;
 
 use crate::error::{FdbBindingError, TransactionMetricsNotFound};
 
 use futures::{
-    future, future::Either, stream, Future, FutureExt, Stream, TryFutureExt, TryStreamExt,
+    Future, FutureExt, Stream, TryFutureExt, TryStreamExt, future, future::Either, stream,
 };
 
 #[cfg_api_versions(min = 610)]
@@ -241,11 +241,7 @@ unsafe impl Sync for Transaction {}
 /// Converts Rust `bool` into `fdb_sys::fdb_bool_t`
 #[inline]
 fn fdb_bool(v: bool) -> fdb_sys::fdb_bool_t {
-    if v {
-        1
-    } else {
-        0
-    }
+    if v { 1 } else { 0 }
 }
 #[inline]
 fn fdb_len(len: usize, context: &'static str) -> std::os::raw::c_int {
@@ -558,7 +554,7 @@ impl Transaction {
         &self,
         key: &[u8],
         snapshot: bool,
-    ) -> impl Future<Output = FdbResult<Option<FdbSlice>>> + Send + Sync + Unpin {
+    ) -> impl Future<Output = FdbResult<Option<FdbSlice>>> + Send + Sync + Unpin + use<> {
         let metrics = self.metrics.clone();
         let lenght_key = key.len();
 
@@ -648,7 +644,7 @@ impl Transaction {
         &self,
         selector: &KeySelector,
         snapshot: bool,
-    ) -> impl Future<Output = FdbResult<FdbSlice>> + Send + Sync + Unpin {
+    ) -> impl Future<Output = FdbResult<FdbSlice>> + Send + Sync + Unpin + use<> {
         let key = selector.key();
         FdbFuture::new(unsafe {
             fdb_sys::fdb_transaction_get_key(
@@ -755,7 +751,7 @@ impl Transaction {
         opt: &RangeOption,
         iteration: usize,
         snapshot: bool,
-    ) -> impl Future<Output = FdbResult<FdbValues>> + Send + Sync + Unpin {
+    ) -> impl Future<Output = FdbResult<FdbValues>> + Send + Sync + Unpin + use<> {
         let begin = &opt.begin;
         let end = &opt.end;
         let key_begin = begin.key();
@@ -833,7 +829,7 @@ impl Transaction {
         mapper: &[u8],
         iteration: usize,
         snapshot: bool,
-    ) -> impl Future<Output = FdbResult<MappedKeyValues>> + Send + Sync + Unpin {
+    ) -> impl Future<Output = FdbResult<MappedKeyValues>> + Send + Sync + Unpin + use<> {
         let begin = &opt.begin;
         let end = &opt.end;
         let key_begin = begin.key();
@@ -942,7 +938,7 @@ impl Transaction {
         &self,
         begin: &[u8],
         end: &[u8],
-    ) -> impl Future<Output = FdbResult<i64>> + Send + Sync + Unpin {
+    ) -> impl Future<Output = FdbResult<i64>> + Send + Sync + Unpin + use<> {
         FdbFuture::<i64>::new(unsafe {
             fdb_sys::fdb_transaction_get_estimated_range_size_bytes(
                 self.inner.as_ptr(),
@@ -1124,7 +1120,7 @@ impl Transaction {
     pub fn get_addresses_for_key(
         &self,
         key: &[u8],
-    ) -> impl Future<Output = FdbResult<FdbAddresses>> + Send + Sync + Unpin {
+    ) -> impl Future<Output = FdbResult<FdbAddresses>> + Send + Sync + Unpin + use<> {
         FdbFuture::new(unsafe {
             fdb_sys::fdb_transaction_get_addresses_for_key(
                 self.inner.as_ptr(),
@@ -1159,7 +1155,10 @@ impl Transaction {
     /// too_many_watches error. This limit can be changed using the MAX_WATCHES database option.
     /// Because a watch outlives the transaction that creates it, any watch that is no longer
     /// needed should be cancelled by dropping its future.
-    pub fn watch(&self, key: &[u8]) -> impl Future<Output = FdbResult<()>> + Send + Sync + Unpin {
+    pub fn watch(
+        &self,
+        key: &[u8],
+    ) -> impl Future<Output = FdbResult<()>> + Send + Sync + Unpin + use<> {
         FdbFuture::new(unsafe {
             fdb_sys::fdb_transaction_watch(
                 self.inner.as_ptr(),
@@ -1177,7 +1176,7 @@ impl Transaction {
     #[cfg_api_versions(min = 620)]
     pub fn get_approximate_size(
         &self,
-    ) -> impl Future<Output = FdbResult<i64>> + Send + Sync + Unpin {
+    ) -> impl Future<Output = FdbResult<i64>> + Send + Sync + Unpin + use<> {
         FdbFuture::new(unsafe {
             fdb_sys::fdb_transaction_get_approximate_size(self.inner.as_ptr())
         })
@@ -1191,7 +1190,7 @@ impl Transaction {
         begin: &[u8],
         end: &[u8],
         chunk_size: i64,
-    ) -> impl Future<Output = FdbResult<FdbKeys>> + Send + Sync + Unpin {
+    ) -> impl Future<Output = FdbResult<FdbKeys>> + Send + Sync + Unpin + use<> {
         FdbFuture::<FdbKeys>::new(unsafe {
             fdb_sys::fdb_transaction_get_range_split_points(
                 self.inner.as_ptr(),
@@ -1215,7 +1214,7 @@ impl Transaction {
     /// Most applications will not call this function.
     pub fn get_versionstamp(
         &self,
-    ) -> impl Future<Output = FdbResult<FdbSlice>> + Send + Sync + Unpin {
+    ) -> impl Future<Output = FdbResult<FdbSlice>> + Send + Sync + Unpin + use<> {
         FdbFuture::new(unsafe { fdb_sys::fdb_transaction_get_versionstamp(self.inner.as_ptr()) })
     }
 
@@ -1223,7 +1222,9 @@ impl Transaction {
     /// to `get_*()` (including this one) and (unless causal consistency has been deliberately
     /// compromised by transaction options) is guaranteed to represent all transactions which were
     /// reported committed before that call.
-    pub fn get_read_version(&self) -> impl Future<Output = FdbResult<i64>> + Send + Sync + Unpin {
+    pub fn get_read_version(
+        &self,
+    ) -> impl Future<Output = FdbResult<i64>> + Send + Sync + Unpin + use<> {
         FdbFuture::new(unsafe { fdb_sys::fdb_transaction_get_read_version(self.inner.as_ptr()) })
     }
 

--- a/foundationdb/src/tuple_ext/hca.rs
+++ b/foundationdb/src/tuple_ext/hca.rs
@@ -28,7 +28,7 @@ use std::fmt;
 use std::sync::{Mutex, PoisonError};
 
 use futures::future;
-use rand::{rngs::SmallRng, RngExt};
+use rand::{RngExt, rngs::SmallRng};
 
 use crate::options::{ConflictRangeType, MutationType, TransactionOption};
 use crate::tuple::{PackError, Subspace};

--- a/foundationdb/tests/common/mod.rs
+++ b/foundationdb/tests/common/mod.rs
@@ -1,6 +1,6 @@
 use foundationdb as fdb;
-use rand::distr::Alphanumeric;
 use rand::RngExt;
+use rand::distr::Alphanumeric;
 
 /// generate random string. Foundationdb watch only fires when value changed, so updating with same
 /// value twice will not fire watches. To make examples work over multiple run, we use random

--- a/foundationdb/tests/get.rs
+++ b/foundationdb/tests/get.rs
@@ -10,7 +10,7 @@ use foundationdb_macros::cfg_api_versions;
 use foundationdb_sys::if_cfg_api_versions;
 use futures::future::*;
 use std::ops::Deref;
-use std::sync::{atomic::*, Arc};
+use std::sync::{Arc, atomic::*};
 
 mod common;
 

--- a/foundationdb/tests/hca.rs
+++ b/foundationdb/tests/hca.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use foundationdb::tuple::{hca::HighContentionAllocator, Subspace};
+use foundationdb::tuple::{Subspace, hca::HighContentionAllocator};
 use foundationdb::{FdbResult, TransactOption};
 use futures::prelude::*;
 use std::collections::HashSet;

--- a/foundationdb/tests/leader_election.rs
+++ b/foundationdb/tests/leader_election.rs
@@ -10,9 +10,9 @@ mod common;
 #[cfg(feature = "recipes-leader-election")]
 mod leader_election_tests {
     use foundationdb::{
+        Database, FdbBindingError,
         recipes::leader_election::{ElectionConfig, LeaderElection},
         tuple::Subspace,
-        Database, FdbBindingError,
     };
     use std::time::Duration;
 
@@ -402,8 +402,10 @@ mod leader_election_tests {
         .await?;
 
         // Change config to disable elections
-        let mut new_config = ElectionConfig::default();
-        new_config.election_enabled = false;
+        let new_config = ElectionConfig {
+            election_enabled: false,
+            ..Default::default()
+        };
 
         let election_ref = &election;
         db.run(|txn, _| {
@@ -435,8 +437,10 @@ mod leader_election_tests {
         );
 
         // Re-enable elections
-        let mut enabled_config = ElectionConfig::default();
-        enabled_config.election_enabled = true;
+        let enabled_config = ElectionConfig {
+            election_enabled: true,
+            ..Default::default()
+        };
 
         let election_ref = &election;
         db.run(|txn, _| {
@@ -539,8 +543,10 @@ mod leader_election_tests {
         let high_priority = "high-priority";
 
         // Initialize with preemption enabled
-        let mut config = ElectionConfig::default();
-        config.allow_preemption = true;
+        let config = ElectionConfig {
+            allow_preemption: true,
+            ..Default::default()
+        };
 
         let election_ref = &election;
         db.run(|txn, _| {

--- a/foundationdb/tests/range.rs
+++ b/foundationdb/tests/range.rs
@@ -284,7 +284,7 @@ async fn test_get_range_split_points() -> FdbResult<()> {
 
 #[cfg_api_versions(min = 710)]
 async fn test_mapped_value() -> FdbResult<()> {
-    use foundationdb::tuple::{pack, Subspace};
+    use foundationdb::tuple::{Subspace, pack};
 
     let db = common::database().await?;
 
@@ -328,7 +328,7 @@ fn verify_mapped_values(
     blue_counter: i32,
     vec_mapped_key_values: Vec<mapped_key_values::MappedKeyValues>,
 ) {
-    use foundationdb::tuple::{unpack, Element};
+    use foundationdb::tuple::{Element, unpack};
 
     let mut value_counter = 0;
 
@@ -365,7 +365,7 @@ fn verify_mapped_values(
 
 #[cfg_api_versions(min = 710)]
 async fn test_mapped_values() -> FdbResult<()> {
-    use foundationdb::tuple::{pack, Subspace};
+    use foundationdb::tuple::{Subspace, pack};
 
     let db = common::database().await?;
 

--- a/foundationdb/tests/ranked_register.rs
+++ b/foundationdb/tests/ranked_register.rs
@@ -10,9 +10,9 @@ mod common;
 #[cfg(feature = "recipes-ranked-register")]
 mod ranked_register_tests {
     use foundationdb::{
+        Database, FdbBindingError,
         recipes::ranked_register::{Rank, RankedRegister, WriteResult},
         tuple::Subspace,
-        Database, FdbBindingError,
     };
 
     #[test]

--- a/foundationdb/tests/runner_hooks.rs
+++ b/foundationdb/tests/runner_hooks.rs
@@ -3,9 +3,9 @@ use foundationdb::*;
 use foundationdb_macros::cfg_api_versions;
 use foundationdb_sys::if_cfg_api_versions;
 #[allow(unused_imports)]
-use std::sync::atomic::{AtomicU64, Ordering};
-#[allow(unused_imports)]
 use std::sync::Arc;
+#[allow(unused_imports)]
+use std::sync::atomic::{AtomicU64, Ordering};
 
 mod common;
 

--- a/foundationdb/tests/timekeeper.rs
+++ b/foundationdb/tests/timekeeper.rs
@@ -1,4 +1,4 @@
-use foundationdb::timekeeper::{hint_version_from_timestamp, HintMode};
+use foundationdb::timekeeper::{HintMode, hint_version_from_timestamp};
 use std::time::SystemTime;
 
 #[tokio::test]

--- a/foundationdb/tests/tokio.rs
+++ b/foundationdb/tests/tokio.rs
@@ -2,12 +2,12 @@ extern crate core;
 
 use foundationdb::future::FdbValues;
 use foundationdb::options::ConflictRangeType;
-use foundationdb::tuple::{pack, Subspace};
+use foundationdb::tuple::{Subspace, pack};
 use foundationdb::*;
 use futures::prelude::*;
 use std::fmt::{Display, Formatter};
-use std::sync::atomic::{AtomicI16, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicI16, Ordering};
 use std::time::Duration;
 use tokio::runtime::Runtime;
 use tokio::time::timeout;

--- a/foundationdb/tests/trace.rs
+++ b/foundationdb/tests/trace.rs
@@ -54,7 +54,7 @@ async fn test_traces_on_run() {
 
     let result = db
         .run(|_trx, _b| async move {
-            return Err::<(), FdbBindingError>(FdbBindingError::CustomError(Box::new(CustomError)));
+            Err::<(), FdbBindingError>(FdbBindingError::CustomError(Box::new(CustomError)))
         })
         .await;
 

--- a/foundationdb/tests/tuple.rs
+++ b/foundationdb/tests/tuple.rs
@@ -6,9 +6,9 @@
 // copied, modified, or distributed except according to those terms.
 
 use foundationdb::{
+    Database,
     options::MutationType,
     tuple::{Subspace, Versionstamp},
-    Database,
 };
 use futures::StreamExt;
 


### PR DESCRIPTION
Closes #255.

Migrates the whole workspace to the Rust 2024 edition.

## Changes

- All 9 crates set to `edition = "2024"`. MSRV stays `1.85.1` (the first stable that supports the 2024 edition), so `msrv.yml` is unaffected.
- `cargo fix --edition` applied per crate across the full feature matrix: `unsafe_op_in_unsafe_fn` blocks and `+ use<>` precise capturing on RPIT futures.
- Hand fixes for what `cargo fix` cannot reach:
  - `foundationdb-simulation` `register_factory!` / `register_workload!` macros: `unsafe extern` block + `#[unsafe(no_mangle)]`.
  - `foundationdb-gen`: the generated option `apply` match is wrapped in a single `unsafe` block, removing 234 `unsafe_op_in_unsafe_fn` warnings in the generated options code at the generator.
- Workspace-wide clippy cleanup ahead of `clippy::pedantic` (`collapsible_if`, `field_reassign_with_default`, `unnecessary_unwrap`, `mismatched_lifetime_syntaxes`, `needless_return`; `arc_with_non_send_sync` justified with a comment in the simulation waker).
- rustfmt 2024 style reformatting.
- New `clippy-all` cargo alias (workspace, all targets, all relevant features, `-D warnings`), now used by the CI clippy job.

## Verification

- `cargo clippy-all` (workspace, all targets, `-D warnings`) clean, plus the `cpp-abi` path.
- `cargo fmt --check` clean.
- `cargo test -p foundationdb` (incl. `tenant` after enabling tenant mode), `-p foundationdb-tuple`, and doctests: all green against FoundationDB 7.4.

## Notes

- The `collapsible_if` fixes introduce let-chains in `foundationdb-simulation` and `foundationdb-recipes-simulation` (Rust 1.88+). Neither declares a `rust-version`, and no CI job builds them below stable, so CI is unaffected.
- Filed #468 to deprecate experimental tenant support (tenant mode is disabled by default on FDB 7.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
