### PR TITLE
feat!: chain-walking retry detection and typed closure errors for Database::run

### DIFF
--- a/foundationdb-recipes-simulation/src/leader_election/workload.rs
+++ b/foundationdb-recipes-simulation/src/leader_election/workload.rs
@@ -67,7 +67,7 @@ impl RustWorkload for LeaderElectionWorkload {
                                 .initialize_with_config(&trx, config)
                                 .await
                                 .map_err(FdbBindingError::from)?;
-                            Ok(())
+                            Ok::<_, FdbBindingError>(())
                         }
                     })
                     .await;
@@ -267,7 +267,7 @@ impl RustWorkload for LeaderElectionWorkload {
                             ));
                             trx.atomic_op(&log_key, &log_value, MutationType::SetVersionstampedKey);
 
-                            Ok(claim_result)
+                            Ok::<_, FdbBindingError>(claim_result)
                         }
                     })
                     .await;
@@ -361,7 +361,7 @@ impl RustWorkload for LeaderElectionWorkload {
                                     MutationType::SetVersionstampedKey,
                                 );
 
-                                Ok(did_resign)
+                                Ok::<_, FdbBindingError>(did_resign)
                             }
                         })
                         .await;
@@ -473,7 +473,13 @@ impl RustWorkload for LeaderElectionWorkload {
 
                     let config = election.read_config(&trx).await.ok();
 
-                    Ok((read_version, entries, leader_state, candidates, config))
+                    Ok::<_, FdbBindingError>((
+                        read_version,
+                        entries,
+                        leader_state,
+                        candidates,
+                        config,
+                    ))
                 }
             })
             .await;

--- a/foundationdb/README.md
+++ b/foundationdb/README.md
@@ -106,7 +106,7 @@ async fn hello_world() -> foundationdb::FdbResult<()> {
     match db
         .run(|trx, _maybe_committed| async move {
             trx.set(b"hello", b"world");
-            Ok(())
+            Ok::<_, foundationdb::FdbBindingError>(())
         })
         .await
     {
@@ -116,7 +116,7 @@ async fn hello_world() -> foundationdb::FdbResult<()> {
 
     // read a value
     match db
-        .run(|trx, _maybe_committed| async move { Ok(trx.get(b"hello", false).await.unwrap()) })
+        .run(|trx, _maybe_committed| async move { Ok::<_, foundationdb::FdbBindingError>(trx.get(b"hello", false).await.unwrap()) })
         .await
     {
         Ok(slice) => assert_eq!(b"world", slice.unwrap().as_ref()),

--- a/foundationdb/examples/atomic-op-counter.rs
+++ b/foundationdb/examples/atomic-op-counter.rs
@@ -1,6 +1,6 @@
 use byteorder::ByteOrder;
 use foundationdb::tuple::Subspace;
-use foundationdb::{Database, FdbResult, Transaction, options};
+use foundationdb::{Database, FdbBindingError, FdbResult, Transaction, options};
 
 #[tokio::main]
 async fn main() {
@@ -27,7 +27,7 @@ async fn main() {
         let counter_key = counter_key.clone();
         async move {
             increment(&trx, &counter_key, 1);
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         }
     })
     .await
@@ -39,7 +39,7 @@ async fn main() {
             let counter_key = counter_key.clone();
             async move {
                 let val = read_counter(&trx, &counter_key).await?;
-                Ok(val)
+                Ok::<_, FdbBindingError>(val)
             }
         })
         .await
@@ -52,7 +52,7 @@ async fn main() {
         let counter_key = counter_key.clone();
         async move {
             increment(&trx, &counter_key, -1);
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         }
     })
     .await
@@ -63,7 +63,7 @@ async fn main() {
             let counter_key = counter_key.clone();
             async move {
                 let val = read_counter(&trx, &counter_key).await?;
-                Ok(val)
+                Ok::<_, FdbBindingError>(val)
             }
         })
         .await

--- a/foundationdb/examples/blob-with-manifest.rs
+++ b/foundationdb/examples/blob-with-manifest.rs
@@ -1,6 +1,6 @@
 use bytesize::ByteSize;
 use foundationdb::tuple::{PackError, Subspace, pack, unpack};
-use foundationdb::{Database, RangeOption};
+use foundationdb::{Database, FdbBindingError, RangeOption};
 use futures::TryStreamExt;
 use sha2::{Digest, Sha256};
 use std::fmt::{Display, Formatter};
@@ -111,7 +111,7 @@ async fn clear_subspace(db: &Database, subspaces: Vec<&Subspace>) {
             for subspace in subspaces {
                 transaction.clear_subspace_range(subspace)
             }
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         }
     })
     .await
@@ -165,7 +165,7 @@ async fn write_data(db: &Database, subspace: &Subspace, data: &Vec<u8>) {
 
     db.run(|transaction, _| async move {
         transaction.set(subspace.bytes(), data.as_slice());
-        Ok(())
+        Ok::<_, FdbBindingError>(())
     })
     .await
     .expect("Unable to commit transaction");
@@ -196,7 +196,7 @@ async fn write_blob(
             chunk_number += 1;
         });
 
-        Ok(chunk_number)
+        Ok::<_, FdbBindingError>(chunk_number)
     })
     .await
     .expect("Unable to commit transaction")
@@ -206,7 +206,7 @@ async fn write_blob(
 async fn read_data(db: &Database, subspace: &Subspace) -> Option<Vec<u8>> {
     db.run(|transaction, _| async move {
         let get_result = transaction.get(subspace.bytes(), false).await?;
-        Ok(get_result.map(|data| data.to_vec()))
+        Ok::<_, FdbBindingError>(get_result.map(|data| data.to_vec()))
     })
     .await
     .ok()
@@ -223,7 +223,7 @@ async fn read_blob(db: &Database, subspace: &Subspace) -> Vec<u8> {
             data.extend(result.value().iter());
         }
 
-        Ok(data)
+        Ok::<_, FdbBindingError>(data)
     })
     .await
     .expect("Unable to read blob")

--- a/foundationdb/examples/blob.rs
+++ b/foundationdb/examples/blob.rs
@@ -1,5 +1,5 @@
 use foundationdb::tuple::Subspace;
-use foundationdb::{Database, RangeOption};
+use foundationdb::{Database, FdbBindingError, RangeOption};
 use futures::TryStreamExt;
 use rand::RngExt;
 use rand::distr::Uniform;
@@ -9,7 +9,7 @@ use rand::distr::Uniform;
 async fn clear_subspace(db: &Database, subspace: &Subspace) {
     db.run(|trx, _maybe_committed| async move {
         trx.clear_subspace_range(subspace);
-        Ok(())
+        Ok::<_, FdbBindingError>(())
     })
     .await
     .expect("Unable to commit transaction");
@@ -27,7 +27,7 @@ async fn write_blob(db: &Database, subspace: &Subspace, data: &[u8]) {
             trx.set(&key, &data[start..end]);
             chunk_number += 1;
         });
-        Ok(())
+        Ok::<_, FdbBindingError>(())
     })
     .await
     .expect("Unable to commit transaction");
@@ -43,7 +43,7 @@ async fn read_blob(db: &Database, subspace: &Subspace) -> Vec<u8> {
             data.extend(result.value().iter());
         }
 
-        Ok(data)
+        Ok::<_, FdbBindingError>(data)
     })
     .await
     .expect("Unable to read blob")

--- a/foundationdb/examples/class-scheduling.rs
+++ b/foundationdb/examples/class-scheduling.rs
@@ -19,15 +19,23 @@ use rand::prelude::IndexedRandom;
 
 use foundationdb as fdb;
 use foundationdb::tuple::{Subspace, pack, unpack};
-use foundationdb::{Database, FdbBindingError, FdbResult, RangeOption, Transaction};
+use foundationdb::{
+    Database, FdbBindingError, FdbError, FdbResult, RangeOption, RetryableError, Transaction,
+};
 use futures::TryStreamExt;
 
-type Result<T> = std::result::Result<T, FdbBindingError>;
+type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Clone, Copy)]
+// The blessed layer-error pattern: one enum for the whole layer, carrying the
+// FdbError (and the retry loop's own FdbBindingError) as a source. The
+// `RetryableError` impl below makes `db.run` retry-transparent for wrapped
+// FdbErrors, and the caller gets this typed error back from `db.run`.
+#[derive(Debug)]
 enum Error {
     NoRemainingSeats,
     TooManyClasses,
+    Fdb(FdbError),
+    Binding(FdbBindingError),
 }
 
 impl std::fmt::Display for Error {
@@ -35,17 +43,36 @@ impl std::fmt::Display for Error {
         match self {
             Error::NoRemainingSeats => write!(f, "No remaining seats"),
             Error::TooManyClasses => write!(f, "Too many classes"),
+            Error::Fdb(e) => write!(f, "FoundationDB error: {e}"),
+            Error::Binding(e) => write!(f, "Retry loop error: {e}"),
         }
     }
 }
 
-impl std::error::Error for Error {}
-
-impl From<Error> for FdbBindingError {
-    fn from(err: Error) -> Self {
-        FdbBindingError::CustomError(Box::new(err))
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Fdb(e) => Some(e),
+            Error::Binding(e) => Some(e),
+            Error::NoRemainingSeats | Error::TooManyClasses => None,
+        }
     }
 }
+
+impl From<FdbError> for Error {
+    fn from(err: FdbError) -> Self {
+        Error::Fdb(err)
+    }
+}
+
+impl From<FdbBindingError> for Error {
+    fn from(err: FdbBindingError) -> Self {
+        Error::Binding(err)
+    }
+}
+
+// The default retry_decision walks source() and finds the wrapped FdbError.
+impl RetryableError for Error {}
 
 // Data model:
 // ("attends", student, class) = ""
@@ -103,7 +130,7 @@ async fn init(db: &Database, all_classes: &[String]) {
         trx.clear_subspace_range(&"attends".into());
         trx.clear_subspace_range(&"class".into());
         init_classes(&trx, all_classes);
-        Ok(())
+        Ok::<_, Error>(())
     })
     .await
     .expect("failed to initialize data");
@@ -124,7 +151,7 @@ async fn get_available_classes(db: &Database) -> Vec<String> {
             }
         }
 
-        Ok(available_classes)
+        Ok::<_, Error>(available_classes)
     })
     .await
     .expect("failed to get classes")
@@ -158,7 +185,7 @@ async fn ditch(db: &Database, student: String, class: String) -> Result<()> {
         let class = class.clone();
         async move {
             ditch_trx(&trx, &student, &class).await?;
-            Ok(())
+            Ok::<_, Error>(())
         }
     })
     .await
@@ -180,7 +207,7 @@ async fn signup_trx(trx: &Transaction, student: &str, class: &str) -> Result<()>
     .expect("failed to decode i64");
 
     if available_seats <= 0 {
-        return Err(Error::NoRemainingSeats.into());
+        return Err(Error::NoRemainingSeats);
     }
 
     let attends_range = RangeOption::from(&("attends", &student).into());
@@ -189,7 +216,7 @@ async fn signup_trx(trx: &Transaction, student: &str, class: &str) -> Result<()>
         .try_collect()
         .await?;
     if attends.len() >= 5 {
-        return Err(Error::TooManyClasses.into());
+        return Err(Error::TooManyClasses);
     }
 
     //println!("{} taking class: {}", student, class);
@@ -221,7 +248,7 @@ async fn switch_classes(
         async move {
             ditch_trx(&trx, &student_id, &old_class).await?;
             signup_trx(&trx, &student_id, &new_class).await?;
-            Ok(())
+            Ok::<_, Error>(())
         }
     })
     .await
@@ -348,7 +375,7 @@ async fn run_sim(db: &Database, students: usize, ops_per_student: usize) {
 
                     println!("{student_id_inner} is taking: {class}");
                 }
-                Ok(())
+                Ok::<_, Error>(())
             }
         })
         .await

--- a/foundationdb/examples/conflict_reporting.rs
+++ b/foundationdb/examples/conflict_reporting.rs
@@ -94,7 +94,7 @@ async fn run_example() -> Result<(), FdbBindingError> {
             }
 
             trx.set(b"example_conflict_key", b"my_value");
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         }
     })
     .await?;

--- a/foundationdb/examples/hello-world.rs
+++ b/foundationdb/examples/hello-world.rs
@@ -26,7 +26,7 @@ async fn hello_world() -> foundationdb::FdbResult<()> {
     match db
         .run(|trx, _maybe_committed| async move {
             trx.set(b"hello", b"world");
-            Ok(())
+            Ok::<_, foundationdb::FdbBindingError>(())
         })
         .await
     {
@@ -36,7 +36,9 @@ async fn hello_world() -> foundationdb::FdbResult<()> {
 
     // read a value
     match db
-        .run(|trx, _maybe_committed| async move { Ok(trx.get(b"hello", false).await.unwrap()) })
+        .run(|trx, _maybe_committed| async move {
+            Ok::<_, foundationdb::FdbBindingError>(trx.get(b"hello", false).await.unwrap())
+        })
         .await
     {
         Ok(slice) => assert_eq!(b"world", slice.unwrap().as_ref()),

--- a/foundationdb/examples/multi_version.rs
+++ b/foundationdb/examples/multi_version.rs
@@ -76,7 +76,7 @@ async fn main() {
             let mut buf = [0u8; 8];
             byteorder::LE::write_i64(&mut buf, 1);
             trx.atomic_op(&key, &buf, options::MutationType::Add);
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         }
     })
     .await
@@ -88,7 +88,7 @@ async fn main() {
             let key = key.clone();
             async move {
                 let result = trx.get(&key, true).await?;
-                Ok(result)
+                Ok::<_, FdbBindingError>(result)
             }
         })
         .await

--- a/foundationdb/examples/simple-index.rs
+++ b/foundationdb/examples/simple-index.rs
@@ -27,7 +27,7 @@ async fn clear_subspaces(db: &Database, subspaces: &[Subspace]) {
         for subspace in subspaces {
             trx.clear_subspace_range(subspace);
         }
-        Ok(())
+        Ok::<_, FdbBindingError>(())
     })
     .await
     .expect("Unable to commit transaction");

--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -25,7 +25,7 @@ use crate::options;
 use crate::transaction::*;
 use crate::{FdbError, FdbResult, error};
 
-use crate::error::FdbBindingError;
+use crate::error::{FdbBindingError, RetryDecision, RetryableError};
 use futures::prelude::*;
 
 /// Wrapper around the boolean representing whether the
@@ -60,6 +60,9 @@ pub trait RunnerHooks {
     }
 
     /// Called when a closure error triggers a retry.
+    ///
+    /// A closure error classified as [`crate::RetryDecision::Retry`] surfaces
+    /// here as a synthetic `FdbError` with code 1020 (not_committed).
     fn on_closure_error(&self, _err: &FdbError) {}
 
     /// Called after `on_error()` completes with its duration.
@@ -131,7 +134,7 @@ impl RunnerHooks for InstrumentedHooks {
 /// # Hook lifecycle per iteration
 ///
 /// 1. Execute closure
-/// 2. If closure returns `Err` with an `FdbError`:
+/// 2. If closure returns `Err` classified as `Fdb` or `Retry`:
 ///    - `on_closure_error` → `on_error()` → `on_error_duration` → `on_retry` → loop
 /// 3. If closure succeeds, attempt commit:
 ///    - Commit succeeds → `on_commit_success` → return `Ok`
@@ -141,14 +144,15 @@ impl RunnerHooks for InstrumentedHooks {
     feature = "trace",
     tracing::instrument(level = "debug", skip(initial_transaction, hooks, closure))
 )]
-pub(crate) async fn run_with_hooks<F, Fut, T, H: RunnerHooks>(
+pub(crate) async fn run_with_hooks<F, Fut, T, E, H: RunnerHooks>(
     initial_transaction: RetryableTransaction,
     hooks: &H,
     closure: F,
-) -> Result<T, FdbBindingError>
+) -> Result<T, E>
 where
     F: Fn(RetryableTransaction, MaybeCommitted) -> Fut,
-    Fut: Future<Output = Result<T, FdbBindingError>>,
+    Fut: Future<Output = Result<T, E>>,
+    E: RetryableError,
 {
     let mut maybe_committed = false;
     let mut transaction = initial_transaction;
@@ -164,34 +168,44 @@ where
         let result_closure = closure(transaction.clone(), MaybeCommitted(maybe_committed)).await;
 
         if let Err(e) = result_closure {
-            if let Some(fdb_err) = e.get_fdb_error() {
-                maybe_committed = fdb_err.is_maybe_committed();
-                hooks.on_closure_error(&fdb_err);
+            let fdb_err = match e.retry_decision() {
+                RetryDecision::Fdb(fdb_err) => {
+                    maybe_committed = fdb_err.is_maybe_committed();
+                    fdb_err
+                }
+                // Synthetic retryable code (1020, not_committed): backoff and
+                // RetryLimit stay governed by fdb_transaction_on_error.
+                // maybe_committed is left untouched: a previous maybe-committed
+                // attempt must stay visible to the closure.
+                RetryDecision::Retry => FdbError::from_code(1020),
+                RetryDecision::Fatal => return Err(e),
+            };
+            hooks.on_closure_error(&fdb_err);
 
-                let now_on_error = Instant::now();
-                match transaction.on_error(fdb_err).await {
-                    Ok(Ok(t)) => {
-                        hooks.on_error_duration(now_on_error.elapsed().as_millis() as u64);
+            let now_on_error = Instant::now();
+            match transaction.on_error(fdb_err).await {
+                Ok(Ok(t)) => {
+                    hooks.on_error_duration(now_on_error.elapsed().as_millis() as u64);
 
-                        #[cfg(feature = "trace")]
-                        {
-                            let error_code = fdb_err.code();
-                            tracing::warn!(iteration, error_code, "restarting transaction");
-                        }
+                    #[cfg(feature = "trace")]
+                    {
+                        let error_code = fdb_err.code();
+                        tracing::warn!(iteration, error_code, "restarting transaction");
+                    }
 
-                        hooks.on_retry();
-                        transaction = t;
-                        continue;
-                    }
-                    Ok(Err(non_retryable)) => {
-                        return Err(FdbBindingError::from(non_retryable));
-                    }
-                    Err(binding_err) => {
-                        return Err(binding_err);
-                    }
+                    hooks.on_retry();
+                    transaction = t;
+                    continue;
+                }
+                // Retries exhausted or non-retryable: return the original
+                // closure error, which carries the caller's context.
+                Ok(Err(_non_retryable)) => {
+                    return Err(e);
+                }
+                Err(binding_err) => {
+                    return Err(E::from(binding_err));
                 }
             }
-            return Err(e);
         }
 
         #[cfg(feature = "trace")]
@@ -208,7 +222,7 @@ where
                     iteration,
                     "transaction reference kept, aborting transaction"
                 );
-                return Err(err);
+                return Err(E::from(err));
             }
             Ok(Ok(committed)) => {
                 hooks.on_commit_success(&committed, commit_duration);
@@ -251,7 +265,7 @@ where
                             );
                         }
 
-                        return Err(FdbBindingError::from(non_retryable));
+                        return Err(E::from(FdbBindingError::from(non_retryable)));
                     }
                 }
             }
@@ -603,16 +617,35 @@ impl Database {
     ///     if maybe_committed.into() {
     ///         // Handle the problem if needed
     ///     }
+    ///     Ok::<_, FdbBindingError>(())
     /// }).await;
     ///```
+    ///
+    /// # Typed closure errors
+    ///
+    /// The closure error type `E` is generic: any type implementing
+    /// [`RetryableError`](crate::RetryableError) works, and the caller gets it
+    /// back typed. Errors are classified through
+    /// [`RetryableError::retry_decision`](crate::RetryableError::retry_decision):
+    /// by default any error that is, or wraps (through `source()`), an
+    /// [`FdbError`] is handed to `on_error`, which judges retryability and
+    /// applies backoff; [`RetryDecision::Retry`](crate::RetryDecision::Retry)
+    /// is routed through `on_error` with code 1020 (not_committed), so backoff
+    /// and [`options::TransactionOption::RetryLimit`] apply uniformly and
+    /// `MaybeCommitted` is left untouched. When retries are exhausted or the
+    /// error is not retryable, the original closure error is returned as-is.
+    ///
+    /// A closure that never names an error type is ambiguous; pin it on the
+    /// tail expression, for example `Ok::<_, FdbBindingError>(value)`.
     #[cfg_attr(
         feature = "trace",
         tracing::instrument(level = "debug", skip(self, closure))
     )]
-    pub async fn run<F, Fut, T>(&self, closure: F) -> Result<T, FdbBindingError>
+    pub async fn run<F, Fut, T, E>(&self, closure: F) -> Result<T, E>
     where
         F: Fn(RetryableTransaction, MaybeCommitted) -> Fut,
-        Fut: Future<Output = Result<T, FdbBindingError>>,
+        Fut: Future<Output = Result<T, E>>,
+        E: RetryableError,
     {
         let transaction = self.create_retryable_trx()?;
         run_with_hooks(transaction, &NoopHooks, closure).await
@@ -628,14 +661,15 @@ impl Database {
         feature = "trace",
         tracing::instrument(level = "debug", skip(self, hooks, closure))
     )]
-    pub async fn run_with_hooks<F, Fut, T, H: RunnerHooks>(
+    pub async fn run_with_hooks<F, Fut, T, E, H: RunnerHooks>(
         &self,
         hooks: &H,
         closure: F,
-    ) -> Result<T, FdbBindingError>
+    ) -> Result<T, E>
     where
         F: Fn(RetryableTransaction, MaybeCommitted) -> Fut,
-        Fut: Future<Output = Result<T, FdbBindingError>>,
+        Fut: Future<Output = Result<T, E>>,
+        E: RetryableError,
     {
         let transaction = self.create_retryable_trx()?;
         run_with_hooks(transaction, hooks, closure).await
@@ -670,13 +704,14 @@ impl Database {
         feature = "trace",
         tracing::instrument(level = "debug", skip(self, closure))
     )]
-    pub async fn instrumented_run<F, Fut, T>(
+    pub async fn instrumented_run<F, Fut, T, E>(
         &self,
         closure: F,
-    ) -> Result<(T, MetricsReport), (FdbBindingError, MetricsReport)>
+    ) -> Result<(T, MetricsReport), (E, MetricsReport)>
     where
         F: Fn(RetryableTransaction, MaybeCommitted) -> Fut,
-        Fut: Future<Output = Result<T, FdbBindingError>>,
+        Fut: Future<Output = Result<T, E>>,
+        E: RetryableError,
     {
         let metrics = TransactionMetrics::new();
         let hooks = InstrumentedHooks {
@@ -687,7 +722,7 @@ impl Database {
             Ok(trx) => trx,
             Err(err) => {
                 hooks.on_complete();
-                return Err((err, metrics.get_metrics_data()));
+                return Err((E::from(err), metrics.get_metrics_data()));
             }
         };
 

--- a/foundationdb/src/directory/error.rs
+++ b/foundationdb/src/directory/error.rs
@@ -66,6 +66,24 @@ pub enum DirectoryError {
     Other(String),
 }
 
+impl std::fmt::Display for DirectoryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
+}
+
+impl std::error::Error for DirectoryError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            DirectoryError::IoError(e) => Some(e),
+            DirectoryError::FdbError(e) => Some(e),
+            DirectoryError::HcaError(e) => Some(e),
+            DirectoryError::PackError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 impl From<error::FdbError> for DirectoryError {
     fn from(err: error::FdbError) -> Self {
         DirectoryError::FdbError(err)

--- a/foundationdb/src/error.rs
+++ b/foundationdb/src/error.rs
@@ -122,6 +122,7 @@ pub type FdbResult<T = ()> = Result<T, FdbError>;
 
 /// This error represent all errors that can be throwed by `db.run`.
 /// Layer developers may use the `CustomError`.
+#[non_exhaustive]
 pub enum FdbBindingError {
     NonRetryableFdbError(FdbError),
     HcaError(HcaError),
@@ -130,6 +131,12 @@ pub enum FdbBindingError {
     /// A reference to the `RetryableTransaction` has been kept
     ReferenceToTransactionKept,
     /// A custom error that layer developers can use
+    ///
+    /// The retry loop of [`crate::Database::run`] recovers the underlying
+    /// [`FdbError`] by walking the boxed error's `source()` chain, so box the
+    /// error itself (or a type that keeps the `FdbError` as its `source()`).
+    /// Never box a stringified error (`e.to_string().into()`): the conversion
+    /// destroys the source chain, and a retryable error becomes fatal.
     CustomError(Box<dyn std::error::Error + Send + Sync>),
     /// Error returned when attempting to access metrics on a transaction that wasn't created with metrics instrumentation
     TransactionMetricsNotFound,
@@ -248,6 +255,108 @@ impl std::error::Error for FdbBindingError {
             Self::ReferenceToTransactionKept | Self::TransactionMetricsNotFound => None,
             #[cfg(feature = "recipes-leader-election")]
             Self::LeaderElectionError(e) => Some(e),
+        }
+    }
+}
+
+/// What the retry loop of [`crate::Database::run`] does with a closure error.
+///
+/// Produced by [`RetryableError::retry_decision`]. In every case the C API
+/// remains the single retry governor: backoff, max retry delay and
+/// `TransactionOption::RetryLimit` are applied by `fdb_transaction_on_error`,
+/// never by a Rust-side budget.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub enum RetryDecision {
+    /// The error is, or wraps, this `FdbError`: hand it to `on_error` and let
+    /// the C API judge retryability.
+    Fdb(FdbError),
+    /// App-level retry request with no native error underneath (lock
+    /// contention, optimistic-concurrency conditions). Routed through
+    /// `on_error` with code 1020 (not_committed, retryable by definition), so
+    /// backoff and retry limits apply uniformly.
+    Retry,
+    /// Not retryable: the loop returns the original error to the caller as-is.
+    Fatal,
+}
+
+/// What the retry loop of [`crate::Database::run`] asks of a closure error.
+///
+/// The default `retry_decision` walks the `source()` chain looking for an
+/// [`FdbError`], so any error type that keeps its `FdbError` as a source (the
+/// idiomatic thiserror `#[from]`/`#[source]` pattern) is retry-transparent
+/// without overriding anything. Override only to add [`RetryDecision::Retry`]
+/// arms for app-level retry conditions.
+///
+/// The `From` bounds let the loop surface its own failures through your type:
+/// `From<FdbError>` supports `?` on `FdbResult` inside the closure, and
+/// `From<FdbBindingError>` carries loop-level failures such as
+/// [`FdbBindingError::ReferenceToTransactionKept`].
+///
+/// `FdbError` itself cannot implement this trait (there is no lossless
+/// `From<FdbBindingError> for FdbError`); use a wrapper type such as
+/// [`FdbBindingError`] or your own enum.
+///
+/// # Example
+///
+/// ```
+/// use foundationdb::{FdbBindingError, FdbError, RetryableError};
+///
+/// #[derive(Debug)]
+/// enum MyLayerError {
+///     Fdb(FdbError),
+///     Binding(FdbBindingError),
+///     InvalidDocument,
+/// }
+///
+/// impl std::fmt::Display for MyLayerError {
+///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+///         write!(f, "{self:?}")
+///     }
+/// }
+///
+/// impl std::error::Error for MyLayerError {
+///     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+///         match self {
+///             Self::Fdb(e) => Some(e),
+///             Self::Binding(e) => Some(e),
+///             Self::InvalidDocument => None,
+///         }
+///     }
+/// }
+///
+/// impl From<FdbError> for MyLayerError {
+///     fn from(e: FdbError) -> Self {
+///         Self::Fdb(e)
+///     }
+/// }
+///
+/// impl From<FdbBindingError> for MyLayerError {
+///     fn from(e: FdbBindingError) -> Self {
+///         Self::Binding(e)
+///     }
+/// }
+///
+/// // The default source() walk makes wrapped FdbErrors retryable.
+/// impl RetryableError for MyLayerError {}
+/// ```
+pub trait RetryableError:
+    std::error::Error + Send + Sync + Sized + 'static + From<FdbError> + From<FdbBindingError>
+{
+    /// Classifies this error for the retry loop.
+    fn retry_decision(&self) -> RetryDecision {
+        match find_fdb_error(self) {
+            Some(e) => RetryDecision::Fdb(e),
+            None => RetryDecision::Fatal,
+        }
+    }
+}
+
+impl RetryableError for FdbBindingError {
+    fn retry_decision(&self) -> RetryDecision {
+        match self.get_fdb_error() {
+            Some(e) => RetryDecision::Fdb(e),
+            None => RetryDecision::Fatal,
         }
     }
 }

--- a/foundationdb/src/error.rs
+++ b/foundationdb/src/error.rs
@@ -138,28 +138,38 @@ pub enum FdbBindingError {
     LeaderElectionError(crate::recipes::leader_election::LeaderElectionError),
 }
 
+/// Walks an error's `source()` chain, returning the first `FdbError` found.
+///
+/// The depth cap guards against pathological or cyclic source chains.
+pub(crate) fn find_fdb_error(err: &(dyn std::error::Error + 'static)) -> Option<FdbError> {
+    const MAX_DEPTH: usize = 128;
+    let mut current = Some(err);
+    for _ in 0..=MAX_DEPTH {
+        let e = current?;
+        if let Some(fdb) = e.downcast_ref::<FdbError>() {
+            return Some(*fdb);
+        }
+        current = e.source();
+    }
+    None
+}
+
 impl FdbBindingError {
     /// Returns the underlying `FdbError`, if any.
+    ///
+    /// A `CustomError` boxing an `FdbError` or an `FdbBindingError` is checked
+    /// first, then the whole `source()` chain is walked, so any error that
+    /// carries an `FdbError` as its `source()` (however deeply nested) is found.
     pub fn get_fdb_error(&self) -> Option<FdbError> {
-        match *self {
-            Self::NonRetryableFdbError(error)
-            | Self::DirectoryError(DirectoryError::FdbError(error))
-            | Self::HcaError(HcaError::FdbError(error)) => Some(error),
-            Self::CustomError(ref error) => {
-                if let Some(e) = error.downcast_ref::<FdbError>() {
-                    Some(*e)
-                } else if let Some(e) = error.downcast_ref::<FdbBindingError>() {
-                    e.get_fdb_error()
-                } else {
-                    None
-                }
+        if let Self::CustomError(e) = self {
+            if let Some(e) = e.downcast_ref::<FdbError>() {
+                return Some(*e);
             }
-            #[cfg(feature = "recipes-leader-election")]
-            Self::LeaderElectionError(
-                crate::recipes::leader_election::LeaderElectionError::Fdb(e),
-            ) => Some(e),
-            _ => None,
+            if let Some(e) = e.downcast_ref::<FdbBindingError>() {
+                return e.get_fdb_error();
+            }
         }
+        find_fdb_error(self)
     }
 }
 
@@ -227,4 +237,17 @@ impl Display for FdbBindingError {
     }
 }
 
-impl std::error::Error for FdbBindingError {}
+impl std::error::Error for FdbBindingError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::NonRetryableFdbError(e) => Some(e),
+            Self::HcaError(e) => Some(e),
+            Self::DirectoryError(e) => Some(e),
+            Self::PackError(e) => Some(e),
+            Self::CustomError(e) => Some(e.as_ref()),
+            Self::ReferenceToTransactionKept | Self::TransactionMetricsNotFound => None,
+            #[cfg(feature = "recipes-leader-election")]
+            Self::LeaderElectionError(e) => Some(e),
+        }
+    }
+}

--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -54,7 +54,7 @@ if_cfg_api_versions! {min = 510, max = 600 =>
 }
 
 pub use crate::database::*;
-pub use crate::error::FdbBindingError;
+pub use crate::error::{FdbBindingError, RetryDecision, RetryableError};
 pub use crate::error::{FdbError, FdbResult};
 pub use crate::keyselector::*;
 pub use crate::transaction::*;

--- a/foundationdb/src/recipes/leader_election/errors.rs
+++ b/foundationdb/src/recipes/leader_election/errors.rs
@@ -65,7 +65,15 @@ impl fmt::Display for LeaderElectionError {
     }
 }
 
-impl std::error::Error for LeaderElectionError {}
+impl std::error::Error for LeaderElectionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Fdb(e) => Some(e),
+            Self::PackError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
 
 impl From<FdbError> for LeaderElectionError {
     fn from(error: FdbError) -> Self {

--- a/foundationdb/src/recipes/ranked_register/errors.rs
+++ b/foundationdb/src/recipes/ranked_register/errors.rs
@@ -7,8 +7,8 @@
 
 //! Error types for the ranked register
 
-use crate::FdbError;
 use crate::tuple::PackError;
+use crate::{FdbBindingError, FdbError, RetryableError};
 use std::fmt;
 
 /// Ranked register specific errors
@@ -16,6 +16,8 @@ use std::fmt;
 pub enum RankedRegisterError {
     /// Database error
     Fdb(FdbError),
+    /// Retry loop error
+    Binding(FdbBindingError),
     /// Serialization error
     PackError(PackError),
     /// Invalid state encountered in the register
@@ -26,6 +28,7 @@ impl fmt::Display for RankedRegisterError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Fdb(e) => write!(f, "Database error: {e}"),
+            Self::Binding(e) => write!(f, "Retry loop error: {e}"),
             Self::PackError(e) => write!(f, "Pack error: {e:?}"),
             Self::InvalidState(msg) => write!(f, "Invalid state: {msg}"),
         }
@@ -36,6 +39,7 @@ impl std::error::Error for RankedRegisterError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Fdb(e) => Some(e),
+            Self::Binding(e) => Some(e),
             Self::PackError(e) => Some(e),
             Self::InvalidState(_) => None,
         }
@@ -48,11 +52,21 @@ impl From<FdbError> for RankedRegisterError {
     }
 }
 
+impl From<FdbBindingError> for RankedRegisterError {
+    fn from(error: FdbBindingError) -> Self {
+        Self::Binding(error)
+    }
+}
+
 impl From<PackError> for RankedRegisterError {
     fn from(error: PackError) -> Self {
         Self::PackError(error)
     }
 }
+
+/// The `source()` chain exposes the wrapped `FdbError`, so the default
+/// `retry_decision` makes this error retry-transparent in `db.run`.
+impl RetryableError for RankedRegisterError {}
 
 /// Result type for ranked register operations
 pub type Result<T> = std::result::Result<T, RankedRegisterError>;

--- a/foundationdb/src/recipes/ranked_register/errors.rs
+++ b/foundationdb/src/recipes/ranked_register/errors.rs
@@ -32,7 +32,15 @@ impl fmt::Display for RankedRegisterError {
     }
 }
 
-impl std::error::Error for RankedRegisterError {}
+impl std::error::Error for RankedRegisterError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Fdb(e) => Some(e),
+            Self::PackError(e) => Some(e),
+            Self::InvalidState(_) => None,
+        }
+    }
+}
 
 impl From<FdbError> for RankedRegisterError {
     fn from(error: FdbError) -> Self {

--- a/foundationdb/src/tuple_ext/hca.rs
+++ b/foundationdb/src/tuple_ext/hca.rs
@@ -56,6 +56,22 @@ impl fmt::Debug for HcaError {
     }
 }
 
+impl fmt::Display for HcaError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl std::error::Error for HcaError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            HcaError::FdbError(e) => Some(e),
+            HcaError::PackError(e) => Some(e),
+            HcaError::InvalidDirectoryLayerMetadata | HcaError::PoisonError => None,
+        }
+    }
+}
+
 impl From<FdbError> for HcaError {
     fn from(err: FdbError) -> Self {
         Self::FdbError(err)

--- a/foundationdb/tests/error.rs
+++ b/foundationdb/tests/error.rs
@@ -1,6 +1,6 @@
 use foundationdb::directory::DirectoryError;
 use foundationdb::tuple::hca::HcaError;
-use foundationdb::{FdbBindingError, FdbError};
+use foundationdb::{FdbBindingError, FdbError, RetryDecision, RetryableError};
 use std::fmt;
 
 #[test]
@@ -54,6 +54,65 @@ fn get_fdb_error_boxed_binding_error() {
     let inner = FdbBindingError::from(FdbError::from_code(1020));
     let err = FdbBindingError::new_custom_error(Box::new(inner));
     assert_eq!(err.get_fdb_error().map(|e| e.code()), Some(1020));
+}
+
+/// A layer error enum implementing RetryableError with the default
+/// source-walk classification.
+#[derive(Debug)]
+enum TypedLayerError {
+    Fdb(FdbError),
+    Binding(FdbBindingError),
+    Invalid,
+}
+
+impl fmt::Display for TypedLayerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for TypedLayerError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Fdb(e) => Some(e),
+            Self::Binding(e) => Some(e),
+            Self::Invalid => None,
+        }
+    }
+}
+
+impl From<FdbError> for TypedLayerError {
+    fn from(e: FdbError) -> Self {
+        Self::Fdb(e)
+    }
+}
+
+impl From<FdbBindingError> for TypedLayerError {
+    fn from(e: FdbBindingError) -> Self {
+        Self::Binding(e)
+    }
+}
+
+impl RetryableError for TypedLayerError {}
+
+#[test]
+fn retry_decision_default_walk() {
+    let wrapped = TypedLayerError::Fdb(FdbError::from_code(1020));
+    match wrapped.retry_decision() {
+        RetryDecision::Fdb(e) => assert_eq!(e.code(), 1020),
+        other => panic!("expected Fdb decision, got {other:?}"),
+    }
+
+    let nested = TypedLayerError::Binding(FdbBindingError::from(FdbError::from_code(1020)));
+    match nested.retry_decision() {
+        RetryDecision::Fdb(e) => assert_eq!(e.code(), 1020),
+        other => panic!("expected Fdb decision, got {other:?}"),
+    }
+
+    match TypedLayerError::Invalid.retry_decision() {
+        RetryDecision::Fatal => {}
+        other => panic!("expected Fatal decision, got {other:?}"),
+    }
 }
 
 #[test]

--- a/foundationdb/tests/error.rs
+++ b/foundationdb/tests/error.rs
@@ -1,4 +1,7 @@
-use foundationdb::FdbBindingError;
+use foundationdb::directory::DirectoryError;
+use foundationdb::tuple::hca::HcaError;
+use foundationdb::{FdbBindingError, FdbError};
+use std::fmt;
 
 #[test]
 // This test is here because I'm always creating infinite recursion on Display and Debug impl 🤦
@@ -8,4 +11,58 @@ fn test_debug_display_trait() {
     let error = FdbBindingError::ReferenceToTransactionKept;
     println!("{error}");
     println!("{error:?}");
+}
+
+/// A typical layer error wrapping an FdbError as its source, like a
+/// thiserror enum with `#[source]`/`#[from]` would.
+#[derive(Debug)]
+struct LayerError {
+    source: FdbError,
+}
+
+impl fmt::Display for LayerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "layer error: {}", self.source)
+    }
+}
+
+impl std::error::Error for LayerError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+#[test]
+fn get_fdb_error_walks_source_chain() {
+    let layer_err = LayerError {
+        source: FdbError::from_code(1020),
+    };
+    let err = FdbBindingError::new_custom_error(Box::new(layer_err));
+    assert_eq!(err.get_fdb_error().map(|e| e.code()), Some(1020));
+}
+
+#[test]
+fn get_fdb_error_finds_nested_directory_hca() {
+    let err = FdbBindingError::from(DirectoryError::HcaError(HcaError::FdbError(
+        FdbError::from_code(1020),
+    )));
+    assert_eq!(err.get_fdb_error().map(|e| e.code()), Some(1020));
+}
+
+#[test]
+fn get_fdb_error_boxed_binding_error() {
+    let inner = FdbBindingError::from(FdbError::from_code(1020));
+    let err = FdbBindingError::new_custom_error(Box::new(inner));
+    assert_eq!(err.get_fdb_error().map(|e| e.code()), Some(1020));
+}
+
+#[test]
+fn stringified_error_has_no_fdb_error() {
+    // Stringifying an error destroys the source chain: there is no FdbError
+    // to recover from a String, so such errors are never retried.
+    let layer_err = LayerError {
+        source: FdbError::from_code(1020),
+    };
+    let err = FdbBindingError::CustomError(layer_err.to_string().into());
+    assert!(err.get_fdb_error().is_none());
 }

--- a/foundationdb/tests/leader_election.rs
+++ b/foundationdb/tests/leader_election.rs
@@ -31,7 +31,7 @@ mod leader_election_tests {
         let to_ref = &to;
         db.run(|txn, _| async move {
             txn.clear_range(from_ref, to_ref);
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -49,7 +49,7 @@ mod leader_election_tests {
         let election_ref = &election;
         db.run(|txn, _| async move {
             election_ref.initialize(&txn).await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -59,7 +59,7 @@ mod leader_election_tests {
             election_ref
                 .register_candidate(&txn, process_id, 0, current_time())
                 .await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -70,7 +70,7 @@ mod leader_election_tests {
                 let result = election_ref
                     .try_claim_leadership(&txn, process_id, 0, current_time())
                     .await?;
-                Ok(result.is_some())
+                Ok::<_, FdbBindingError>(result.is_some())
             })
             .await?;
         assert!(
@@ -85,7 +85,7 @@ mod leader_election_tests {
                 let is_leader = election_ref
                     .is_leader(&txn, process_id, current_time())
                     .await?;
-                Ok(is_leader)
+                Ok::<_, FdbBindingError>(is_leader)
             })
             .await?;
         assert!(is_leader, "Process should be the leader");
@@ -103,7 +103,7 @@ mod leader_election_tests {
         let election_ref = &election;
         db.run(|txn, _| async move {
             election_ref.initialize(&txn).await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -114,7 +114,7 @@ mod leader_election_tests {
                 election_ref
                     .register_candidate(&txn, process_id, 0, current_time())
                     .await?;
-                Ok(())
+                Ok::<_, FdbBindingError>(())
             })
             .await?;
         }
@@ -128,7 +128,7 @@ mod leader_election_tests {
                     let result = election_ref
                         .try_claim_leadership(&txn, process_id, 0, current_time())
                         .await?;
-                    Ok(result.is_some())
+                    Ok::<_, FdbBindingError>(result.is_some())
                 })
                 .await?;
             if became_leader {
@@ -147,7 +147,7 @@ mod leader_election_tests {
                 let is_leader = election_ref
                     .is_leader(&txn, leader_id, current_time())
                     .await?;
-                Ok(is_leader)
+                Ok::<_, FdbBindingError>(is_leader)
             })
             .await?;
         assert!(
@@ -164,7 +164,7 @@ mod leader_election_tests {
                         let is_leader = election_ref
                             .is_leader(&txn, process_id, current_time())
                             .await?;
-                        Ok(is_leader)
+                        Ok::<_, FdbBindingError>(is_leader)
                     })
                     .await?;
                 assert!(!is_leader, "Non-leader process should not be leader");
@@ -191,7 +191,7 @@ mod leader_election_tests {
             let config = config.clone();
             async move {
                 election_ref.initialize_with_config(&txn, config).await?;
-                Ok(())
+                Ok::<_, FdbBindingError>(())
             }
         })
         .await?;
@@ -202,7 +202,7 @@ mod leader_election_tests {
             election_ref
                 .register_candidate(&txn, leader_id, 0, current_time())
                 .await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -211,7 +211,7 @@ mod leader_election_tests {
             election_ref
                 .register_candidate(&txn, follower_id, 0, current_time())
                 .await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -222,7 +222,7 @@ mod leader_election_tests {
                 let result = election_ref
                     .try_claim_leadership(&txn, leader_id, 0, current_time())
                     .await?;
-                Ok(result.is_some())
+                Ok::<_, FdbBindingError>(result.is_some())
             })
             .await?;
         assert!(became_leader, "First process should become leader");
@@ -234,7 +234,7 @@ mod leader_election_tests {
                 let result = election_ref
                     .refresh_lease(&txn, leader_id, current_time())
                     .await?;
-                Ok(result.is_some())
+                Ok::<_, FdbBindingError>(result.is_some())
             })
             .await?;
         assert!(refreshed, "Leader should be able to refresh lease");
@@ -249,7 +249,7 @@ mod leader_election_tests {
                 let result = election_ref
                     .refresh_lease(&txn, leader_id, current_time())
                     .await?;
-                Ok(result.is_some())
+                Ok::<_, FdbBindingError>(result.is_some())
             })
             .await?;
         assert!(still_leader, "Leader should still be able to refresh");
@@ -274,7 +274,7 @@ mod leader_election_tests {
             let config = config.clone();
             async move {
                 election_ref.initialize_with_config(&txn, config).await?;
-                Ok(())
+                Ok::<_, FdbBindingError>(())
             }
         })
         .await?;
@@ -285,7 +285,7 @@ mod leader_election_tests {
             election_ref
                 .register_candidate(&txn, initial_leader, 0, current_time())
                 .await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -294,7 +294,7 @@ mod leader_election_tests {
             election_ref
                 .register_candidate(&txn, new_leader, 0, current_time())
                 .await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -305,7 +305,7 @@ mod leader_election_tests {
                 let result = election_ref
                     .try_claim_leadership(&txn, initial_leader, 0, current_time())
                     .await?;
-                Ok(result.is_some())
+                Ok::<_, FdbBindingError>(result.is_some())
             })
             .await?;
         assert!(became_leader, "Initial process should become leader");
@@ -317,7 +317,7 @@ mod leader_election_tests {
                 let result = election_ref
                     .try_claim_leadership(&txn, new_leader, 0, current_time())
                     .await?;
-                Ok(result.is_some())
+                Ok::<_, FdbBindingError>(result.is_some())
             })
             .await?;
         assert!(
@@ -334,7 +334,7 @@ mod leader_election_tests {
             election_ref
                 .heartbeat_candidate(&txn, new_leader, 0, current_time())
                 .await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -345,7 +345,7 @@ mod leader_election_tests {
                 let result = election_ref
                     .try_claim_leadership(&txn, new_leader, 0, current_time())
                     .await?;
-                Ok(result.is_some())
+                Ok::<_, FdbBindingError>(result.is_some())
             })
             .await?;
         assert!(
@@ -360,7 +360,7 @@ mod leader_election_tests {
                 let is_leader = election_ref
                     .is_leader(&txn, new_leader, current_time())
                     .await?;
-                Ok(is_leader)
+                Ok::<_, FdbBindingError>(is_leader)
             })
             .await?;
         assert!(is_leader, "New process should be confirmed as leader");
@@ -372,7 +372,7 @@ mod leader_election_tests {
                 let is_leader = election_ref
                     .is_leader(&txn, initial_leader, current_time())
                     .await?;
-                Ok(is_leader)
+                Ok::<_, FdbBindingError>(is_leader)
             })
             .await?;
         assert!(!is_leader, "Initial process should no longer be leader");
@@ -389,7 +389,7 @@ mod leader_election_tests {
         let election_ref = &election;
         db.run(|txn, _| async move {
             election_ref.initialize(&txn).await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -404,7 +404,7 @@ mod leader_election_tests {
             let config = new_config.clone();
             async move {
                 election_ref.write_config(&txn, &config).await?;
-                Ok(())
+                Ok::<_, FdbBindingError>(())
             }
         })
         .await?;
@@ -417,8 +417,8 @@ mod leader_election_tests {
                     .register_candidate(&txn, "test-process", 0, current_time())
                     .await
                 {
-                    Err(_) => Ok(true), // Registration failed as expected
-                    Ok(_) => Ok(false), // Registration succeeded unexpectedly
+                    Err(_) => Ok::<_, FdbBindingError>(true), // Registration failed as expected
+                    Ok(_) => Ok(false),                       // Registration succeeded unexpectedly
                 }
             })
             .await?;
@@ -439,7 +439,7 @@ mod leader_election_tests {
             let config = enabled_config.clone();
             async move {
                 election_ref.write_config(&txn, &config).await?;
-                Ok(())
+                Ok::<_, FdbBindingError>(())
             }
         })
         .await?;
@@ -450,7 +450,7 @@ mod leader_election_tests {
             election_ref
                 .register_candidate(&txn, "test-process", 0, current_time())
                 .await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -468,7 +468,7 @@ mod leader_election_tests {
         let election_ref = &election;
         db.run(|txn, _| async move {
             election_ref.initialize(&txn).await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -478,7 +478,7 @@ mod leader_election_tests {
             election_ref
                 .register_candidate(&txn, leader_id, 0, current_time())
                 .await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -487,7 +487,7 @@ mod leader_election_tests {
             election_ref
                 .register_candidate(&txn, follower_id, 0, current_time())
                 .await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -497,7 +497,7 @@ mod leader_election_tests {
             election_ref
                 .try_claim_leadership(&txn, leader_id, 0, current_time())
                 .await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -506,7 +506,7 @@ mod leader_election_tests {
         let resigned = db
             .run(|txn, _| async move {
                 let resigned = election_ref.resign_leadership(&txn, leader_id).await?;
-                Ok(resigned)
+                Ok::<_, FdbBindingError>(resigned)
             })
             .await?;
         assert!(resigned, "Leader should be able to resign");
@@ -518,7 +518,7 @@ mod leader_election_tests {
                 let result = election_ref
                     .try_claim_leadership(&txn, follower_id, 0, current_time())
                     .await?;
-                Ok(result.is_some())
+                Ok::<_, FdbBindingError>(result.is_some())
             })
             .await?;
         assert!(
@@ -547,7 +547,7 @@ mod leader_election_tests {
             let config = config.clone();
             async move {
                 election_ref.initialize_with_config(&txn, config).await?;
-                Ok(())
+                Ok::<_, FdbBindingError>(())
             }
         })
         .await?;
@@ -558,7 +558,7 @@ mod leader_election_tests {
             election_ref
                 .register_candidate(&txn, low_priority, 1, current_time())
                 .await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -567,7 +567,7 @@ mod leader_election_tests {
             election_ref
                 .register_candidate(&txn, high_priority, 10, current_time())
                 .await?;
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await?;
 
@@ -578,7 +578,7 @@ mod leader_election_tests {
                 let result = election_ref
                     .try_claim_leadership(&txn, low_priority, 1, current_time())
                     .await?;
-                Ok(result.is_some())
+                Ok::<_, FdbBindingError>(result.is_some())
             })
             .await?;
         assert!(became_leader, "Low priority should become leader initially");
@@ -590,7 +590,7 @@ mod leader_election_tests {
                 let result = election_ref
                     .try_claim_leadership(&txn, high_priority, 10, current_time())
                     .await?;
-                Ok(result.is_some())
+                Ok::<_, FdbBindingError>(result.is_some())
             })
             .await?;
         assert!(
@@ -605,7 +605,7 @@ mod leader_election_tests {
                 let is_leader = election_ref
                     .is_leader(&txn, high_priority, current_time())
                     .await?;
-                Ok(is_leader)
+                Ok::<_, FdbBindingError>(is_leader)
             })
             .await?;
         assert!(is_leader, "High priority should be the leader");
@@ -617,7 +617,7 @@ mod leader_election_tests {
                 let is_leader = election_ref
                     .is_leader(&txn, low_priority, current_time())
                     .await?;
-                Ok(is_leader)
+                Ok::<_, FdbBindingError>(is_leader)
             })
             .await?;
         assert!(!is_leader, "Low priority should not be the leader anymore");

--- a/foundationdb/tests/metrics.rs
+++ b/foundationdb/tests/metrics.rs
@@ -19,7 +19,7 @@ async fn instrumented_run_success() -> FdbResult<()> {
     let (result, metrics) = match db
         .instrumented_run(|txn, _| async move {
             txn.set(KEY, VALUE);
-            Ok(SUCCESS)
+            Ok::<_, FdbBindingError>(SUCCESS)
         })
         .await
     {
@@ -319,7 +319,7 @@ async fn test_transaction_info() -> FdbResult<()> {
             .instrumented_run(|txn, _| async move {
                 // Perform a write operation
                 txn.set(b"test_commit_version", b"value");
-                Ok(())
+                Ok::<_, FdbBindingError>(())
             })
             .await
             .expect("Transaction failed");
@@ -394,7 +394,7 @@ async fn test_time_metrics() -> FdbResult<()> {
                 }
                 // Read some data to add more execution time
                 let _ = txn.get(b"test_time_metrics_0", false).await?;
-                Ok(())
+                Ok::<_, FdbBindingError>(())
             })
             .await
             .expect("Transaction failed");

--- a/foundationdb/tests/ranked_register.rs
+++ b/foundationdb/tests/ranked_register.rs
@@ -9,8 +9,10 @@ mod common;
 
 #[cfg(feature = "recipes-ranked-register")]
 mod ranked_register_tests {
+    use std::sync::atomic::{AtomicU8, Ordering};
+
     use foundationdb::{
-        Database,
+        Database, FdbBindingError, FdbError,
         recipes::ranked_register::{Rank, RankedRegister, RankedRegisterError, WriteResult},
         tuple::Subspace,
     };
@@ -260,5 +262,60 @@ mod ranked_register_tests {
         assert_eq!(result, WriteResult::Committed);
 
         Ok(())
+    }
+
+    /// Regression freezing the old anti-pattern this file used to demonstrate:
+    /// stringifying an error into CustomError destroys the source chain, so
+    /// even the chain-walking retry detection cannot rescue it. A retryable
+    /// FdbError flattened to a String is fatal; that is correct, documented
+    /// behavior, and the fix is rewriting the wrapping (as the helpers above
+    /// now do), not the detection.
+    #[tokio::test]
+    async fn stringified_error_is_not_retried() {
+        let db = crate::common::database().await.expect("failed to open db");
+        let attempt = AtomicU8::new(0);
+        let attempt_ref = &attempt;
+
+        let result: Result<(), FdbBindingError> = db
+            .run(|_txn, _| async move {
+                attempt_ref.fetch_add(1, Ordering::SeqCst);
+                let err = RankedRegisterError::Fdb(FdbError::from_code(1020));
+                Err(FdbBindingError::CustomError(err.to_string().into()))
+            })
+            .await;
+
+        assert!(result.is_err(), "stringified errors must stay fatal");
+        assert_eq!(
+            attempt.load(Ordering::SeqCst),
+            1,
+            "a stringified retryable error must not be retried"
+        );
+    }
+
+    /// With the blessed pattern, a retryable FdbError injected through the
+    /// recipe's own error type is retried and the operation completes.
+    #[tokio::test]
+    async fn injected_fdb_error_retries_through_recipe_error() {
+        let db = crate::common::database().await.expect("failed to open db");
+        let rr = setup_test(&db, "test_injected_retry")
+            .await
+            .expect("setup failed");
+        let attempt = AtomicU8::new(0);
+        let attempt_ref = &attempt;
+
+        let rr_ref = &rr;
+        let result = db
+            .run(|txn, _| async move {
+                if attempt_ref.fetch_add(1, Ordering::SeqCst) == 0 {
+                    return Err(RankedRegisterError::Fdb(FdbError::from_code(1020)));
+                }
+                let r = rr_ref.write(&txn, Rank::from(1u64), b"retried").await?;
+                Ok(r)
+            })
+            .await
+            .expect("injected retryable error must be retried");
+
+        assert_eq!(result, WriteResult::Committed);
+        assert!(attempt.load(Ordering::SeqCst) >= 2);
     }
 }

--- a/foundationdb/tests/ranked_register.rs
+++ b/foundationdb/tests/ranked_register.rs
@@ -10,12 +10,19 @@ mod common;
 #[cfg(feature = "recipes-ranked-register")]
 mod ranked_register_tests {
     use foundationdb::{
-        Database, FdbBindingError,
-        recipes::ranked_register::{Rank, RankedRegister, WriteResult},
+        Database,
+        recipes::ranked_register::{Rank, RankedRegister, RankedRegisterError, WriteResult},
         tuple::Subspace,
     };
 
-    async fn setup_test(db: &Database, test_name: &str) -> Result<RankedRegister, FdbBindingError> {
+    // RankedRegisterError implements RetryableError, so closures return it
+    // directly with plain `?` and the retry loop still recognizes wrapped
+    // FdbErrors through the source chain.
+
+    async fn setup_test(
+        db: &Database,
+        test_name: &str,
+    ) -> Result<RankedRegister, RankedRegisterError> {
         let subspace = Subspace::all().subspace(&test_name);
         let (from, to) = subspace.range();
 
@@ -23,7 +30,7 @@ mod ranked_register_tests {
         let to_ref = &to;
         db.run(|txn, _| async move {
             txn.clear_range(from_ref, to_ref);
-            Ok(())
+            Ok::<_, RankedRegisterError>(())
         })
         .await?;
 
@@ -31,7 +38,7 @@ mod ranked_register_tests {
     }
 
     #[tokio::test]
-    async fn test_basic_write_and_read() -> Result<(), FdbBindingError> {
+    async fn test_basic_write_and_read() -> Result<(), RankedRegisterError> {
         let db = crate::common::database().await?;
         let rr = setup_test(&db, "test_basic_write_and_read").await?;
 
@@ -39,13 +46,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let result = db
             .run(|txn, _| async move {
-                let r = rr_ref
-                    .write(&txn, Rank::from(1u64), b"hello")
-                    .await
-                    .map_err(|e| {
-                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                    })?;
-                Ok(r)
+                let r = rr_ref.write(&txn, Rank::from(1u64), b"hello").await?;
+                Ok::<_, RankedRegisterError>(r)
             })
             .await?;
         assert_eq!(result, WriteResult::Committed);
@@ -54,10 +56,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let read_result = db
             .run(|txn, _| async move {
-                let r = rr_ref.read(&txn, Rank::from(2u64)).await.map_err(|e| {
-                    foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                })?;
-                Ok((r.write_rank(), r.into_value()))
+                let r = rr_ref.read(&txn, Rank::from(2u64)).await?;
+                Ok::<_, RankedRegisterError>((r.write_rank(), r.into_value()))
             })
             .await?;
         assert_eq!(read_result.0, Rank::from(1u64));
@@ -67,18 +67,15 @@ mod ranked_register_tests {
     }
 
     #[tokio::test]
-    async fn test_rank_fencing() -> Result<(), FdbBindingError> {
+    async fn test_rank_fencing() -> Result<(), RankedRegisterError> {
         let db = crate::common::database().await?;
         let rr = setup_test(&db, "test_rank_fencing").await?;
 
         // Read with rank 10 installs a fence
         let rr_ref = &rr;
         db.run(|txn, _| async move {
-            rr_ref
-                .read(&txn, Rank::from(10u64))
-                .await
-                .map_err(|e| foundationdb::FdbBindingError::CustomError(e.to_string().into()))?;
-            Ok(())
+            rr_ref.read(&txn, Rank::from(10u64)).await?;
+            Ok::<_, RankedRegisterError>(())
         })
         .await?;
 
@@ -86,13 +83,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let result = db
             .run(|txn, _| async move {
-                let r = rr_ref
-                    .write(&txn, Rank::from(5u64), b"blocked")
-                    .await
-                    .map_err(|e| {
-                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                    })?;
-                Ok(r)
+                let r = rr_ref.write(&txn, Rank::from(5u64), b"blocked").await?;
+                Ok::<_, RankedRegisterError>(r)
             })
             .await?;
         assert_eq!(result, WriteResult::Aborted);
@@ -101,13 +93,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let result = db
             .run(|txn, _| async move {
-                let r = rr_ref
-                    .write(&txn, Rank::from(10u64), b"accepted")
-                    .await
-                    .map_err(|e| {
-                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                    })?;
-                Ok(r)
+                let r = rr_ref.write(&txn, Rank::from(10u64), b"accepted").await?;
+                Ok::<_, RankedRegisterError>(r)
             })
             .await?;
         assert_eq!(result, WriteResult::Committed);
@@ -116,7 +103,7 @@ mod ranked_register_tests {
     }
 
     #[tokio::test]
-    async fn test_write_ordering() -> Result<(), FdbBindingError> {
+    async fn test_write_ordering() -> Result<(), RankedRegisterError> {
         let db = crate::common::database().await?;
         let rr = setup_test(&db, "test_write_ordering").await?;
 
@@ -124,13 +111,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let result = db
             .run(|txn, _| async move {
-                let r = rr_ref
-                    .write(&txn, Rank::from(1u64), b"A")
-                    .await
-                    .map_err(|e| {
-                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                    })?;
-                Ok(r)
+                let r = rr_ref.write(&txn, Rank::from(1u64), b"A").await?;
+                Ok::<_, RankedRegisterError>(r)
             })
             .await?;
         assert_eq!(result, WriteResult::Committed);
@@ -139,13 +121,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let result = db
             .run(|txn, _| async move {
-                let r = rr_ref
-                    .write(&txn, Rank::from(2u64), b"B")
-                    .await
-                    .map_err(|e| {
-                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                    })?;
-                Ok(r)
+                let r = rr_ref.write(&txn, Rank::from(2u64), b"B").await?;
+                Ok::<_, RankedRegisterError>(r)
             })
             .await?;
         assert_eq!(result, WriteResult::Committed);
@@ -154,10 +131,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let read_result = db
             .run(|txn, _| async move {
-                let r = rr_ref.read(&txn, Rank::from(3u64)).await.map_err(|e| {
-                    foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                })?;
-                Ok(r.into_value())
+                let r = rr_ref.read(&txn, Rank::from(3u64)).await?;
+                Ok::<_, RankedRegisterError>(r.into_value())
             })
             .await?;
         assert_eq!(read_result.as_deref(), Some(b"B".as_slice()));
@@ -166,13 +141,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let result = db
             .run(|txn, _| async move {
-                let r = rr_ref
-                    .write(&txn, Rank::from(1u64), b"C")
-                    .await
-                    .map_err(|e| {
-                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                    })?;
-                Ok(r)
+                let r = rr_ref.write(&txn, Rank::from(1u64), b"C").await?;
+                Ok::<_, RankedRegisterError>(r)
             })
             .await?;
         assert_eq!(result, WriteResult::Aborted);
@@ -181,7 +151,7 @@ mod ranked_register_tests {
     }
 
     #[tokio::test]
-    async fn test_stale_write_rejected() -> Result<(), FdbBindingError> {
+    async fn test_stale_write_rejected() -> Result<(), RankedRegisterError> {
         let db = crate::common::database().await?;
         let rr = setup_test(&db, "test_stale_write_rejected").await?;
 
@@ -189,13 +159,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let result = db
             .run(|txn, _| async move {
-                let r = rr_ref
-                    .write(&txn, Rank::from(5u64), b"initial")
-                    .await
-                    .map_err(|e| {
-                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                    })?;
-                Ok(r)
+                let r = rr_ref.write(&txn, Rank::from(5u64), b"initial").await?;
+                Ok::<_, RankedRegisterError>(r)
             })
             .await?;
         assert_eq!(result, WriteResult::Committed);
@@ -203,11 +168,8 @@ mod ranked_register_tests {
         // Read with rank 10 installs fence
         let rr_ref = &rr;
         db.run(|txn, _| async move {
-            rr_ref
-                .read(&txn, Rank::from(10u64))
-                .await
-                .map_err(|e| foundationdb::FdbBindingError::CustomError(e.to_string().into()))?;
-            Ok(())
+            rr_ref.read(&txn, Rank::from(10u64)).await?;
+            Ok::<_, RankedRegisterError>(())
         })
         .await?;
 
@@ -216,13 +178,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let result = db
             .run(|txn, _| async move {
-                let r = rr_ref
-                    .write(&txn, Rank::from(7u64), b"stale")
-                    .await
-                    .map_err(|e| {
-                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                    })?;
-                Ok(r)
+                let r = rr_ref.write(&txn, Rank::from(7u64), b"stale").await?;
+                Ok::<_, RankedRegisterError>(r)
             })
             .await?;
         assert_eq!(result, WriteResult::Aborted);
@@ -231,18 +188,15 @@ mod ranked_register_tests {
     }
 
     #[tokio::test]
-    async fn test_follower_value_read() -> Result<(), FdbBindingError> {
+    async fn test_follower_value_read() -> Result<(), RankedRegisterError> {
         let db = crate::common::database().await?;
         let rr = setup_test(&db, "test_follower_value_read").await?;
 
         // Write with rank 5
         let rr_ref = &rr;
         db.run(|txn, _| async move {
-            rr_ref
-                .write(&txn, Rank::from(5u64), b"X")
-                .await
-                .map_err(|e| foundationdb::FdbBindingError::CustomError(e.to_string().into()))?;
-            Ok(())
+            rr_ref.write(&txn, Rank::from(5u64), b"X").await?;
+            Ok::<_, RankedRegisterError>(())
         })
         .await?;
 
@@ -250,10 +204,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let val = db
             .run(|txn, _| async move {
-                let v = rr_ref.value(&txn).await.map_err(|e| {
-                    foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                })?;
-                Ok(v)
+                let v = rr_ref.value(&txn).await?;
+                Ok::<_, RankedRegisterError>(v)
             })
             .await?;
         assert_eq!(val.as_deref(), Some(b"X".as_slice()));
@@ -262,13 +214,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let result = db
             .run(|txn, _| async move {
-                let r = rr_ref
-                    .write(&txn, Rank::from(10u64), b"Y")
-                    .await
-                    .map_err(|e| {
-                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                    })?;
-                Ok(r)
+                let r = rr_ref.write(&txn, Rank::from(10u64), b"Y").await?;
+                Ok::<_, RankedRegisterError>(r)
             })
             .await?;
         assert_eq!(result, WriteResult::Committed);
@@ -277,7 +224,7 @@ mod ranked_register_tests {
     }
 
     #[tokio::test]
-    async fn test_empty_register() -> Result<(), FdbBindingError> {
+    async fn test_empty_register() -> Result<(), RankedRegisterError> {
         let db = crate::common::database().await?;
         let rr = setup_test(&db, "test_empty_register").await?;
 
@@ -285,10 +232,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let read_result = db
             .run(|txn, _| async move {
-                let r = rr_ref.read(&txn, Rank::from(1u64)).await.map_err(|e| {
-                    foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                })?;
-                Ok((r.write_rank(), r.into_value()))
+                let r = rr_ref.read(&txn, Rank::from(1u64)).await?;
+                Ok::<_, RankedRegisterError>((r.write_rank(), r.into_value()))
             })
             .await?;
         assert_eq!(read_result.0, Rank::ZERO);
@@ -298,10 +243,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let val = db
             .run(|txn, _| async move {
-                let v = rr_ref.value(&txn).await.map_err(|e| {
-                    foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                })?;
-                Ok(v)
+                let v = rr_ref.value(&txn).await?;
+                Ok::<_, RankedRegisterError>(v)
             })
             .await?;
         assert_eq!(val, None);
@@ -310,13 +253,8 @@ mod ranked_register_tests {
         let rr_ref = &rr;
         let result = db
             .run(|txn, _| async move {
-                let r = rr_ref
-                    .write(&txn, Rank::from(1u64), b"first")
-                    .await
-                    .map_err(|e| {
-                        foundationdb::FdbBindingError::CustomError(e.to_string().into())
-                    })?;
-                Ok(r)
+                let r = rr_ref.write(&txn, Rank::from(1u64), b"first").await?;
+                Ok::<_, RankedRegisterError>(r)
             })
             .await?;
         assert_eq!(result, WriteResult::Committed);

--- a/foundationdb/tests/run_retry.rs
+++ b/foundationdb/tests/run_retry.rs
@@ -1,0 +1,202 @@
+// Copyright 2026 foundationdb-rs developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Retry behavior of `Database::run` for closure errors that wrap an
+//! FdbError, request an app-level retry, or are fatal (#479).
+
+use std::fmt;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use foundationdb::{FdbBindingError, FdbError, RetryDecision, RetryableError, options};
+
+mod common;
+
+/// A layer error keeping the FdbError as its source, like a thiserror enum
+/// with `#[source]`/`#[from]` would.
+#[derive(Debug)]
+struct WrappedFdbError {
+    source: FdbError,
+}
+
+impl fmt::Display for WrappedFdbError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "layer error: {}", self.source)
+    }
+}
+
+impl std::error::Error for WrappedFdbError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+/// A typed layer error with an app-level retry condition.
+#[derive(Debug)]
+enum RetryTestError {
+    /// App-level retry request, no native error underneath.
+    NeedsRetry,
+    /// A domain error with no FdbError anywhere in its chain.
+    InvalidDocument,
+    Fdb(FdbError),
+    Binding(FdbBindingError),
+}
+
+impl fmt::Display for RetryTestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for RetryTestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Fdb(e) => Some(e),
+            Self::Binding(e) => Some(e),
+            Self::NeedsRetry | Self::InvalidDocument => None,
+        }
+    }
+}
+
+impl From<FdbError> for RetryTestError {
+    fn from(e: FdbError) -> Self {
+        Self::Fdb(e)
+    }
+}
+
+impl From<FdbBindingError> for RetryTestError {
+    fn from(e: FdbBindingError) -> Self {
+        Self::Binding(e)
+    }
+}
+
+impl RetryableError for RetryTestError {
+    fn retry_decision(&self) -> RetryDecision {
+        match self {
+            Self::NeedsRetry => RetryDecision::Retry,
+            Self::Fdb(e) => RetryDecision::Fdb(*e),
+            Self::InvalidDocument | Self::Binding(_) => RetryDecision::Fatal,
+        }
+    }
+}
+
+/// The end-to-end regression for #479: a retryable FdbError wrapped inside a
+/// layer error and boxed into CustomError is retried (port of the Go
+/// binding's TestErrorWrapping).
+#[tokio::test]
+async fn run_retries_wrapped_closure_error() {
+    let db = common::database().await.expect("failed to open database");
+    let attempt = AtomicU8::new(0);
+    let attempt_ref = &attempt;
+
+    let result = db
+        .run(|trx, _| async move {
+            if attempt_ref.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(FdbBindingError::new_custom_error(Box::new(
+                    WrappedFdbError {
+                        source: FdbError::from_code(1020),
+                    },
+                )));
+            }
+            trx.set(b"run_retry_wrapped", b"ok");
+            Ok(())
+        })
+        .await;
+
+    assert!(result.is_ok(), "wrapped retryable error must be retried");
+    assert_eq!(attempt.load(Ordering::SeqCst), 2);
+}
+
+/// Same regression through a typed closure error: the default source() walk
+/// makes the wrapped FdbError retryable and the caller gets the typed error
+/// back on fatal paths.
+#[tokio::test]
+async fn run_retries_typed_wrapped_error() {
+    let db = common::database().await.expect("failed to open database");
+    let attempt = AtomicU8::new(0);
+    let attempt_ref = &attempt;
+
+    let result = db
+        .run(|trx, _| async move {
+            if attempt_ref.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(RetryTestError::from(FdbError::from_code(1020)));
+            }
+            trx.set(b"run_retry_typed", b"ok");
+            Ok(())
+        })
+        .await;
+
+    assert!(result.is_ok(), "typed wrapped error must be retried");
+    assert_eq!(attempt.load(Ordering::SeqCst), 2);
+}
+
+/// RetryDecision::Retry re-runs the closure through on_error(1020).
+#[tokio::test]
+async fn run_retry_decision_reruns_closure() {
+    let db = common::database().await.expect("failed to open database");
+    let attempt = AtomicU8::new(0);
+    let attempt_ref = &attempt;
+
+    let result = db
+        .run(|trx, _| async move {
+            if attempt_ref.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(RetryTestError::NeedsRetry);
+            }
+            trx.set(b"run_retry_decision", b"ok");
+            Ok(())
+        })
+        .await;
+
+    assert!(result.is_ok(), "Retry decision must re-run the closure");
+    assert_eq!(attempt.load(Ordering::SeqCst), 2);
+}
+
+/// RetryDecision::Retry is governed by the C API retry budget: with
+/// RetryLimit(n) the closure runs n + 1 times and exhaustion returns the
+/// ORIGINAL typed error, not a synthetic FdbError.
+#[tokio::test]
+async fn run_retry_decision_honors_retry_limit() {
+    let db = common::database().await.expect("failed to open database");
+    let attempt = AtomicU8::new(0);
+    let attempt_ref = &attempt;
+    let retry_limit = 2;
+
+    let result: Result<(), RetryTestError> = db
+        .run(|trx, _| async move {
+            trx.set_option(options::TransactionOption::RetryLimit(retry_limit))?;
+            attempt_ref.fetch_add(1, Ordering::SeqCst);
+            Err(RetryTestError::NeedsRetry)
+        })
+        .await;
+
+    assert!(
+        matches!(result, Err(RetryTestError::NeedsRetry)),
+        "exhaustion must return the original typed error, got {result:?}"
+    );
+    assert_eq!(attempt.load(Ordering::SeqCst) as i32, retry_limit + 1);
+}
+
+/// An error with no FdbError in its chain is fatal: the closure runs exactly
+/// once and the caller gets the original error back.
+#[tokio::test]
+async fn run_typed_error_fatal_returns_original() {
+    let db = common::database().await.expect("failed to open database");
+    let attempt = AtomicU8::new(0);
+    let attempt_ref = &attempt;
+
+    let result: Result<(), RetryTestError> = db
+        .run(|_trx, _| async move {
+            attempt_ref.fetch_add(1, Ordering::SeqCst);
+            Err(RetryTestError::InvalidDocument)
+        })
+        .await;
+
+    assert!(
+        matches!(result, Err(RetryTestError::InvalidDocument)),
+        "fatal error must be returned as-is, got {result:?}"
+    );
+    assert_eq!(attempt.load(Ordering::SeqCst), 1);
+}

--- a/foundationdb/tests/runner_hooks.rs
+++ b/foundationdb/tests/runner_hooks.rs
@@ -16,7 +16,7 @@ async fn test_happy_path_instrumented() -> FdbResult<()> {
     let (result, metrics) = db
         .instrumented_run(|trx, _| async move {
             trx.set(b"test_runner_hooks_happy", b"value");
-            Ok(42u64)
+            Ok::<_, FdbBindingError>(42u64)
         })
         .await
         .expect("transaction should succeed");
@@ -62,7 +62,7 @@ async fn test_conflict_reports_in_metrics() -> FdbResult<()> {
                 }
 
                 trx.set(b"test_conflict_metrics_key", b"my_value");
-                Ok(())
+                Ok::<_, FdbBindingError>(())
             }
         })
         .await

--- a/foundationdb/tests/tokio.rs
+++ b/foundationdb/tests/tokio.rs
@@ -146,7 +146,7 @@ async fn do_run() {
             }
 
             // trying to commit
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await;
 
@@ -197,7 +197,7 @@ async fn do_run_with_transaction_limits() {
                 .await
                 .expect("cannot commit the conflict transaction");
 
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await;
 

--- a/foundationdb/tests/trace.rs
+++ b/foundationdb/tests/trace.rs
@@ -32,7 +32,7 @@ async fn test_traces_on_run() {
 
     db.run(|trx, _b| async move {
         trx.set("tracing".as_ref(), "ok".as_ref());
-        Ok(())
+        Ok::<_, FdbBindingError>(())
     })
     .await
     .expect("could not run transaction");
@@ -76,7 +76,7 @@ async fn test_traces_on_run() {
             if *new_val < 2 {
                 return Err(FdbError::from_code(1020).into());
             }
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
         .await;
     assert!(result.is_ok());
@@ -84,7 +84,7 @@ async fn test_traces_on_run() {
     // cleaning up
     db.run(|trx, _b| async move {
         trx.clear("tracing".as_ref());
-        Ok(())
+        Ok::<_, FdbBindingError>(())
     })
     .await
     .expect("could not run transaction");


### PR DESCRIPTION
Closes #479.

## What

Two pieces, as designed in the issue:

**Piece 1 (standalone fix).** `FdbBindingError`, `HcaError`, `DirectoryError`, `LeaderElectionError` and `RankedRegisterError` now implement `Error::source()`, and `get_fdb_error()` walks the source chain (with the original `CustomError` downcasts kept as the first hop, and a depth cap against cyclic chains). A layer error wrapping a retryable `FdbError` (the idiomatic thiserror `#[from]`/`#[source]` pattern) is now retried instead of silently returned. This matches the Go binding, which uses `errors.As` over `Unwrap()` chains. The walk also fixes the previously missed `DirectoryError::HcaError(HcaError::FdbError)` nesting.

**Piece 2 (breaking).** `Database::run`, `run_with_hooks` and `instrumented_run` are generic over the closure error type `E: RetryableError`, so layers pass their own error through the retry loop and get it back typed, without boxing into `CustomError` and downcasting on the way out.

`RetryableError::retry_decision()` classifies closure errors:
- `RetryDecision::Fdb(e)`: the error is, or wraps, this `FdbError`; handed to `on_error`, which stays the single retry governor (backoff, max retry delay, `RetryLimit`).
- `RetryDecision::Retry`: app-level retry request; routed through `on_error(1020)` (not_committed) so backoff and limits apply uniformly, `maybe_committed` untouched.
- `RetryDecision::Fatal`: returned to the caller as-is.

The default implementation is the source() walk, so idiomatic error enums are retry-transparent without overriding anything. On exhaustion or a non-retryable code the loop returns the original typed error, not a rebuilt one (Go parity; deliberate deviation from the issue text, which suggested `E::from(fdb_err)`).

## Breaking changes

- `run`/`run_with_hooks`/`instrumented_run` gained the type parameter `E: RetryableError`. Closures that never name an error type need one annotation, for example `Ok::<_, FdbBindingError>(value)`; existing closures typed with `FdbBindingError` keep compiling.
- `FdbBindingError` is `#[non_exhaustive]` (external matches need a wildcard arm; variant construction is unaffected). `RetryDecision` is born `#[non_exhaustive]`.
- `RankedRegisterError` gained a `Binding(FdbBindingError)` variant and implements `RetryableError`.

## Docs and examples

- `CustomError` doc warns that stringifying an error (`e.to_string().into()`) destroys the source chain and makes retryable errors fatal.
- `Database::run` documents the typed-error contract, the Retry semantics and the inference note.
- `examples/class-scheduling.rs` is rewritten as the blessed layer-error pattern (typed enum carrying `FdbError`/`FdbBindingError` as sources, `impl RetryableError`), replacing the convention-only guidance.
- `tests/ranked_register.rs` drops the error-stringifying anti-pattern for typed errors.

## Tests

- `tests/error.rs` (no cluster): source-chain walk, nested directory/hca recovery, boxed-binding first hop, stringified errors yield no `FdbError`, default `retry_decision` classification.
- `tests/run_retry.rs` (live cluster): wrapped retryable error retried through `CustomError` and through a typed closure error (port of Go's `TestErrorWrapping`); `Retry` re-runs the closure; `RetryLimit(2)` exhausts after exactly 3 attempts and surfaces the original typed error; fatal errors run exactly once.
- `tests/ranked_register.rs`: regression freezing the old stringify pattern as permanently fatal (correct, documented: there is no chain to walk into a String), and a retryable `FdbError` injected through the recipe's typed error is retried to completion.

Full sweep green: `cargo fmt --check`, `cargo clippy-all`, `cargo test-fdb-latest` (22 suites incl. doctests) against a live 7.4 cluster, `bindingtester` builds.

## Out of scope / follow-ups

- Retiring the legacy `transact`/`TransactError` family (coexists without conflict; separate issue after typed `run` has baked).
- Downstream adoption in layer SDKs (their runner wrappers still hardcode `FdbBindingError` and can go generic once this releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)