### PR TITLE
feat!: ballot-preserving resign, elapsed-time lease stealing, real mutex sim invariants

### DIFF
--- a/foundationdb-recipes-simulation/README.md
+++ b/foundationdb-recipes-simulation/README.md
@@ -44,7 +44,14 @@ Tests the leader election recipe with:
 **Configuration (TOML):**
 - `operationCount`: Number of heartbeat+leadership cycles per client (default: 50)
 - `heartbeatTimeoutSecs`: Lease duration in seconds (default: 10)
-- `resignProbability`: Probability of resigning after becoming leader (default: 0.2)
+- `resignProbability`: Probability of resigning after becoming leader (default: 0.1)
+- `allowPreemption`: Integer `0`/`1` (default: `1`). Set `0` to disable priority
+  preemption, which is required for the strict `NoBeliefOverlap` assertion.
+- `maxClockSkewSecs`: Override the randomized per-client clock skew with a fixed
+  one-sided bound in seconds. `0.0` disables skew entirely (local time equals
+  simulation time). When unset, each client gets a random skew tier.
+- `minLeadershipClaims` / `minHeartbeats`: Minimum successful operations a run
+  must produce for `ProgressMade` to pass (default: `1`, floored at `1`).
 
 **Test Configurations:**
 
@@ -54,47 +61,42 @@ Tests the leader election recipe with:
 | `test_ballot_stress.toml` | High contention test with rapid ballot transitions |
 | `test_rapid_leadership.toml` | Fast leadership turnover with high resign probability |
 | `test_short_lease.toml` | Short lease duration for timing edge cases |
+| `test_strict_mutex.toml` | Preemption off + zero skew: strict belief-overlap assertion under chaos |
 
-**Invariants Verified (13 total):**
+Note: a check-phase violation fails the simulation by emitting a
+`Severity::Error` trace (FDB tallies `SevError` events as failures); the check
+phase's return value alone does not signal failure. Every client runs the check
+against the shared operation log, so verification survives Attrition killing any
+single client.
 
-### Core Invariants (Foundational Safety)
+**Invariants Verified:**
 
-**1. DualPathValidation** - The keystone invariant using the "atomic ops pattern". Replays all logged operations in true FDB commit order (versionstamp-ordered keys) to compute expected leader state, then compares with the actual FDB snapshot. This single invariant subsumes both safety (at most one leader at a time) and ballot conservation (ballot matches claims). If the replayed state diverges from the database state, it indicates a bug in the leader election logic or logging.
+**1. DualPathValidation** - The keystone invariant. Replays all logged operations in true FDB commit order (versionstamp-ordered keys) to compute the expected leader identity and running ballot, then compares with the actual FDB snapshot. Subsumes both safety (at most one leader record) and ballot conservation. A resignation leaves a *vacant* record (no holder, ballot preserved), which the replay models as leaderless-but-ballot-preserved.
 
-**2. LeaderIsCandidate** - Validates structural integrity: the current leader must exist in the candidates list. This ensures leadership can only be claimed by registered candidates. Exception: if the leader's lease has expired, candidate eviction is valid (the candidate may have timed out).
+**2. LeaderIsCandidate** - The current active leader must exist in the candidate list. A vacant record (resigned) is skipped. If the leader's lease has expired, candidate eviction is valid.
 
-**3. CandidateTimestamps** - Clock skew detection: ensures no candidate has a heartbeat timestamp more than 3 seconds in the future. This tolerance accounts for extreme clock skew simulation (up to ±1s offset, 1s drift ahead, 1.1x jitter multiplier). Future timestamps beyond this threshold indicate clock handling bugs.
+**3. CandidateTimestamps** - No candidate heartbeat timestamp is implausibly in the future. The tolerance tracks the configured clock-skew bound (plus a small margin) and collapses toward zero in the strict configuration.
 
-**4. LeadershipSequence** - Validates log ordering: each client's operation numbers (`op_num`) must be strictly monotonically increasing. With versionstamp-ordered logging, this verifies the log entries are properly sequenced per client.
+**4. LeadershipSequence** - Each client's operation numbers (`op_num`) are strictly increasing.
 
-**5. RegistrationCoverage** - Protocol compliance: every client that successfully claimed leadership must have a prior registration entry in the log. This ensures the registration requirement of the leader election protocol is enforced.
+**5. RegistrationCoverage** - Every client that claimed leadership has a prior registration entry.
 
-### Split-Brain Detection
+**6. BallotSuccession** - Every successful leadership claim satisfies `ballot == previous_ballot + 1`, unconditionally. Because ballots are globally monotonic and never reset (resign preserves the ballot in a vacant record), this holds for first claims (`0 -> 1`), steals, preemptions, refreshes, and post-resign claims alike. Replaces the older per-tenure ballot invariants, which existed only to work around the ballot reset that the recipe no longer does.
 
-**6. NoOverlappingLeadership** - Ensures leadership claims have distinct versionstamps. Since FDB commits are serialized and each successful leadership claim commits atomically, versionstamp ordering guarantees sequential transitions. Duplicate versionstamps would indicate a logging bug. This invariant catches split-brain scenarios where two clients might incorrectly believe they are both leaders.
+**7. OneValuePerBallot** - Each ballot number maps to exactly one client, globally. Since ballots strictly increase across the whole run, a ballot claimed by two clients indicates broken conflict ranges or ballot-assignment logic.
 
-**7. BallotValueBinding** - Validates ballot progression within each claim: the new ballot must be greater than the previous ballot read in the same transaction. This ensures the fencing token mechanism is working correctly and prevents duplicate elections at the same ballot number.
+**8. LeaseExpiryAfterClaim** - Every successful claim has a lease that expires after its claim timestamp (catches lease-duration or clock bugs).
 
-### Timing and Ballot Bug Detection
+**9. NoBeliefOverlap** - Real mutual exclusion. A belief overlap can only be created by a *steal* (one client taking the leader record from a different client that neither resigned nor lost it), so the check walks the log in commit order and asserts that every steal lands after the victim's lease horizon (`victim_last_refresh + lease_duration`), within `2 * maxClockSkewSecs` plus a small floor. Resign -> vacant -> claim handoffs create no overlap and are not flagged. Only meaningful with preemption disabled (preemption deliberately steals a live lease; the fencing ballot, not the lease, provides safety there), so it reports an informational skip when `allowPreemption` is on. In `test_strict_mutex.toml` (zero skew, read-anchored timestamps) steals reliably land after the lease expires.
 
-**8. FencingTokenMonotonicity** - Ensures ballots never regress: each successful leadership claim must have `ballot > previous_ballot` (or `previous_ballot == 0` for first claims after system reset). This catches stale leader writes where an old leader might attempt to use an outdated fencing token.
-
-**9. GlobalBallotSuccession** - State machine safety: each new leader's ballot must be strictly greater than the predecessor's ballot. This invariant catches state regression bugs where the system might accept a lower ballot number.
-
-### Correctness
-
-**10. MutexLinearizability** - Leadership transfers must happen sequentially with at most one holder at a time in log order. In lease-based systems, a new leader claiming leadership implicitly ends the previous leader's tenure (lease expired or preempted). This tracks both explicit resigns and implicit releases to verify the leadership history linearizes to a valid mutex model.
-
-**11. LeaseOverlapCheck** - Validates each successful leadership claim has a positive, non-zero `lease_expiry_nanos`. This ensures every leader has a bounded lease duration, which is essential for the lease-based leadership protocol to function correctly.
-
-**12. OneValuePerBallot** - Paxos safety property within each tenure: each ballot number must map to exactly one client between ballot resets. The ballot resets to 0 after a resign, starting a new tenure. This catches broken conflict ranges or ballot assignment logic where two clients might somehow both claim the same ballot within the same tenure.
-
-**13. LeaseExpiryAfterClaim** - Validates that every successful leadership claim has a lease that expires AFTER the claim was made. This catches incorrect lease duration calculations, clock skew causing past-expiry leases, or missing lease assignments. Uses the logged `claim_timestamp_nanos` to verify `lease_expiry > claim_time`.
+**10. ProgressMade** - Guards against a vacuous pass: the log must be non-empty and the run must produce at least `minLeadershipClaims` successful claims and `minHeartbeats` successful heartbeats.
 
 ### Architecture Notes
 
-**Versionstamp-Ordered Logging**: All log entries use FDB versionstamp-ordered keys, providing true causal ordering based on actual FDB commit order rather than wall-clock time. This eliminates clock skew issues in log replay.
+**Versionstamp-Ordered Logging**: All log entries use FDB versionstamp-ordered keys, providing true causal ordering based on actual FDB commit order rather than wall-clock time. Each entry also records the unskewed simulation time (`context.now()`) at commit, used to reconstruct belief intervals without clock-skew contamination.
 
-**Dual-Path Validation Pattern**: The simulation uses a "dual-path" approach where one path replays the operation log to compute expected state, while the other path reads the actual FDB state. Comparing these two paths catches bugs that might only manifest under specific timing or failure conditions.
+**Dual-Path Validation Pattern**: The simulation replays the operation log to compute expected state and compares it against the actual FDB state, catching bugs that only manifest under specific timing or failure conditions.
 
-**Clock Skew Simulation**: The simulation injects extreme clock skew (up to 2.2s total deviation) to stress-test time-dependent logic like lease expiry handling.
+**Read-Anchored Timestamps**: The recipe measures its lease-observation window against a caller-supplied `current_time`. The workload samples that clock *inside* the claim transaction, after the leader read, rather than at loop-top. This matters because a stale, pre-transaction sample would let heartbeat/retry/clogging latency inflate the observed duration and cause spurious belief overlaps. This is also a real deployment note for the recipe: sample `current_time` close to the transaction, or belief-level exclusion can be under-counted (record-level exclusion and fencing are unaffected).
+
+**Clock Skew Simulation**: Each client gets a randomized skew tier (offset + drift + jitter, up to ~2.2s worst-case one-sided deviation) unless `maxClockSkewSecs` overrides it. Skew perturbs measured durations, so time-based invariants carry a matching tolerance; the strict configuration disables skew so `NoBeliefOverlap` asserts that every steal lands after the victim's lease has expired.

--- a/foundationdb-recipes-simulation/src/leader_election/helpers.rs
+++ b/foundationdb-recipes-simulation/src/leader_election/helpers.rs
@@ -29,8 +29,10 @@ impl LeaderElectionWorkload {
         let real_time = self.context.now();
 
         // 1. Apply FDB-style timer drift
-        // Timer moves partway toward (real_time + base_offset + max_drift)
-        let max_ahead = self.clock_skew_level.max_offset_secs();
+        // Timer moves partway toward (real_time + base_offset + max_drift).
+        // `clock_max_ahead` is 0 in the strict (zero-skew) config, which -
+        // together with a 0 offset - makes local_time collapse to real_time.
+        let max_ahead = self.clock_max_ahead;
         let target = real_time + self.clock_offset_secs + max_ahead;
         self.clock_timer_time += self.rnd_f64() * (target - self.clock_timer_time) / 2.0;
 

--- a/foundationdb-recipes-simulation/src/leader_election/invariants.rs
+++ b/foundationdb-recipes-simulation/src/leader_election/invariants.rs
@@ -1,32 +1,31 @@
 //! Invariant verification methods for leader election simulation.
 //!
-//! Contains the core leader election invariants:
-//! 1. Dual-Path Validation - Replay logs vs FDB state must match (safety + conservation)
-//! 2. Leader Is Candidate - Leader must be a registered candidate (structural integrity)
-//! 3. Candidate Timestamps - No future timestamps in candidates
-//! 4. Leadership Sequence - Per-client monotonic op_nums
-//! 5. Registration Coverage - All leadership claims come from registered processes
+//! The check phase replays the versionstamp-ordered operation log and compares
+//! it against the committed FDB state. Log entries are in true FDB commit order
+//! (versionstamp-ordered keys), so replay reflects real causal ordering.
 //!
-//! Additional invariants for split-brain, timing, and ballot bug detection:
-//! 6. No Overlapping Leadership - No two clients have active leadership periods that overlap
-//! 7. Ballot Value Binding - Each ballot maps to exactly one leader identity
-//! 8. Fencing Token Monotonicity - Ballot numbers increase monotonically across claims
-//! 9. Global Ballot Succession - Each new leader has ballot > previous leader's ballot
-//! 10. Mutex Linearizability - Leadership history linearizes to valid mutex model
-//! 11. Lease Overlap Check - Use lease_expiry_nanos to verify no active lease overlaps
-//! 12. One Value Per Ballot - Paxos safety: each ballot maps to one client within a tenure
-//! 13. Lease Expiry After Claim - Lease must expire after claim timestamp
+//! Invariants (all report failures via `Severity::Error` traces, which is what
+//! actually fails an FDB simulation):
 //!
-//! Note: Log entries are now in FDB commit order (versionstamp-ordered keys),
-//! so we have true causal ordering without clock skew issues.
+//! 1. **DualPathValidation** - Replayed log must match committed leader state
+//!    (subsumes safety + ballot conservation).
+//! 2. **LeaderIsCandidate** - An active leader must be a registered candidate.
+//! 3. **CandidateTimestamps** - No candidate heartbeat is implausibly in the future.
+//! 4. **LeadershipSequence** - Per-client op_nums are strictly increasing.
+//! 5. **RegistrationCoverage** - Every leader registered first.
+//! 6. **BallotSuccession** - Every successful claim has `ballot == previous_ballot + 1`.
+//! 7. **OneValuePerBallot** - Each ballot maps to exactly one client (globally).
+//! 8. **LeaseExpiryAfterClaim** - Each claim's lease expires after its claim time.
+//! 9. **NoBeliefOverlap** - With preemption disabled, no two clients' leadership
+//!    belief intervals overlap (in unskewed sim time) beyond the skew tolerance.
+//! 10. **ProgressMade** - The run actually elected leaders and heartbeated.
 
 use std::collections::BTreeMap;
 
-use foundationdb::tuple::Versionstamp;
-
 use super::LeaderElectionWorkload;
 use super::types::{
-    CheckResult, DatabaseSnapshot, LogEntries, OP_REGISTER, OP_RESIGN, OP_TRY_BECOME_LEADER,
+    CheckResult, DatabaseSnapshot, LogEntries, OP_HEARTBEAT, OP_REGISTER, OP_RESIGN,
+    OP_TRY_BECOME_LEADER,
 };
 
 impl LeaderElectionWorkload {
@@ -35,11 +34,12 @@ impl LeaderElectionWorkload {
     /// Replay log entries (in true FDB commit order via versionstamp keys)
     /// to compute expected leader state, then compare with actual FDB state.
     ///
-    /// This is the key insight: with versionstamp-ordered keys, we have TRUE
-    /// causal ordering, so replay gives us the exact expected state.
-    ///
     /// This invariant subsumes both safety (at most one leader) and ballot
     /// conservation (ballot matches claims) by verifying exact state equality.
+    ///
+    /// Ballots are globally monotonic: a resignation does NOT reset the ballot,
+    /// it leaves a vacant record that preserves it. So the replay tracks the
+    /// leader identity and the running ballot independently.
     pub(crate) fn verify_dual_path(
         &self,
         entries: &LogEntries,
@@ -51,20 +51,22 @@ impl LeaderElectionWorkload {
 
         for entry in entries {
             if entry.op_type == OP_TRY_BECOME_LEADER && entry.success && entry.became_leader {
-                expected_ballot += 1;
+                expected_ballot = entry.ballot;
                 expected_leader = Some(format!("process_{}", entry.client_id));
             }
             if entry.op_type == OP_RESIGN && entry.success {
                 let resigning = format!("process_{}", entry.client_id);
                 if expected_leader.as_ref() == Some(&resigning) {
+                    // Vacant record: no holder, but the ballot is preserved.
                     expected_leader = None;
-                    expected_ballot = 0; // Ballot resets after resign
                 }
             }
         }
 
-        // Path 2: Actual FDB state
+        // Path 2: Actual FDB state. A vacant record has no holder but a
+        // preserved ballot; a live record binds both.
         let (actual_leader, actual_ballot) = match &snapshot.leader_state {
+            Some(l) if l.is_vacant() => (None, l.ballot),
             Some(l) => (Some(l.leader_id.clone()), l.ballot),
             None => (None, 0),
         };
@@ -90,19 +92,19 @@ impl LeaderElectionWorkload {
 
     /// Invariant 2: Leader Is Candidate - Structural Integrity
     ///
-    /// The current leader must be in the candidate list.
-    /// This verifies the data structure invariant that leadership
-    /// can only be claimed by registered candidates.
-    ///
-    /// NOTE: If the leader's lease has expired, the candidate may have been
-    /// evicted due to timeout. This is valid - we only enforce this invariant
-    /// for leaders with active leases.
+    /// An active leader must be in the candidate list. A vacant record (left by
+    /// a resignation) has no holder and is skipped. If the leader's lease has
+    /// expired, the candidate may have been evicted, which is valid.
     pub(crate) fn verify_leader_is_candidate(
         &self,
         snapshot: &DatabaseSnapshot,
         current_time: f64,
     ) -> (bool, String) {
         match &snapshot.leader_state {
+            Some(leader) if leader.is_vacant() => (
+                true,
+                "Vacant record (resigned), no active leader".to_string(),
+            ),
             Some(leader) => {
                 // Check if lease has expired - if so, candidate eviction is valid
                 let lease_expiry_secs = leader.lease_expiry_nanos as f64 / 1_000_000_000.0;
@@ -150,16 +152,10 @@ impl LeaderElectionWorkload {
 
     /// Invariant 3: Candidate Timestamps - No Future Timestamps
     ///
-    /// All candidate heartbeat timestamps should be in the past or present,
-    /// not in the future. Future timestamps would indicate clock skew issues
-    /// or bugs in timestamp handling.
-    ///
-    /// With clock skew simulation enabled, we allow tolerance for:
-    ///   - clock_offset: up to ±1.0s (Extreme level)
-    ///   - drift ahead: up to 1.0s (max_ahead)
-    ///   - jitter: up to 1.1x multiplier on offset
-    ///
-    /// Max theoretical offset: (1.0 + 1.0) * 1.1 = 2.2s, use 3s for margin.
+    /// No candidate heartbeat timestamp should be implausibly far in the future.
+    /// The tolerance is the global worst-case one-sided clock deviation plus a
+    /// small margin for scheduling/rounding; it collapses toward zero in the
+    /// strict (zero-skew) configuration.
     pub(crate) fn verify_candidate_timestamps(
         &self,
         snapshot: &DatabaseSnapshot,
@@ -167,16 +163,16 @@ impl LeaderElectionWorkload {
     ) -> (bool, String) {
         let mut issues = Vec::new();
 
-        // Tolerance accounts for clock skew simulation (Extreme level + jitter)
-        const MAX_CLOCK_SKEW_TOLERANCE: f64 = 3.0;
+        // Tolerance tracks the configured clock-skew bound (+ small margin).
+        let tolerance = self.max_clock_skew_secs + 0.5;
 
         for candidate in &snapshot.candidates {
             let heartbeat_secs = candidate.last_heartbeat_nanos as f64 / 1_000_000_000.0;
 
-            if heartbeat_secs > current_time + MAX_CLOCK_SKEW_TOLERANCE {
+            if heartbeat_secs > current_time + tolerance {
                 issues.push(format!(
-                    "{} has future timestamp: {:.3} > {:.3}",
-                    candidate.process_id, heartbeat_secs, current_time
+                    "{} has future timestamp: {:.3} > {:.3} (+{:.3} tol)",
+                    candidate.process_id, heartbeat_secs, current_time, tolerance
                 ));
             }
         }
@@ -196,10 +192,7 @@ impl LeaderElectionWorkload {
 
     /// Invariant 4: Leadership Sequence - Monotonic Per-Client Operations
     ///
-    /// For each client, their op_nums should be monotonically increasing.
-    /// This verifies the log entries are properly ordered per client.
-    /// (Note: With versionstamp ordering, we have true commit order, so this
-    /// is a simpler check now - just verify op_nums are increasing per client)
+    /// For each client, their op_nums must be strictly increasing.
     pub(crate) fn verify_leadership_sequence(&self, entries: &LogEntries) -> (bool, String) {
         let mut client_last_op: BTreeMap<i32, u64> = BTreeMap::new();
         let mut leadership_count: BTreeMap<i32, usize> = BTreeMap::new();
@@ -239,9 +232,8 @@ impl LeaderElectionWorkload {
 
     /// Invariant 5: Registration Coverage - All Leaders Were Registered
     ///
-    /// Every client that successfully claimed leadership must have
-    /// previously registered (logged a Register operation).
-    /// This verifies the registration requirement of the protocol.
+    /// Every client that successfully claimed leadership must have a prior
+    /// registration entry in the log.
     pub(crate) fn verify_registration_coverage(&self, entries: &LogEntries) -> (bool, String) {
         // Track which clients have registered (either success or attempted)
         let mut registered_clients: BTreeMap<i32, bool> = BTreeMap::new();
@@ -287,85 +279,29 @@ impl LeaderElectionWorkload {
         }
     }
 
-    // ==========================================================================
-    // NEW INVARIANTS (6-11): Catch split-brain, timing, and ballot bugs
-    // ==========================================================================
-
-    /// Invariant 6: No Overlapping Leadership
+    /// Invariant 6: Ballot Succession
     ///
-    /// Verifies that leadership transitions are sequential in versionstamp order.
-    /// Since each successful leadership claim commits atomically in FDB,
-    /// versionstamp ordering guarantees no true overlap can occur.
-    ///
-    /// This invariant verifies:
-    /// - Each leadership period ends (explicitly via resign or implicitly via new claim) before the next starts
-    /// - No two clients claim leadership at the exact same versionstamp
-    pub(crate) fn verify_no_overlapping_leadership(&self, entries: &LogEntries) -> (bool, String) {
-        // Track leadership transitions in versionstamp order
-        // Since FDB commits are serialized, a successful leadership claim at versionstamp V
-        // implicitly ends any previous leadership (either lease expired or was preempted)
-        let mut leadership_claims: Vec<(i32, Versionstamp)> = Vec::new();
-        let mut explicit_resigns = 0;
-
-        for entry in entries {
-            if entry.op_type == OP_TRY_BECOME_LEADER && entry.success && entry.became_leader {
-                leadership_claims.push((entry.client_id, entry.versionstamp.clone()));
-            }
-            if entry.op_type == OP_RESIGN && entry.success {
-                explicit_resigns += 1;
-            }
-        }
-
-        // Check for duplicate versionstamps (would indicate a bug in logging)
-        for i in 0..leadership_claims.len() {
-            for j in (i + 1)..leadership_claims.len() {
-                if leadership_claims[i].1 == leadership_claims[j].1 {
-                    return (
-                        false,
-                        format!(
-                            "Duplicate versionstamp: clients {} and {} both claimed at {:?}",
-                            leadership_claims[i].0, leadership_claims[j].0, leadership_claims[i].1
-                        ),
-                    );
-                }
-            }
-        }
-
-        // With FDB's serialized commits and versionstamp ordering,
-        // sequential leadership claims are valid - each new claim implicitly
-        // ends the previous leadership (due to lease expiry or preemption)
-        (
-            true,
-            format!(
-                "Leadership transitions sequential ({} claims, {} explicit resigns)",
-                leadership_claims.len(),
-                explicit_resigns
-            ),
-        )
-    }
-
-    /// Invariant 7: Ballot Progression Check
-    ///
-    /// Verifies that each successful leadership claim has ballot > previous_ballot.
-    /// This ensures the fencing token mechanism is working correctly within each claim.
-    ///
-    /// Note: This uses the logged previous_ballot field, not global tracking,
-    /// because the ballot read in the same transaction is the authoritative previous value.
-    pub(crate) fn verify_ballot_value_binding(&self, entries: &LogEntries) -> (bool, String) {
+    /// Every successful leadership claim must have `ballot == previous_ballot + 1`.
+    /// `previous_ballot` is the ballot read in the same transaction, so this is
+    /// the authoritative predecessor. Because ballots are globally monotonic and
+    /// never reset (resign leaves a vacant record that preserves the ballot),
+    /// this holds unconditionally for every claim: first claim (`0 -> 1`), steal,
+    /// preemption, refresh, and post-resign claim alike.
+    pub(crate) fn verify_ballot_succession(&self, entries: &LogEntries) -> (bool, String) {
         let mut violations = Vec::new();
-        let mut valid_progressions = 0;
+        let mut claims = 0;
 
         for entry in entries {
             if entry.op_type == OP_TRY_BECOME_LEADER && entry.success && entry.became_leader {
-                // The ballot after claim should be greater than the ballot before claim
-                // (previous_ballot + 1 == ballot for normal claims)
-                if entry.ballot > 0 && entry.ballot <= entry.previous_ballot {
+                claims += 1;
+                if entry.ballot != entry.previous_ballot + 1 {
                     violations.push(format!(
-                        "Invalid ballot progression: client {} got ballot {} but previous was {}",
-                        entry.client_id, entry.ballot, entry.previous_ballot
+                        "Client {} got ballot {} but previous was {} (expected {})",
+                        entry.client_id,
+                        entry.ballot,
+                        entry.previous_ballot,
+                        entry.previous_ballot + 1
                     ));
-                } else {
-                    valid_progressions += 1;
                 }
             }
         }
@@ -373,201 +309,24 @@ impl LeaderElectionWorkload {
         if violations.is_empty() {
             (
                 true,
-                format!("Ballot progression OK ({valid_progressions} valid claims)"),
+                format!("Ballot succession OK ({claims} claims, each previous+1)"),
             )
         } else {
             (false, violations.join("; "))
         }
     }
 
-    /// Invariant 8: Fencing Token Increment
+    /// Invariant 7: One Value Per Ballot (Paxos Safety)
     ///
-    /// Each successful leadership claim should increment the ballot by exactly 1.
-    /// This verifies the fencing token mechanism is working as expected.
-    ///
-    /// ballot = previous_ballot + 1 for each successful claim
-    pub(crate) fn verify_fencing_token_monotonicity(&self, entries: &LogEntries) -> (bool, String) {
-        let mut violations = Vec::new();
-        let mut proper_increments = 0;
-        let mut first_claims = 0; // Claims where previous_ballot was 0 (no prior leader)
-
-        for entry in entries {
-            if entry.op_type == OP_TRY_BECOME_LEADER && entry.success && entry.became_leader {
-                if entry.previous_ballot == 0 {
-                    // First claim or claim after system reset - ballot can be any positive value
-                    first_claims += 1;
-                } else if entry.ballot == entry.previous_ballot + 1 {
-                    // Normal case: ballot incremented by 1
-                    proper_increments += 1;
-                } else if entry.ballot > entry.previous_ballot {
-                    // Ballot increased but not by exactly 1 - could indicate skipped ballots
-                    // This is OK as long as ballot > previous_ballot
-                    proper_increments += 1;
-                } else {
-                    // Ballot didn't increase - this is a problem
-                    violations.push(format!(
-                        "Ballot not incremented: client {} got ballot {} but previous was {}",
-                        entry.client_id, entry.ballot, entry.previous_ballot
-                    ));
-                }
-            }
-        }
-
-        if violations.is_empty() {
-            (
-                true,
-                format!(
-                    "Fencing token increment OK ({proper_increments} increments, {first_claims} first claims)"
-                ),
-            )
-        } else {
-            (false, violations.join("; "))
-        }
-    }
-
-    /// Invariant 9: Global Ballot Succession
-    ///
-    /// Each new leader must have a ballot strictly greater than the previous leader's ballot.
-    /// Uses the previous_ballot field to verify proper succession.
-    pub(crate) fn verify_global_ballot_succession(&self, entries: &LogEntries) -> (bool, String) {
-        let mut violations = Vec::new();
-        let mut leadership_transitions = 0;
-
-        for entry in entries {
-            if entry.op_type == OP_TRY_BECOME_LEADER && entry.success && entry.became_leader {
-                leadership_transitions += 1;
-                // New ballot must be strictly greater than previous
-                if entry.ballot <= entry.previous_ballot && entry.previous_ballot > 0 {
-                    violations.push(format!(
-                        "Ballot regression: client {} got ballot {} but previous was {}",
-                        entry.client_id, entry.ballot, entry.previous_ballot
-                    ));
-                }
-            }
-        }
-
-        if violations.is_empty() {
-            (
-                true,
-                format!("Global ballot succession OK ({leadership_transitions} transitions)"),
-            )
-        } else {
-            (false, violations.join("; "))
-        }
-    }
-
-    /// Invariant 10: Mutex Linearizability
-    ///
-    /// Leadership history must linearize to a valid mutex model:
-    /// - At most one process holds leadership at any given time
-    /// - Leadership transfers happen sequentially (in versionstamp order)
-    ///
-    /// Note: In lease-based leadership, a new leader claiming leadership
-    /// implicitly ends the previous leader's tenure (lease expired or was preempted).
-    /// This is NOT a mutex violation - it's how lease-based systems work.
-    pub(crate) fn verify_mutex_linearizability(&self, entries: &LogEntries) -> (bool, String) {
-        let mut acquire_count = 0;
-        let mut release_count = 0;
-        let mut implicit_releases = 0;
-        let mut current_holder: Option<i32> = None;
-
-        for entry in entries {
-            if entry.op_type == OP_TRY_BECOME_LEADER && entry.success && entry.became_leader {
-                acquire_count += 1;
-                if let Some(prev_holder) = current_holder
-                    && prev_holder != entry.client_id
-                {
-                    // Different client claiming - previous holder's lease expired
-                    // or was preempted. This is an implicit release.
-                    implicit_releases += 1;
-                }
-                // New leader takes over
-                current_holder = Some(entry.client_id);
-            }
-            if entry.op_type == OP_RESIGN
-                && entry.success
-                && let Some(holder) = current_holder
-                && holder == entry.client_id
-            {
-                release_count += 1;
-                current_holder = None;
-            }
-        }
-
-        // In a lease-based system, the invariant is simply that leadership
-        // transfers happen sequentially (which is guaranteed by versionstamp ordering)
-        (
-            true,
-            format!(
-                "Mutex linearizability OK ({acquire_count} acquires, {release_count} explicit releases, {implicit_releases} implicit releases)"
-            ),
-        )
-    }
-
-    /// Invariant 11: Lease Validity Check
-    ///
-    /// Verifies that leadership claims have valid lease expiry times:
-    /// - Lease expiry should be positive (in the future at claim time)
-    /// - Lease duration should be reasonable (not extremely long or short)
-    pub(crate) fn verify_lease_overlap_check(&self, entries: &LogEntries) -> (bool, String) {
-        let mut claims_with_lease = 0;
-        let mut claims_without_lease = 0;
-        let mut violations = Vec::new();
-
-        for entry in entries {
-            if entry.op_type == OP_TRY_BECOME_LEADER && entry.success && entry.became_leader {
-                if entry.lease_expiry_nanos > 0 {
-                    claims_with_lease += 1;
-                } else {
-                    // A successful leadership claim should have a lease expiry
-                    claims_without_lease += 1;
-                    violations.push(format!(
-                        "Client {} claimed leadership but lease_expiry_nanos is {}",
-                        entry.client_id, entry.lease_expiry_nanos
-                    ));
-                }
-            }
-        }
-
-        if violations.is_empty() {
-            (
-                true,
-                format!("Lease validity OK ({claims_with_lease} claims with valid leases)"),
-            )
-        } else {
-            // Note: This might be expected if the logging doesn't capture lease properly
-            // For now, just report as info
-            (
-                true,
-                format!(
-                    "Lease check: {claims_with_lease} with lease, {claims_without_lease} without (may need logging fix)"
-                ),
-            )
-        }
-    }
-
-    /// Invariant 12: One Value Per Ballot (Paxos Safety)
-    ///
-    /// Within each leadership tenure (between ballot resets), each ballot number
-    /// must map to exactly one client. The ballot resets to 0 after a resign,
-    /// starting a new tenure.
-    ///
-    /// This catches broken conflict ranges or ballot assignment logic where
-    /// two clients somehow both claim the same ballot within the same tenure.
+    /// Each ballot number must map to exactly one client, globally. Since
+    /// ballots are strictly increasing across the whole run, a ballot claimed
+    /// by two different clients would indicate broken conflict ranges or ballot
+    /// assignment logic.
     pub(crate) fn verify_one_value_per_ballot(&self, entries: &LogEntries) -> (bool, String) {
         let mut ballot_to_client: BTreeMap<u64, i32> = BTreeMap::new();
         let mut violations = Vec::new();
-        let mut tenure_count = 1;
-        let mut total_unique_ballots = 0;
 
         for entry in entries {
-            // Reset tracking on resign (ballot resets to 0, new tenure starts)
-            if entry.op_type == OP_RESIGN && entry.success {
-                total_unique_ballots += ballot_to_client.len();
-                ballot_to_client.clear();
-                tenure_count += 1;
-            }
-
             if entry.op_type == OP_TRY_BECOME_LEADER && entry.success && entry.became_leader {
                 if entry.ballot == 0 {
                     continue; // Skip ballot 0 (initial state)
@@ -577,35 +336,28 @@ impl LeaderElectionWorkload {
                     && prev_client != entry.client_id
                 {
                     violations.push(format!(
-                        "Tenure {}: Ballot {} claimed by client {} and client {}",
-                        tenure_count, entry.ballot, prev_client, entry.client_id
+                        "Ballot {} claimed by client {} and client {}",
+                        entry.ballot, prev_client, entry.client_id
                     ));
                 }
                 ballot_to_client.insert(entry.ballot, entry.client_id);
             }
         }
 
-        total_unique_ballots += ballot_to_client.len();
-
         if violations.is_empty() {
             (
                 true,
-                format!(
-                    "Paxos safety OK: {total_unique_ballots} unique ballots across {tenure_count} tenures"
-                ),
+                format!("Paxos safety OK: {} unique ballots", ballot_to_client.len()),
             )
         } else {
             (false, violations.join("; "))
         }
     }
 
-    /// Invariant 13: Lease Expiry After Claim Time
+    /// Invariant 8: Lease Expiry After Claim Time
     ///
-    /// Every successful leadership claim must have a lease that expires
-    /// AFTER the claim was made. This catches:
-    /// - Incorrect lease duration calculation
-    /// - Clock skew causing past-expiry leases
-    /// - Missing lease assignment
+    /// Every successful leadership claim must have a lease that expires AFTER
+    /// the claim was made.
     pub(crate) fn verify_lease_expiry_after_claim(&self, entries: &LogEntries) -> (bool, String) {
         let mut violations = Vec::new();
         let mut valid_leases = 0;
@@ -643,6 +395,181 @@ impl LeaderElectionWorkload {
         }
     }
 
+    /// Invariant 9: No Belief Overlap (real mutual exclusion)
+    ///
+    /// A belief overlap - two clients simultaneously thinking they hold a valid
+    /// lease - can only be created by a *steal*: one client taking the leader
+    /// record from a different client that neither resigned nor lost it
+    /// legitimately. Resign -> vacant -> claim handoffs create no overlap (the
+    /// resigning client stops believing when it resigns), so only steals are
+    /// checked.
+    ///
+    /// Walking the log in commit (versionstamp) order, track the current record
+    /// holder and its last-refresh time. When a *different* client becomes
+    /// leader over a still-held (non-vacant) record, that is a steal: the victim
+    /// keeps believing until `victim_last_refresh + lease_duration` (it is
+    /// unaware), so the stealer must not claim before then. A legitimate steal
+    /// only happens after observing the record unchanged for a full
+    /// `lease_duration`, so `stealer_claim >= victim_last_refresh + lease` and
+    /// the overlap is <= 0.
+    ///
+    /// Times are each client's own clock samples. The workload samples them
+    /// *inside* the transaction, after the leader read (see `workload.rs`), so
+    /// they are read-anchored: they reflect real record-existence time rather
+    /// than a stale op-start sample that retry/clogging latency would inflate.
+    /// For a steal the victim genuinely refreshed, then time passed, then the
+    /// stealer claimed, so commit order and sampled order agree.
+    ///
+    /// Only meaningful with preemption disabled: preemption deliberately steals
+    /// a live lease, so with it enabled the invariant reports an informational
+    /// skip (fencing ballots provide safety there). Tolerance is
+    /// `2 * max_clock_skew_secs` plus a small sampling-slack floor; in practice
+    /// steals land well after the lease expires (negative overlap), and a
+    /// genuinely broken observation leaks close to a full `lease_duration`.
+    pub(crate) fn verify_no_belief_overlap(
+        &self,
+        entries: &LogEntries,
+        snapshot: &DatabaseSnapshot,
+    ) -> (bool, String) {
+        let config = match &snapshot.config {
+            Some(c) => c,
+            None => {
+                return (
+                    true,
+                    "No config available, skipping belief-overlap check".to_string(),
+                );
+            }
+        };
+
+        if config.allow_preemption {
+            return (
+                true,
+                "Skipped: preemption enabled - belief-level exclusion intentionally not enforced; \
+                 safety relies on fencing ballots"
+                    .to_string(),
+            );
+        }
+
+        let lease_secs = config.lease_duration.as_secs_f64();
+
+        // Belief times come from `context.now()` sampled at each op's *start*,
+        // not its commit. A stealer's observation window is anchored to its own
+        // op-start samples, which can slightly precede the victim's record
+        // commit, so a legitimate steal can appear to land a fraction of a
+        // second before the victim's lease horizon. Absorb that sampling slack.
+        // A genuinely broken observation would leak close to a full
+        // `lease_duration`, far above this floor, so real violations still fail.
+        const SAMPLING_SLACK_SECS: f64 = 0.5;
+        let tolerance = 2.0 * self.max_clock_skew_secs + SAMPLING_SLACK_SECS;
+
+        // Current record holder in commit order: (client_id, last_refresh_secs).
+        // None means the record is vacant (after a resign) or never claimed.
+        let mut holder: Option<(i32, f64)> = None;
+        let mut steals = 0usize;
+        // Largest overlap seen (negative = margin: the steal landed this long
+        // after the victim's lease expired). Reported for reviewer visibility.
+        let mut max_overlap = f64::NEG_INFINITY;
+
+        for entry in entries {
+            let s = entry.sim_time_nanos as f64 / 1_000_000_000.0;
+
+            if entry.op_type == OP_TRY_BECOME_LEADER && entry.success && entry.became_leader {
+                if let Some((victim, victim_last_refresh)) = holder
+                    && victim != entry.client_id
+                {
+                    // Steal: the victim believes it holds the lease until its
+                    // lease horizon; the stealer must not claim before then.
+                    steals += 1;
+                    let victim_belief_end = victim_last_refresh + lease_secs;
+                    let overlap = victim_belief_end - s;
+                    if overlap > max_overlap {
+                        max_overlap = overlap;
+                    }
+                    if overlap > tolerance {
+                        return (
+                            false,
+                            format!(
+                                "Belief overlap {overlap:.3}s (> {tolerance:.3}s tol): client {} \
+                                 stole leadership at {s:.3} while client {victim}'s lease was valid \
+                                 until {victim_belief_end:.3} (last refresh {victim_last_refresh:.3})",
+                                entry.client_id
+                            ),
+                        );
+                    }
+                }
+                holder = Some((entry.client_id, s));
+            }
+
+            if entry.op_type == OP_RESIGN
+                && entry.success
+                && let Some((h, _)) = holder
+                && h == entry.client_id
+            {
+                // Clean handoff: the record is now vacant, no belief carries over.
+                holder = None;
+            }
+        }
+
+        let margin = if steals == 0 {
+            "no steals".to_string()
+        } else {
+            format!("worst approach {max_overlap:+.3}s vs {tolerance:.3}s tol")
+        };
+        (
+            true,
+            format!("No belief overlap across {steals} steals ({margin})"),
+        )
+    }
+
+    /// Invariant 10: Progress Made
+    ///
+    /// Guards against a vacuous pass: a run where nothing happened (empty log,
+    /// or no leader ever elected) must not be reported as success. Minimums are
+    /// configurable (`minLeadershipClaims`, `minHeartbeats`) but floored at 1.
+    pub(crate) fn verify_progress_made(&self, entries: &LogEntries) -> (bool, String) {
+        if entries.is_empty() {
+            return (
+                false,
+                "No log entries: the run made no observable progress".to_string(),
+            );
+        }
+
+        let mut claims = 0usize;
+        let mut heartbeats = 0usize;
+        for entry in entries {
+            if entry.op_type == OP_TRY_BECOME_LEADER && entry.success && entry.became_leader {
+                claims += 1;
+            }
+            if entry.op_type == OP_HEARTBEAT && entry.success {
+                heartbeats += 1;
+            }
+        }
+
+        if claims < self.min_leadership_claims {
+            return (
+                false,
+                format!(
+                    "Only {claims} successful leadership claims (need >= {})",
+                    self.min_leadership_claims
+                ),
+            );
+        }
+        if heartbeats < self.min_heartbeats {
+            return (
+                false,
+                format!(
+                    "Only {heartbeats} successful heartbeats (need >= {})",
+                    self.min_heartbeats
+                ),
+            );
+        }
+
+        (
+            true,
+            format!("Progress OK: {claims} leadership claims, {heartbeats} heartbeats"),
+        )
+    }
+
     /// Run all invariant checks and return results
     pub(crate) fn run_all_invariant_checks(
         &self,
@@ -653,61 +580,45 @@ impl LeaderElectionWorkload {
 
         let mut results: Vec<(&'static str, bool, String)> = Vec::new();
 
-        // Invariant 1: Dual-Path Validation (most important!)
-        // Replay logs in true commit order, compare with FDB state
-        // Subsumes safety (at most one leader) and ballot conservation
+        // 1: Dual-Path Validation (keystone: safety + ballot conservation)
         let (pass, detail) = self.verify_dual_path(entries, snapshot);
         results.push(("DualPathValidation", pass, detail));
 
-        // Invariant 2: Leader Is Candidate (structural integrity)
+        // 2: Leader Is Candidate (structural integrity)
         let (pass, detail) = self.verify_leader_is_candidate(snapshot, current_time);
         results.push(("LeaderIsCandidate", pass, detail));
 
-        // Invariant 3: Candidate Timestamps (no future timestamps)
+        // 3: Candidate Timestamps (no implausible future timestamps)
         let (pass, detail) = self.verify_candidate_timestamps(snapshot, current_time);
         results.push(("CandidateTimestamps", pass, detail));
 
-        // Invariant 4: Leadership Sequence (per-client monotonic op_nums)
+        // 4: Leadership Sequence (per-client monotonic op_nums)
         let (pass, detail) = self.verify_leadership_sequence(entries);
         results.push(("LeadershipSequence", pass, detail));
 
-        // Invariant 5: Registration Coverage (all leaders were registered)
+        // 5: Registration Coverage (all leaders were registered)
         let (pass, detail) = self.verify_registration_coverage(entries);
         results.push(("RegistrationCoverage", pass, detail));
 
-        // === NEW INVARIANTS (6-11): Split-brain, timing, and ballot bug detection ===
+        // 6: Ballot Succession (each claim is exactly previous+1, globally)
+        let (pass, detail) = self.verify_ballot_succession(entries);
+        results.push(("BallotSuccession", pass, detail));
 
-        // Invariant 6: No Overlapping Leadership (critical - catches split-brain)
-        let (pass, detail) = self.verify_no_overlapping_leadership(entries);
-        results.push(("NoOverlappingLeadership", pass, detail));
-
-        // Invariant 7: Ballot Value Binding (critical - catches duplicate elections)
-        let (pass, detail) = self.verify_ballot_value_binding(entries);
-        results.push(("BallotValueBinding", pass, detail));
-
-        // Invariant 8: Fencing Token Monotonicity (high priority - catches stale leader writes)
-        let (pass, detail) = self.verify_fencing_token_monotonicity(entries);
-        results.push(("FencingTokenMonotonicity", pass, detail));
-
-        // Invariant 9: Global Ballot Succession (high priority - catches state regression)
-        let (pass, detail) = self.verify_global_ballot_succession(entries);
-        results.push(("GlobalBallotSuccession", pass, detail));
-
-        // Invariant 10: Mutex Linearizability (medium priority - general correctness)
-        let (pass, detail) = self.verify_mutex_linearizability(entries);
-        results.push(("MutexLinearizability", pass, detail));
-
-        // Invariant 11: Lease Overlap Check (medium priority - lease extension races)
-        let (pass, detail) = self.verify_lease_overlap_check(entries);
-        results.push(("LeaseOverlapCheck", pass, detail));
-
-        // Invariant 12: One Value Per Ballot (critical - Paxos safety within tenure)
+        // 7: One Value Per Ballot (Paxos safety)
         let (pass, detail) = self.verify_one_value_per_ballot(entries);
         results.push(("OneValuePerBallot", pass, detail));
 
-        // Invariant 13: Lease Expiry After Claim Time (critical - lease validity)
+        // 8: Lease Expiry After Claim (lease validity)
         let (pass, detail) = self.verify_lease_expiry_after_claim(entries);
         results.push(("LeaseExpiryAfterClaim", pass, detail));
+
+        // 9: No Belief Overlap (real mutual exclusion, preemption disabled)
+        let (pass, detail) = self.verify_no_belief_overlap(entries, snapshot);
+        results.push(("NoBeliefOverlap", pass, detail));
+
+        // 10: Progress Made (no vacuous passes)
+        let (pass, detail) = self.verify_progress_made(entries);
+        results.push(("ProgressMade", pass, detail));
 
         // Log each result
         for (name, passed, detail) in &results {

--- a/foundationdb-recipes-simulation/src/leader_election/mod.rs
+++ b/foundationdb-recipes-simulation/src/leader_election/mod.rs
@@ -5,20 +5,21 @@
 //!
 //! # Check Phase Invariants
 //!
-//! The check phase validates the core leader election invariants:
-//!
-//! 1. **Safety (No Overlapping Leadership)**: At most one leader at any time
-//! 2. **Ballot Conservation**: Expected ballot from logs matches actual ballot in FDB
+//! The check phase replays the versionstamp-ordered operation log and compares
+//! it against the committed FDB state. See [`invariants`] for the full set;
+//! the headline ones are dual-path validation, global ballot succession,
+//! belief-level no-overlap (with preemption disabled), and a progress gate.
 
 mod helpers;
 mod invariants;
 mod types;
 mod workload;
 
+use foundationdb::recipes::leader_election::LeaseObservation;
 use foundationdb::tuple::Subspace;
 use foundationdb_simulation::{SingleRustWorkload, WorkloadContext};
 
-use types::ClockSkewLevel;
+use types::{ClockSkewLevel, DEFAULT_CLOCK_JITTER_OFFSET, DEFAULT_CLOCK_JITTER_RANGE};
 
 pub struct LeaderElectionWorkload {
     pub(crate) context: WorkloadContext,
@@ -29,6 +30,14 @@ pub struct LeaderElectionWorkload {
     pub(crate) operation_count: usize,
     pub(crate) heartbeat_timeout_secs: u64,
     pub(crate) resign_probability: f64,
+    /// Whether the election config enables priority preemption. Read in setup
+    /// (client 0) to build the config; the checker reads it back from the
+    /// committed config to decide whether the belief-overlap invariant applies.
+    pub(crate) allow_preemption: bool,
+    /// Minimum successful leadership claims a run must produce (progress gate).
+    pub(crate) min_leadership_claims: usize,
+    /// Minimum successful heartbeats a run must produce (progress gate).
+    pub(crate) min_heartbeats: usize,
 
     // Subspaces
     pub(crate) election_subspace: Subspace,
@@ -37,11 +46,20 @@ pub struct LeaderElectionWorkload {
     // State
     pub(crate) process_id: String,
     pub(crate) op_num: u64,
+    /// Lease-observation state threaded through leadership claims so an
+    /// unrefreshed lease is only stolen after a full observation window.
+    pub(crate) lease_observation: LeaseObservation,
 
     // Clock skew simulation (mimics FDB sim2)
     pub(crate) clock_skew_level: ClockSkewLevel,
     pub(crate) clock_offset_secs: f64,
     pub(crate) clock_timer_time: f64,
+    /// Per-client drift bound used by `local_time`; zero disables drift so the
+    /// strict (zero-skew) config makes `local_time == context.now()` exactly.
+    pub(crate) clock_max_ahead: f64,
+    /// Global worst-case one-sided clock deviation across all clients, used as
+    /// the tolerance in time-based invariants. Zero in the strict config.
+    pub(crate) max_clock_skew_secs: f64,
 
     // Metrics
     pub(crate) heartbeat_count: u64,
@@ -63,9 +81,26 @@ impl SingleRustWorkload for LeaderElectionWorkload {
             _ => ClockSkewLevel::Extreme,
         };
 
+        // Maximum jitter multiplier applied to the offset in `local_time`.
+        let jitter_max = DEFAULT_CLOCK_JITTER_OFFSET + DEFAULT_CLOCK_JITTER_RANGE;
+
+        // `maxClockSkewSecs` overrides the randomized tiers with a fixed
+        // per-client bound. `0.0` disables skew entirely (local_time == now).
+        // When unset, each client keeps its random tier, and the global
+        // worst-case (Extreme, both offset and drift, times jitter) is used as
+        // the invariant tolerance.
+        let skew_override: Option<f64> = context.get_option("maxClockSkewSecs");
+        let (max_offset, clock_max_ahead, max_clock_skew_secs) = match skew_override {
+            Some(v) => (v, v, (v + v) * jitter_max),
+            None => {
+                let tier = clock_skew_level.max_offset_secs();
+                let extreme = ClockSkewLevel::Extreme.max_offset_secs();
+                (tier, tier, (extreme + extreme) * jitter_max)
+            }
+        };
+
         // Random offset per node using context.rnd() for determinism
         // Scale rnd() output (u32) to range [-max_offset, +max_offset]
-        let max_offset = clock_skew_level.max_offset_secs();
         let rnd_val = context.rnd() as f64 / u32::MAX as f64; // 0.0 to 1.0
         let clock_offset_secs = (rnd_val * 2.0 - 1.0) * max_offset; // -max to +max
 
@@ -76,6 +111,20 @@ impl SingleRustWorkload for LeaderElectionWorkload {
             operation_count: context.get_option("operationCount").unwrap_or(50),
             heartbeat_timeout_secs: context.get_option("heartbeatTimeoutSecs").unwrap_or(10),
             resign_probability: context.get_option("resignProbability").unwrap_or(0.1),
+            // Integer 0/1 (not a TOML bool) to avoid ambiguity in how the C API
+            // stringifies booleans. Defaults to enabled (matches the recipe).
+            allow_preemption: context
+                .get_option::<u64>("allowPreemption")
+                .map(|v| v != 0)
+                .unwrap_or(true),
+            min_leadership_claims: context
+                .get_option::<u64>("minLeadershipClaims")
+                .map(|v| v.max(1) as usize)
+                .unwrap_or(1),
+            min_heartbeats: context
+                .get_option::<u64>("minHeartbeats")
+                .map(|v| v.max(1) as usize)
+                .unwrap_or(1),
             election_subspace: Subspace::all().subspace(&("leader_election",)),
             log_subspace: Subspace::all().subspace(&("le_log",)),
             process_id: format!("process_{client_id}"),
@@ -83,9 +132,12 @@ impl SingleRustWorkload for LeaderElectionWorkload {
             client_count,
             context,
             op_num: 0,
+            lease_observation: LeaseObservation::new(),
             clock_skew_level,
             clock_offset_secs,
             clock_timer_time,
+            clock_max_ahead,
+            max_clock_skew_secs,
             heartbeat_count: 0,
             leadership_attempts: 0,
             times_became_leader: 0,

--- a/foundationdb-recipes-simulation/src/leader_election/types.rs
+++ b/foundationdb-recipes-simulation/src/leader_election/types.rs
@@ -30,6 +30,10 @@ pub(crate) struct LogEntry {
     pub lease_expiry_nanos: i64,
     /// Timestamp when leadership claim was made (for lease validity checks)
     pub claim_timestamp_nanos: i64,
+    /// Unskewed simulation time (`context.now()`) when the op committed, in
+    /// nanoseconds. Used to reconstruct belief intervals for the no-overlap
+    /// invariant without clock-skew contamination.
+    pub sim_time_nanos: i64,
 }
 
 /// Log entries in FDB commit order (versionstamp-ordered keys give us true ordering)

--- a/foundationdb-recipes-simulation/src/leader_election/workload.rs
+++ b/foundationdb-recipes-simulation/src/leader_election/workload.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use foundationdb::{
     FdbBindingError, RangeOption,
     options::{MutationType, TransactionOption},
-    recipes::leader_election::{ElectionConfig, LeaderElection},
+    recipes::leader_election::{ElectionConfig, LeaderElection, LeaderState, LeaseObservation},
     tuple::{Versionstamp, pack, unpack},
 };
 use foundationdb_simulation::{Metric, Metrics, RustWorkload, Severity, SimDatabase, details};
@@ -49,9 +49,12 @@ impl RustWorkload for LeaderElectionWorkload {
         // Client 0 initializes the leader election
         if self.client_id == 0 {
             let election = LeaderElection::new(self.election_subspace.clone());
-            let config = ElectionConfig::with_lease_duration(Duration::from_secs(
-                self.heartbeat_timeout_secs,
-            ));
+            let config = ElectionConfig {
+                allow_preemption: self.allow_preemption,
+                ..ElectionConfig::with_lease_duration(Duration::from_secs(
+                    self.heartbeat_timeout_secs,
+                ))
+            };
 
             const MAX_INIT_RETRIES: u32 = 10;
             let mut init_success = false;
@@ -103,6 +106,7 @@ impl RustWorkload for LeaderElectionWorkload {
             for cid in 0..self.client_count {
                 let process_id = format!("process_{cid}");
                 let timestamp = self.local_time();
+                let sim_now_nanos = (self.context.now() * 1e9) as i64;
                 let log_subspace = self.log_subspace.clone();
 
                 let result = db
@@ -123,9 +127,17 @@ impl RustWorkload for LeaderElectionWorkload {
                                 cid,
                                 0_u64, // op_num 0 for registration
                             ));
-                            // Format: (op_type, success, became_leader, ballot, previous_ballot, lease_expiry_nanos, claim_timestamp_nanos)
-                            let log_value =
-                                pack(&(OP_REGISTER, success, false, 0_u64, 0_u64, 0_i64, 0_i64));
+                            // Format: (op_type, success, became_leader, ballot, previous_ballot, lease_expiry_nanos, claim_timestamp_nanos, sim_time_nanos)
+                            let log_value = pack(&(
+                                OP_REGISTER,
+                                success,
+                                false,
+                                0_u64,
+                                0_u64,
+                                0_i64,
+                                0_i64,
+                                sim_now_nanos,
+                            ));
                             trx.atomic_op(&log_key, &log_value, MutationType::SetVersionstampedKey);
 
                             reg_result.map_err(FdbBindingError::from)
@@ -168,7 +180,8 @@ impl RustWorkload for LeaderElectionWorkload {
         for _ in 0..self.operation_count {
             // Use local_time() for clock skew simulation
             let timestamp = self.local_time();
-            let current_time = timestamp.as_secs_f64();
+            // Unskewed sim time for the log (drives belief-interval reconstruction)
+            let sim_now_nanos = (self.context.now() * 1e9) as i64;
 
             // Send heartbeat
             {
@@ -196,9 +209,17 @@ impl RustWorkload for LeaderElectionWorkload {
                                 client_id,
                                 op_num,
                             ));
-                            // Format: (op_type, success, became_leader, ballot, previous_ballot, lease_expiry_nanos, claim_timestamp_nanos)
-                            let log_value =
-                                pack(&(OP_HEARTBEAT, success, false, 0_u64, 0_u64, 0_i64, 0_i64));
+                            // Format: (op_type, success, became_leader, ballot, previous_ballot, lease_expiry_nanos, claim_timestamp_nanos, sim_time_nanos)
+                            let log_value = pack(&(
+                                OP_HEARTBEAT,
+                                success,
+                                false,
+                                0_u64,
+                                0_u64,
+                                0_i64,
+                                0_i64,
+                                sim_now_nanos,
+                            ));
                             trx.atomic_op(&log_key, &log_value, MutationType::SetVersionstampedKey);
 
                             hb_result.map_err(FdbBindingError::from)
@@ -222,21 +243,50 @@ impl RustWorkload for LeaderElectionWorkload {
                 let log_subspace = self.log_subspace.clone();
                 let client_id = self.client_id;
                 let op_num = self.op_num;
+                // Observation state threaded into the claim; db.run re-executes
+                // its closure on conflict, so clone per retry from this snapshot.
+                let observation = self.lease_observation.clone();
+                // Sample the clock INSIDE the transaction (below), not at loop
+                // top: the recipe's lease-observation window is measured in
+                // caller-supplied time, and a stale outer sample would let the
+                // heartbeat's and retries' elapsed simulation time inflate the
+                // observed duration, causing premature steals. `context` is a
+                // cheap handle clone; `clock_offset` reproduces this client's
+                // fixed skew without the mutable drift state local_time needs.
+                let context = self.context.clone();
+                let clock_offset = self.clock_offset_secs;
 
-                let result: Result<Option<_>, _> = db
-                    .run(|trx, _maybe_committed| {
+                let result: Result<(Option<LeaderState>, LeaseObservation), _> = db
+                    .run(move |trx, _maybe_committed| {
                         let election = election.clone();
                         let process_id = process_id.clone();
                         let log_subspace = log_subspace.clone();
+                        let observation = observation.clone();
+                        let context = context.clone();
                         async move {
                             trx.set_option(TransactionOption::AutomaticIdempotency)?;
 
-                            // Get previous ballot before claim attempt
+                            // Get previous ballot before claim attempt (this read
+                            // establishes the transaction's read version).
                             let current = election.get_leader_raw(&trx).await.ok().flatten();
                             let previous_ballot = current.map(|l| l.ballot).unwrap_or(0);
 
-                            let claim_result = election
-                                .try_claim_leadership(&trx, &process_id, 0, timestamp)
+                            // Read-anchored, per-attempt time: sampled after the
+                            // leader read, so the observation and lease reflect
+                            // real record-existence time even across retries.
+                            let now = context.now();
+                            let current_time =
+                                Duration::from_secs_f64((now + clock_offset).max(0.0));
+                            let sim_now_nanos = (now * 1e9) as i64;
+
+                            let (claim_result, new_obs) = election
+                                .try_claim_leadership(
+                                    &trx,
+                                    &process_id,
+                                    0,
+                                    current_time,
+                                    observation,
+                                )
                                 .await
                                 .map_err(FdbBindingError::from)?;
 
@@ -249,8 +299,8 @@ impl RustWorkload for LeaderElectionWorkload {
                             };
 
                             // Log with versionstamp-ordered key (FDB commit order)
-                            // Format: (op_type, success, became_leader, ballot, previous_ballot, lease_expiry_nanos, claim_timestamp_nanos)
-                            let claim_timestamp_nanos = timestamp.as_nanos() as i64;
+                            // Format: (op_type, success, became_leader, ballot, previous_ballot, lease_expiry_nanos, claim_timestamp_nanos, sim_time_nanos)
+                            let claim_timestamp_nanos = current_time.as_nanos() as i64;
                             let log_key = log_subspace.pack_with_versionstamp(&(
                                 Versionstamp::incomplete(0),
                                 client_id,
@@ -264,52 +314,60 @@ impl RustWorkload for LeaderElectionWorkload {
                                 previous_ballot,
                                 lease_expiry,
                                 claim_timestamp_nanos,
+                                sim_now_nanos,
                             ));
                             trx.atomic_op(&log_key, &log_value, MutationType::SetVersionstampedKey);
 
-                            Ok::<_, FdbBindingError>(claim_result)
+                            Ok::<_, FdbBindingError>((claim_result, new_obs))
                         }
                     })
                     .await;
 
                 self.op_num += 1;
                 self.leadership_attempts += 1;
-                let became_leader = matches!(&result, Ok(Some(_)));
-                if became_leader {
-                    self.times_became_leader += 1;
-                    // Enhanced logging with ballot and lease info for debugging
-                    if let Ok(Some(ref state)) = result {
-                        self.context.trace(
-                            Severity::Info,
-                            "BecameLeader",
-                            details![
-                                "Layer" => "Rust",
-                                "Client" => self.client_id,
-                                "ProcessId" => self.process_id.clone(),
-                                "Timestamp" => current_time,
-                                "Ballot" => state.ballot,
-                                "LeaseExpirySecs" => state.lease_expiry_nanos as f64 / 1_000_000_000.0
-                            ],
-                        );
+
+                match result {
+                    Ok((claim_result, new_obs)) => {
+                        // Persist the updated observation for the next attempt.
+                        self.lease_observation = new_obs;
+                        let now = self.context.now();
+                        let became_leader = claim_result.is_some();
+                        if let Some(ref state) = claim_result {
+                            self.times_became_leader += 1;
+                            // Enhanced logging with ballot and lease info for debugging
+                            self.context.trace(
+                                Severity::Info,
+                                "BecameLeader",
+                                details![
+                                    "Layer" => "Rust",
+                                    "Client" => self.client_id,
+                                    "ProcessId" => self.process_id.clone(),
+                                    "Timestamp" => now,
+                                    "Ballot" => state.ballot,
+                                    "LeaseExpirySecs" => state.lease_expiry_nanos as f64 / 1_000_000_000.0
+                                ],
+                            );
+                        } else {
+                            // Log when leadership claim is rejected (for debugging overlaps)
+                            self.context.trace(
+                                Severity::Debug,
+                                "LeadershipClaimRejected",
+                                details![
+                                    "Layer" => "Rust",
+                                    "Client" => self.client_id,
+                                    "ProcessId" => self.process_id.clone(),
+                                    "Timestamp" => now,
+                                    "Reason" => "Still observing incumbent lease"
+                                ],
+                            );
+                        }
+                        became_leader
                     }
-                } else if result.is_ok() {
-                    // Log when leadership claim is rejected (for debugging overlaps)
-                    self.context.trace(
-                        Severity::Debug,
-                        "LeadershipClaimRejected",
-                        details![
-                            "Layer" => "Rust",
-                            "Client" => self.client_id,
-                            "ProcessId" => self.process_id.clone(),
-                            "Timestamp" => current_time,
-                            "Reason" => "Another leader has valid lease"
-                        ],
-                    );
+                    Err(_) => {
+                        self.error_count += 1;
+                        false
+                    }
                 }
-                if result.is_err() {
-                    self.error_count += 1;
-                }
-                became_leader
             };
 
             // Randomly resign if we became leader
@@ -321,12 +379,14 @@ impl RustWorkload for LeaderElectionWorkload {
                     let log_subspace = self.log_subspace.clone();
                     let client_id = self.client_id;
                     let op_num = self.op_num;
+                    let context = self.context.clone();
 
                     let resign_result: Result<bool, _> = db
-                        .run(|trx, _maybe_committed| {
+                        .run(move |trx, _maybe_committed| {
                             let election = election.clone();
                             let process_id = process_id.clone();
                             let log_subspace = log_subspace.clone();
+                            let context = context.clone();
                             async move {
                                 trx.set_option(TransactionOption::AutomaticIdempotency)?;
 
@@ -339,8 +399,12 @@ impl RustWorkload for LeaderElectionWorkload {
                                     .await
                                     .map_err(FdbBindingError::from)?;
 
+                                // Read-anchored sim time (after the read), for
+                                // consistent belief-interval reconstruction.
+                                let sim_now_nanos = (context.now() * 1e9) as i64;
+
                                 // Log with versionstamp-ordered key (FDB commit order)
-                                // Format: (op_type, success, became_leader, ballot, previous_ballot, lease_expiry_nanos, claim_timestamp_nanos)
+                                // Format: (op_type, success, became_leader, ballot, previous_ballot, lease_expiry_nanos, claim_timestamp_nanos, sim_time_nanos)
                                 let log_key = log_subspace.pack_with_versionstamp(&(
                                     Versionstamp::incomplete(0),
                                     client_id,
@@ -354,6 +418,7 @@ impl RustWorkload for LeaderElectionWorkload {
                                     previous_ballot,
                                     0_i64,
                                     0_i64,
+                                    sim_now_nanos,
                                 ));
                                 trx.atomic_op(
                                     &log_key,
@@ -377,7 +442,7 @@ impl RustWorkload for LeaderElectionWorkload {
                                 "Layer" => "Rust",
                                 "Client" => self.client_id,
                                 "ProcessId" => self.process_id.clone(),
-                                "Timestamp" => current_time
+                                "Timestamp" => self.context.now()
                             ],
                         );
                     }
@@ -405,15 +470,16 @@ impl RustWorkload for LeaderElectionWorkload {
     async fn check(&mut self, db: SimDatabase) {
         self.trace_check_start();
 
-        // Only client 0 performs verification
-        if self.client_id != 0 {
-            return;
-        }
+        // Verification is read-only and deterministic (it reads the global
+        // le_log and replays it), so every surviving client verifies. This
+        // closes the hole where Attrition killing client 0 skipped all checks.
 
         // Step 1: Read all log entries and snapshot in a single transaction
         // Capture read version for debugging (like Cycle.actor.cpp)
         let log_subspace = self.log_subspace.clone();
         let election_subspace = self.election_subspace.clone();
+        // Unskewed sim time for the candidate-liveness filter in the snapshot.
+        let snapshot_time = Duration::from_secs_f64(self.context.now());
 
         let check_result = db
             .run(|trx, _maybe_committed| {
@@ -439,8 +505,8 @@ impl RustWorkload for LeaderElectionWorkload {
                             .map_err(FdbBindingError::PackError)?;
                         let (versionstamp, client_id, op_num) = key_tuple;
 
-                        // Unpack value: (op_type, success, became_leader, ballot, previous_ballot, lease_expiry_nanos, claim_timestamp_nanos)
-                        let value_tuple: (i64, bool, bool, u64, u64, i64, i64) =
+                        // Unpack value: (op_type, success, became_leader, ballot, previous_ballot, lease_expiry_nanos, claim_timestamp_nanos, sim_time_nanos)
+                        let value_tuple: (i64, bool, bool, u64, u64, i64, i64, i64) =
                             unpack(kv.value()).map_err(FdbBindingError::PackError)?;
 
                         entries.push(LogEntry {
@@ -454,12 +520,12 @@ impl RustWorkload for LeaderElectionWorkload {
                             previous_ballot: value_tuple.4,
                             lease_expiry_nanos: value_tuple.5,
                             claim_timestamp_nanos: value_tuple.6,
+                            sim_time_nanos: value_tuple.7,
                         });
                     }
 
                     // Read snapshot data
                     let election = LeaderElection::new(election_subspace);
-                    let current_time = Duration::from_secs_f64(0.0); // Will use context.now() later
 
                     let leader_state = election
                         .get_leader_raw(&trx)
@@ -467,7 +533,7 @@ impl RustWorkload for LeaderElectionWorkload {
                         .map_err(FdbBindingError::from)?;
 
                     let candidates = election
-                        .list_candidates(&trx, current_time)
+                        .list_candidates(&trx, snapshot_time)
                         .await
                         .map_err(FdbBindingError::from)?;
 

--- a/foundationdb-recipes-simulation/test_strict_mutex.toml
+++ b/foundationdb-recipes-simulation/test_strict_mutex.toml
@@ -1,0 +1,42 @@
+# Strict mutual-exclusion configuration.
+#
+# Preemption disabled + zero clock skew lets the NoBeliefOverlap invariant
+# assert strict mutual exclusion of leadership belief intervals: every steal
+# must land after the victim's lease has expired. RandomClogging (partitions)
+# and Attrition (kill/reboot) make leaders stop refreshing so failover and
+# stealing are exercised, and ProgressMade ensures the run is not vacuous.
+#
+# This relies on the workload sampling the claim clock INSIDE the transaction
+# (read-anchored), so the recipe's lease-observation window is measured from the
+# actual read, not a stale op-start sample - otherwise clogging/retry latency
+# would inflate the observed duration and produce spurious overlaps.
+[[test]]
+testTitle = 'LeaderElectionStrictMutex'
+
+  [[test.workload]]
+    testName = 'External'
+    useCAPI = true
+    libraryName = 'foundationdb_recipes_simulation'
+    workloadName = 'LeaderElectionWorkload'
+    libraryPath = './target/release'
+    operationCount = 100
+    heartbeatTimeoutSecs = 5
+    resignProbability = 0.2
+    # 0 = preemption disabled (integer, not a TOML bool)
+    allowPreemption = 0
+    # 0.0 = clocks perfectly synchronized -> tightest overlap assertion
+    maxClockSkewSecs = 0.0
+
+  [[test.workload]]
+    # Introduce network partitions
+    testName = 'RandomClogging'
+    testDuration = 30.0
+    swizzle = 1
+
+  [[test.workload]]
+    # Reboot processes to test failover
+    testName = 'Attrition'
+    machinesToKill = 4
+    machinesToLeave = 4
+    reboot = true
+    testDuration = 30.0

--- a/foundationdb-simulation/src/bindings.rs
+++ b/foundationdb-simulation/src/bindings.rs
@@ -70,6 +70,13 @@ macro_rules! details {
 // Rust Types
 
 /// Wrapper around the C FDBWorkloadContext
+///
+/// `Clone` copies the underlying handle (a set of raw pointers owned by the
+/// simulation harness, not by Rust - there is no `Drop`). This lets a workload
+/// hand a context to a transaction closure so it can read `now()`/`rnd()`/emit
+/// traces from inside the transaction. The handle is valid for the workload's
+/// lifetime and its accessors are read-only, so sharing a clone is sound.
+#[derive(Clone)]
 pub struct WorkloadContext(FDBWorkloadContext);
 /// Wrapper around the C FDBPromise
 pub struct Promise(FDBPromise);

--- a/foundationdb/src/recipes/leader_election/algorithm.rs
+++ b/foundationdb/src/recipes/leader_election/algorithm.rs
@@ -202,15 +202,99 @@ where
 // LEADER OPERATIONS - ALL O(1)
 // ============================================================================
 
+/// Outcome of the pure claim decision, see [`decide_claim`].
+#[derive(Debug, PartialEq, Eq)]
+enum ClaimOutcome {
+    /// The caller may claim leadership with this ballot.
+    Claim { new_ballot: u64 },
+    /// The caller may not claim (must keep observing / following).
+    Deny,
+}
+
+/// Pure decision for whether `process_id` may claim leadership right now.
+///
+/// This holds all the election policy so it can be unit-tested without a
+/// cluster. It never consults the absolute lease validity of a live leader;
+/// stealing an unrefreshed lease is gated purely on how long the *same* leader
+/// record has been observed (`observation`), measured on the caller's own
+/// clock. See [`LeaseObservation`] for the rationale.
+fn decide_claim(
+    current: Option<&LeaderState>,
+    process_id: &str,
+    my_priority: i32,
+    allow_preemption: bool,
+    lease_duration: Duration,
+    current_time: Duration,
+    observation: &mut LeaseObservation,
+) -> ClaimOutcome {
+    match current {
+        // No record at all: first claim ever.
+        None => {
+            observation.clear();
+            ClaimOutcome::Claim { new_ballot: 1 }
+        }
+        // Vacant record left by a resignation: claim immediately, ballot continues.
+        Some(leader) if leader.is_vacant() => {
+            observation.clear();
+            ClaimOutcome::Claim {
+                new_ballot: leader.ballot + 1,
+            }
+        }
+        // Already the leader (refresh-like re-claim): no waiting.
+        Some(leader) if leader.leader_id == process_id => {
+            observation.clear();
+            ClaimOutcome::Claim {
+                new_ballot: leader.ballot + 1,
+            }
+        }
+        // Some other live leader.
+        Some(leader) => {
+            // Preemption bypasses the observation wait by design. This
+            // sacrifices belief-level mutual exclusion (the old leader may
+            // still think it holds the lease); safety then relies on the
+            // fencing ballot alone.
+            if allow_preemption && my_priority > leader.priority {
+                observation.clear();
+                return ClaimOutcome::Claim {
+                    new_ballot: leader.ballot + 1,
+                };
+            }
+
+            // Elapsed-time stealing: only steal once we have observed this
+            // exact record (ballot + versionstamp identity) continuously for
+            // at least `lease_duration` on our own clock.
+            let observed = observation.observe(leader.ballot, leader.versionstamp, current_time);
+            if observed >= lease_duration {
+                observation.clear();
+                ClaimOutcome::Claim {
+                    new_ballot: leader.ballot + 1,
+                }
+            } else {
+                ClaimOutcome::Deny
+            }
+        }
+    }
+}
+
 /// Try to claim leadership
 ///
 /// This is the core leader election operation:
 /// 1. Look up candidate registration (O(1))
 /// 2. Read current leader state (O(1))
-/// 3. Decide if we can claim based on ballot/priority/lease
+/// 3. Decide if we can claim (see [`decide_claim`])
 /// 4. Write new state with incremented ballot (O(1))
 ///
 /// FDB transaction conflict detection ensures safety.
+///
+/// # Observation state
+///
+/// Stealing an apparently-expired lease requires observing the same leader
+/// record for `lease_duration` on the caller's own clock. The caller owns a
+/// [`LeaseObservation`] and threads it through successive calls: pass it in,
+/// keep the returned value for the next call. Taking it by value (rather than
+/// `&mut`) keeps this usable inside a `Database::run` closure, which is
+/// re-executed on conflict; the update is a pure function of the read record,
+/// so retries recompute the same result.
 ///
 /// # Arguments
 /// * `txn` - The FoundationDB transaction
@@ -218,10 +302,12 @@ where
 /// * `process_id` - ID of the process attempting to claim leadership
 /// * `my_priority` - This process's priority (higher = more preferred)
 /// * `current_time` - Current time for lease calculation
+/// * `observation` - Caller-owned lease-observation state
 ///
 /// # Returns
-/// * `Ok(Some(state))` - Successfully claimed leadership
-/// * `Ok(None)` - Cannot claim, another valid leader exists
+/// A tuple of the claim result and the updated observation:
+/// * `Ok((Some(state), obs))` - Successfully claimed leadership
+/// * `Ok((None, obs))` - Cannot claim yet (keep observing, another leader exists)
 /// * `Err(UnregisteredCandidate)` - Process is not registered as a candidate
 /// * `Err(_)` - Other error occurred
 pub async fn try_claim_leadership<T>(
@@ -230,7 +316,8 @@ pub async fn try_claim_leadership<T>(
     process_id: &str,
     my_priority: i32,
     current_time: Duration,
-) -> Result<Option<LeaderState>>
+    mut observation: LeaseObservation,
+) -> Result<(Option<LeaderState>, LeaseObservation)>
 where
     T: Deref<Target = Transaction>,
 {
@@ -248,21 +335,21 @@ where
     let key = leader_key(subspace);
     let current_leader = read_leader_state(txn, &key).await?;
 
-    let can_claim = match &current_leader {
-        None => true, // No leader exists
-        Some(leader) => {
-            leader.leader_id == process_id // Already leader (refresh)
-                || !leader.is_lease_valid(current_time) // Lease expired
-                || (config.allow_preemption && my_priority > leader.priority) // Preemption
-        }
+    let outcome = decide_claim(
+        current_leader.as_ref(),
+        process_id,
+        my_priority,
+        config.allow_preemption,
+        config.lease_duration,
+        current_time,
+        &mut observation,
+    );
+
+    let new_ballot = match outcome {
+        ClaimOutcome::Deny => return Ok((None, observation)),
+        ClaimOutcome::Claim { new_ballot } => new_ballot,
     };
 
-    if !can_claim {
-        return Ok(None);
-    }
-
-    // Claim leadership with incremented ballot
-    let new_ballot = current_leader.as_ref().map(|l| l.ballot + 1).unwrap_or(1);
     let lease_expiry = current_time + config.lease_duration;
 
     let new_state = LeaderState {
@@ -274,7 +361,7 @@ where
     };
 
     write_leader_state(txn, &key, &new_state);
-    Ok(Some(new_state))
+    Ok((Some(new_state), observation))
 }
 
 /// Refresh leadership lease
@@ -324,7 +411,11 @@ where
 
 /// Voluntarily resign leadership
 ///
-/// Immediately releases leadership. Other candidates can claim.
+/// Immediately releases leadership. Other candidates can claim right away
+/// (no lease wait), because a resigned record is written as *vacant* rather
+/// than deleted: `leader_id` is cleared and `lease_expiry_nanos` set to `0`
+/// while the ballot is preserved. Preserving the ballot keeps it globally
+/// monotonic so it stays valid as a fencing token across resignations.
 ///
 /// # Arguments
 /// * `txn` - The FoundationDB transaction
@@ -342,7 +433,15 @@ where
 
     match current {
         Some(leader) if leader.leader_id == process_id => {
-            txn.clear(&key);
+            // Write a vacant record: preserve the ballot, drop the holder.
+            let vacant = LeaderState {
+                ballot: leader.ballot,
+                leader_id: String::new(),
+                priority: 0,
+                lease_expiry_nanos: 0,
+                versionstamp: leader.versionstamp,
+            };
+            write_leader_state(txn, &key, &vacant);
             Ok(true)
         }
         _ => Ok(false),
@@ -710,12 +809,20 @@ where
 /// # Returns
 /// `ElectionResult::Leader` if this process is leader, `ElectionResult::Follower` otherwise
 ///
+/// # Observation state
+///
+/// Like [`try_claim_leadership`], this threads a caller-owned
+/// [`LeaseObservation`] value in and out so an unrefreshed lease can be stolen
+/// only after being observed for `lease_duration`.
+///
 /// # Example
 /// ```ignore
+/// let mut obs = LeaseObservation::new();
 /// loop {
-///     let result = db.run(|txn| {
-///         run_election_cycle(&txn, &subspace, &my_id, my_priority, now())
+///     let (result, next_obs) = db.run(|txn| {
+///         run_election_cycle(&txn, &subspace, &my_id, my_priority, now(), obs.clone())
 ///     }).await?;
+///     obs = next_obs;
 ///
 ///     match result {
 ///         ElectionResult::Leader(state) => {
@@ -738,7 +845,8 @@ pub async fn run_election_cycle<T>(
     process_id: &str,
     my_priority: i32,
     current_time: Duration,
-) -> Result<ElectionResult>
+    observation: LeaseObservation,
+) -> Result<(ElectionResult, LeaseObservation)>
 where
     T: Deref<Target = Transaction>,
 {
@@ -746,11 +854,247 @@ where
     heartbeat_candidate(txn, subspace, process_id, my_priority, current_time).await?;
 
     // 2. Try to claim/maintain leadership
-    match try_claim_leadership(txn, subspace, process_id, my_priority, current_time).await? {
-        Some(state) => Ok(ElectionResult::Leader(state)),
+    let (claim, observation) = try_claim_leadership(
+        txn,
+        subspace,
+        process_id,
+        my_priority,
+        current_time,
+        observation,
+    )
+    .await?;
+    match claim {
+        Some(state) => Ok((ElectionResult::Leader(state), observation)),
         None => {
             let current_leader = get_leader(txn, subspace, current_time).await?;
-            Ok(ElectionResult::Follower(current_leader))
+            Ok((ElectionResult::Follower(current_leader), observation))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn leader(id: &str, ballot: u64, priority: i32, vs_seed: u8) -> LeaderState {
+        LeaderState {
+            ballot,
+            leader_id: id.to_string(),
+            priority,
+            lease_expiry_nanos: 1_000, // non-zero => not vacant
+            versionstamp: [vs_seed; 12],
+        }
+    }
+
+    fn vacant(ballot: u64, vs_seed: u8) -> LeaderState {
+        LeaderState {
+            ballot,
+            leader_id: String::new(),
+            priority: 0,
+            lease_expiry_nanos: 0,
+            versionstamp: [vs_seed; 12],
+        }
+    }
+
+    const LEASE: Duration = Duration::from_secs(10);
+
+    #[test]
+    fn no_record_claims_ballot_one() {
+        let mut obs = LeaseObservation::new();
+        let outcome = decide_claim(None, "p1", 0, true, LEASE, Duration::from_secs(1), &mut obs);
+        assert_eq!(outcome, ClaimOutcome::Claim { new_ballot: 1 });
+        assert_eq!(obs, LeaseObservation::new());
+    }
+
+    #[test]
+    fn vacant_record_claims_next_ballot_without_waiting() {
+        let mut obs = LeaseObservation::new();
+        let state = vacant(7, 3);
+        let outcome = decide_claim(
+            Some(&state),
+            "p1",
+            0,
+            false,
+            LEASE,
+            Duration::from_secs(1),
+            &mut obs,
+        );
+        assert_eq!(outcome, ClaimOutcome::Claim { new_ballot: 8 });
+        assert_eq!(obs, LeaseObservation::new());
+    }
+
+    #[test]
+    fn already_leader_reclaims_next_ballot() {
+        let mut obs = LeaseObservation::new();
+        let state = leader("p1", 4, 0, 1);
+        let outcome = decide_claim(
+            Some(&state),
+            "p1",
+            0,
+            false,
+            LEASE,
+            Duration::from_secs(1),
+            &mut obs,
+        );
+        assert_eq!(outcome, ClaimOutcome::Claim { new_ballot: 5 });
+    }
+
+    #[test]
+    fn other_leader_first_sight_denies_and_starts_timer() {
+        let mut obs = LeaseObservation::new();
+        let state = leader("p2", 4, 0, 1);
+        let outcome = decide_claim(
+            Some(&state),
+            "p1",
+            0,
+            false,
+            LEASE,
+            Duration::from_secs(1),
+            &mut obs,
+        );
+        assert_eq!(outcome, ClaimOutcome::Deny);
+        // Now watching, timer at t=1s.
+        assert_ne!(obs, LeaseObservation::new());
+    }
+
+    #[test]
+    fn other_leader_same_identity_before_lease_keeps_denying() {
+        let mut obs = LeaseObservation::new();
+        let state = leader("p2", 4, 0, 1);
+        // First sight at t=1.
+        decide_claim(
+            Some(&state),
+            "p1",
+            0,
+            false,
+            LEASE,
+            Duration::from_secs(1),
+            &mut obs,
+        );
+        let snapshot = obs.clone();
+        // Same identity at t=5 (elapsed 4s < 10s lease): still deny, timer unchanged.
+        let outcome = decide_claim(
+            Some(&state),
+            "p1",
+            0,
+            false,
+            LEASE,
+            Duration::from_secs(5),
+            &mut obs,
+        );
+        assert_eq!(outcome, ClaimOutcome::Deny);
+        assert_eq!(
+            obs, snapshot,
+            "first_seen must not move while identity is stable"
+        );
+    }
+
+    #[test]
+    fn other_leader_same_identity_after_lease_steals() {
+        let mut obs = LeaseObservation::new();
+        let state = leader("p2", 4, 0, 1);
+        // First sight at t=1.
+        decide_claim(
+            Some(&state),
+            "p1",
+            0,
+            false,
+            LEASE,
+            Duration::from_secs(1),
+            &mut obs,
+        );
+        // Same identity at t=11 (elapsed 10s >= 10s lease): steal.
+        let outcome = decide_claim(
+            Some(&state),
+            "p1",
+            0,
+            false,
+            LEASE,
+            Duration::from_secs(11),
+            &mut obs,
+        );
+        assert_eq!(outcome, ClaimOutcome::Claim { new_ballot: 5 });
+        assert_eq!(
+            obs,
+            LeaseObservation::new(),
+            "observation cleared after steal"
+        );
+    }
+
+    #[test]
+    fn identity_change_resets_timer() {
+        let mut obs = LeaseObservation::new();
+        // Watch p2 ballot 4 from t=1.
+        decide_claim(
+            Some(&leader("p2", 4, 0, 1)),
+            "p1",
+            0,
+            false,
+            LEASE,
+            Duration::from_secs(1),
+            &mut obs,
+        );
+        // Leader refreshed to ballot 5 (identity changed) at t=11: timer resets, deny.
+        let outcome = decide_claim(
+            Some(&leader("p2", 5, 0, 1)),
+            "p1",
+            0,
+            false,
+            LEASE,
+            Duration::from_secs(11),
+            &mut obs,
+        );
+        assert_eq!(outcome, ClaimOutcome::Deny);
+        // A further 9s (t=20, elapsed 9s < 10s) still denies: the timer restarted at t=11.
+        let outcome = decide_claim(
+            Some(&leader("p2", 5, 0, 1)),
+            "p1",
+            0,
+            false,
+            LEASE,
+            Duration::from_secs(20),
+            &mut obs,
+        );
+        assert_eq!(outcome, ClaimOutcome::Deny);
+    }
+
+    #[test]
+    fn preemption_bypasses_observation_wait() {
+        let mut obs = LeaseObservation::new();
+        let state = leader("p2", 4, 1, 1);
+        // Higher priority (10 > 1), preemption on: claim immediately on first sight.
+        let outcome = decide_claim(
+            Some(&state),
+            "p1",
+            10,
+            true,
+            LEASE,
+            Duration::from_secs(1),
+            &mut obs,
+        );
+        assert_eq!(outcome, ClaimOutcome::Claim { new_ballot: 5 });
+        assert_eq!(obs, LeaseObservation::new());
+    }
+
+    #[test]
+    fn decision_is_idempotent_under_identical_inputs() {
+        let state = leader("p2", 4, 0, 1);
+        let mut obs_a = LeaseObservation::new();
+        let mut obs_b = LeaseObservation::new();
+        let t = Duration::from_secs(3);
+
+        let a = decide_claim(Some(&state), "p1", 0, false, LEASE, t, &mut obs_a);
+        // Same call twice on obs_a: a retry recomputes the same result and state.
+        let a_retry = decide_claim(Some(&state), "p1", 0, false, LEASE, t, &mut obs_a);
+        // Fresh observation reaching the same input reaches the same state.
+        let b = decide_claim(Some(&state), "p1", 0, false, LEASE, t, &mut obs_b);
+
+        assert_eq!(a, ClaimOutcome::Deny);
+        assert_eq!(a_retry, ClaimOutcome::Deny);
+        assert_eq!(b, ClaimOutcome::Deny);
+        assert_eq!(
+            obs_a, obs_b,
+            "retry leaves observation identical to first run"
+        );
     }
 }

--- a/foundationdb/src/recipes/leader_election/mod.rs
+++ b/foundationdb/src/recipes/leader_election/mod.rs
@@ -47,25 +47,48 @@
 //! ### Ballots
 //! Ballot numbers work like Raft's term - a monotonically increasing counter
 //! that establishes ordering. Higher ballot always wins. Each leadership claim
-//! or lease refresh increments the ballot. This prevents split-brain scenarios
-//! after network partitions heal.
+//! or lease refresh increments the ballot by one. Ballots are *globally
+//! monotonic*: they never regress and never reset, including across a
+//! resignation (a resigned record is kept as a vacant record that preserves
+//! the ballot). This prevents split-brain scenarios after network partitions
+//! heal.
 //!
 //! The ballot is returned in [`LeaderState::ballot`](leader_election::LeaderState::ballot) and can be used as a
-//! fencing token when accessing external resources.
+//! fencing token when accessing external resources: a stale leader always
+//! carries a strictly lower ballot than its successor.
 //!
 //! ### Leases
 //! Leaders hold time-bounded leases configured via [`lease_duration`](leader_election::ElectionConfig::lease_duration).
 //! A leader must call [`run_election_cycle`](leader_election::LeaderElection::run_election_cycle) (or [`refresh_lease`](leader_election::LeaderElection::refresh_lease))
 //! before the lease expires to maintain leadership.
 //!
-//! If a leader fails to refresh (crash, network partition), other candidates
-//! can claim leadership after the lease expires.
+//! If a leader fails to refresh (crash, network partition), another candidate
+//! can claim leadership, but only after it has observed the same unrefreshed
+//! leader record for a full `lease_duration` on *its own* clock. This
+//! elapsed-time rule (see [`LeaseObservation`](leader_election::LeaseObservation)) means the protocol does not
+//! assume clocks are synchronized: it relies only on clock *rates* being
+//! roughly comparable, not on absolute offsets. A leader that keeps refreshing
+//! bumps its ballot each time, which resets every observer's timer, so a live
+//! leader is never stolen from.
+//!
+//! The observation window is measured against the `current_time` you pass in.
+//! For belief-level exclusion to hold, sample `current_time` close to the
+//! transaction's execution (for example just before the read), not far in
+//! advance. If you sample it and then run a slow or heavily-retried
+//! transaction, the window is measured from that earlier instant and can
+//! over-count, letting a lease be stolen before it has truly been idle for
+//! `lease_duration`. Record-level exclusion and the fencing ballot are
+//! unaffected either way; only the belief-level guarantee is timing-sensitive.
 //!
 //! ### Preemption
 //! When [`allow_preemption`](leader_election::ElectionConfig::allow_preemption) is true, higher-priority candidates
-//! can preempt lower-priority leaders. Priority is set via the `priority` parameter
+//! can preempt lower-priority leaders immediately, without the observation
+//! wait. Priority is set via the `priority` parameter
 //! in [`register_candidate`](leader_election::LeaderElection::register_candidate). This enables graceful leadership migration
 //! to new machines during rolling deployments or infrastructure upgrades.
+//! Preemption deliberately trades away belief-level mutual exclusion (the old
+//! leader may still think it holds the lease until it next checks); correctness
+//! then rests on the fencing ballot alone.
 //!
 //! ## Configuration
 //!
@@ -91,20 +114,29 @@
 //!
 //! ## Safety Properties
 //!
-//! - **Mutual Exclusion**: At most one leader at any time (guaranteed by FDB serializable transactions)
-//! - **Liveness**: A correct process eventually becomes leader
-//! - **Consistency**: Ballot numbers provide total ordering of leadership changes
+//! - **Record-level mutual exclusion**: At most one leader record exists at any
+//!   time (guaranteed by FDB serializable transactions on the single leader key).
+//! - **Fencing**: Ballot numbers are strictly increasing and never reset, so a
+//!   stale leader always holds a lower ballot than its successor. Guarding
+//!   external writes with the ballot gives mutual exclusion even when two
+//!   processes transiently *believe* they are leader.
+//! - **Belief-level exclusion** (preemption disabled): with `allow_preemption`
+//!   false, a lease is only stolen after being observed unrefreshed for a full
+//!   `lease_duration`, so two processes cannot both believe they hold a valid
+//!   lease as long as their clock rates stay comparable.
+//! - **Liveness**: A correct process eventually becomes leader.
 //!
 //! ## Simulation Testing
 //!
 //! This implementation is validated through FoundationDB's deterministic simulation
-//! framework under extreme conditions including network partitions, process failures,
-//! and clock skew up to ±2 seconds.
+//! framework under network partitions, process failures/reboots, and per-client
+//! clock skew.
 //!
 //! Key invariants verified:
-//! - No overlapping leadership (mutual exclusion)
-//! - Ballot monotonicity (ballots never regress)
-//! - Fencing token validity (each claim increments ballot)
+//! - Dual-path validation (replayed log matches the committed leader state)
+//! - Ballot succession (each claim is exactly `previous_ballot + 1`, globally)
+//! - No belief-level leadership overlap (with preemption disabled)
+//! - Progress (a run actually elects leaders and heartbeats)
 //!
 //! See `foundationdb-recipes-simulation` crate for test configurations.
 
@@ -114,7 +146,7 @@ mod keys;
 mod types;
 
 pub use errors::{LeaderElectionError, Result};
-pub use types::{CandidateInfo, ElectionConfig, ElectionResult, LeaderState};
+pub use types::{CandidateInfo, ElectionConfig, ElectionResult, LeaderState, LeaseObservation};
 
 use crate::{Transaction, tuple::Subspace};
 use std::ops::Deref;
@@ -370,17 +402,28 @@ impl LeaderElection {
     /// Attempts to become the leader. This is an O(1) operation that:
     /// 1. Looks up candidate registration to get versionstamp
     /// 2. Reads the current leader state
-    /// 3. Checks if we can claim (no leader, expired lease, or preemption)
+    /// 3. Decides if we can claim (no leader, vacant record, preemption, or an
+    ///    unrefreshed lease observed for `lease_duration`)
     /// 4. Writes new leader state with incremented ballot
+    ///
+    /// # Observation state
+    ///
+    /// To steal an apparently-expired lease, the caller must observe the same
+    /// leader record for `lease_duration` on its own clock. Pass a caller-owned
+    /// [`LeaseObservation`] in and keep the returned value for the next call.
+    /// A healthy leader bumps its ballot on every refresh, resetting the timer,
+    /// so a live leader is never stolen from.
     ///
     /// # Arguments
     /// * `process_id` - Unique identifier for this process
     /// * `priority` - Priority level for preemption decisions
     /// * `current_time` - Current time for lease calculation
+    /// * `observation` - Caller-owned lease-observation state
     ///
     /// # Returns
-    /// * `Ok(Some(state))` - Successfully claimed leadership
-    /// * `Ok(None)` - Cannot claim, another valid leader exists
+    /// A tuple of the claim result and the updated observation:
+    /// * `Ok((Some(state), obs))` - Successfully claimed leadership
+    /// * `Ok((None, obs))` - Cannot claim yet (another leader exists)
     /// * `Err(UnregisteredCandidate)` - Process is not registered as a candidate
     pub async fn try_claim_leadership<T>(
         &self,
@@ -388,12 +431,20 @@ impl LeaderElection {
         process_id: &str,
         priority: i32,
         current_time: Duration,
-    ) -> Result<Option<LeaderState>>
+        observation: LeaseObservation,
+    ) -> Result<(Option<LeaderState>, LeaseObservation)>
     where
         T: Deref<Target = Transaction>,
     {
-        algorithm::try_claim_leadership(txn, &self.subspace, process_id, priority, current_time)
-            .await
+        algorithm::try_claim_leadership(
+            txn,
+            &self.subspace,
+            process_id,
+            priority,
+            current_time,
+            observation,
+        )
+        .await
     }
 
     /// Refresh leadership lease
@@ -478,23 +529,40 @@ impl LeaderElection {
     /// Combines candidate heartbeat + leadership claim in one operation.
     /// This is what most users should call in their main loop.
     ///
+    /// # Observation state
+    ///
+    /// Like [`try_claim_leadership`](Self::try_claim_leadership), this threads a
+    /// caller-owned [`LeaseObservation`] value in and out so an unrefreshed
+    /// lease can be stolen only after being observed for `lease_duration`.
+    ///
     /// # Arguments
     /// * `process_id` - Unique identifier for this process
     /// * `priority` - Priority level
     /// * `current_time` - Current time
+    /// * `observation` - Caller-owned lease-observation state
     ///
     /// # Returns
-    /// `ElectionResult::Leader` if this process is leader, `ElectionResult::Follower` otherwise
+    /// A tuple of the [`ElectionResult`] (`Leader` if this process is leader,
+    /// `Follower` otherwise) and the updated observation.
     pub async fn run_election_cycle<T>(
         &self,
         txn: &T,
         process_id: &str,
         priority: i32,
         current_time: Duration,
-    ) -> Result<ElectionResult>
+        observation: LeaseObservation,
+    ) -> Result<(ElectionResult, LeaseObservation)>
     where
         T: Deref<Target = Transaction>,
     {
-        algorithm::run_election_cycle(txn, &self.subspace, process_id, priority, current_time).await
+        algorithm::run_election_cycle(
+            txn,
+            &self.subspace,
+            process_id,
+            priority,
+            current_time,
+            observation,
+        )
+        .await
     }
 }

--- a/foundationdb/src/recipes/leader_election/types.rs
+++ b/foundationdb/src/recipes/leader_election/types.rs
@@ -40,6 +40,14 @@ pub const DEFAULT_CANDIDATE_TIMEOUT: Duration = Duration::from_secs(15);
 /// - Higher ballot always wins
 /// - Prevents split-brain after recovery/partition
 /// - Incremented on every leadership claim or refresh
+///
+/// # Vacant Records
+///
+/// When a leader resigns, the record is not deleted. Instead a *vacant*
+/// record is written: `leader_id` is empty and `lease_expiry_nanos` is `0`,
+/// while `ballot` is preserved. This keeps ballots globally monotonic so they
+/// remain usable as fencing tokens across resignations. Use [`is_vacant`](Self::is_vacant)
+/// to detect this state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LeaderState {
     /// Ballot number (like Raft's term)
@@ -94,6 +102,83 @@ impl LeaderState {
             ))
         } else {
             None
+        }
+    }
+
+    /// Check if this is a vacant record left behind by a resignation
+    ///
+    /// A vacant record preserves the ballot (so fencing tokens stay monotonic)
+    /// but has no holder: `leader_id` is empty and `lease_expiry_nanos` is `0`.
+    /// A vacant record can be claimed immediately by any candidate without
+    /// waiting for a lease to expire.
+    pub fn is_vacant(&self) -> bool {
+        self.lease_expiry_nanos == 0
+    }
+}
+
+/// Caller-owned state for elapsed-time lease stealing
+///
+/// To claim leadership from a leader whose lease looks expired, a candidate
+/// must first observe the *same* leader record continuously for
+/// `lease_duration` measured on its own clock. This mirrors the DynamoDB lock
+/// client approach and avoids assuming clocks are synchronized: a healthy
+/// leader bumps its ballot on every refresh, which changes the record identity
+/// and resets every observer's timer, so a live leader can never be stolen
+/// from. Only a stalled leader (crash or partition, no refresh) keeps a fixed
+/// identity long enough to be stolen.
+///
+/// Each participating process owns one `LeaseObservation` and threads it
+/// through successive [`try_claim_leadership`](crate::recipes::leader_election::LeaderElection::try_claim_leadership)
+/// / [`run_election_cycle`](crate::recipes::leader_election::LeaderElection::run_election_cycle)
+/// calls: pass it in, then keep the returned value for the next call. The
+/// update is a pure function of the observed record and the supplied
+/// `current_time`, so it is safe under transaction retries.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LeaseObservation {
+    seen: Option<SeenRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SeenRecord {
+    ballot: u64,
+    versionstamp: [u8; 12],
+    /// Caller's own clock when this record identity was first observed.
+    first_seen: Duration,
+}
+
+impl LeaseObservation {
+    /// Create a fresh observation that is not watching any record
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Stop watching (called once a claim is made or the record identity changes)
+    pub(crate) fn clear(&mut self) {
+        self.seen = None;
+    }
+
+    /// Record that we saw `(ballot, versionstamp)` at `current_time`.
+    ///
+    /// Returns how long the same identity has been observed. Starting to watch
+    /// a new identity (or a changed one) resets the timer to zero.
+    pub(crate) fn observe(
+        &mut self,
+        ballot: u64,
+        versionstamp: [u8; 12],
+        current_time: Duration,
+    ) -> Duration {
+        match &self.seen {
+            Some(s) if s.ballot == ballot && s.versionstamp == versionstamp => {
+                current_time.saturating_sub(s.first_seen)
+            }
+            _ => {
+                self.seen = Some(SeenRecord {
+                    ballot,
+                    versionstamp,
+                    first_seen: current_time,
+                });
+                Duration::ZERO
+            }
         }
     }
 }

--- a/foundationdb/tests/leader_election.rs
+++ b/foundationdb/tests/leader_election.rs
@@ -11,7 +11,7 @@ mod common;
 mod leader_election_tests {
     use foundationdb::{
         Database, FdbBindingError,
-        recipes::leader_election::{ElectionConfig, LeaderElection},
+        recipes::leader_election::{ElectionConfig, LeaderElection, LeaseObservation},
         tuple::Subspace,
     };
     use std::time::Duration;
@@ -67,8 +67,14 @@ mod leader_election_tests {
         let election_ref = &election;
         let became_leader = db
             .run(|txn, _| async move {
-                let result = election_ref
-                    .try_claim_leadership(&txn, process_id, 0, current_time())
+                let (result, _) = election_ref
+                    .try_claim_leadership(
+                        &txn,
+                        process_id,
+                        0,
+                        current_time(),
+                        LeaseObservation::default(),
+                    )
                     .await?;
                 Ok::<_, FdbBindingError>(result.is_some())
             })
@@ -125,8 +131,14 @@ mod leader_election_tests {
             let election_ref = &election;
             let became_leader = db
                 .run(|txn, _| async move {
-                    let result = election_ref
-                        .try_claim_leadership(&txn, process_id, 0, current_time())
+                    let (result, _) = election_ref
+                        .try_claim_leadership(
+                            &txn,
+                            process_id,
+                            0,
+                            current_time(),
+                            LeaseObservation::default(),
+                        )
                         .await?;
                     Ok::<_, FdbBindingError>(result.is_some())
                 })
@@ -219,8 +231,14 @@ mod leader_election_tests {
         let election_ref = &election;
         let became_leader = db
             .run(|txn, _| async move {
-                let result = election_ref
-                    .try_claim_leadership(&txn, leader_id, 0, current_time())
+                let (result, _) = election_ref
+                    .try_claim_leadership(
+                        &txn,
+                        leader_id,
+                        0,
+                        current_time(),
+                        LeaseObservation::default(),
+                    )
                     .await?;
                 Ok::<_, FdbBindingError>(result.is_some())
             })
@@ -302,30 +320,47 @@ mod leader_election_tests {
         let election_ref = &election;
         let became_leader = db
             .run(|txn, _| async move {
-                let result = election_ref
-                    .try_claim_leadership(&txn, initial_leader, 0, current_time())
+                let (result, _) = election_ref
+                    .try_claim_leadership(
+                        &txn,
+                        initial_leader,
+                        0,
+                        current_time(),
+                        LeaseObservation::default(),
+                    )
                     .await?;
                 Ok::<_, FdbBindingError>(result.is_some())
             })
             .await?;
         assert!(became_leader, "Initial process should become leader");
 
-        // New leader tries to claim (should fail - lease is valid)
+        // new_leader owns an observation that it threads across claim attempts.
+        // Stealing an expired lease now requires observing the same leader
+        // record for a full lease_duration, so the first attempt only starts
+        // the timer.
+        let mut obs = LeaseObservation::default();
+
+        // New leader tries to claim (should fail - lease is valid, and this is
+        // the first observation of the incumbent record anyway)
         let election_ref = &election;
-        let became_leader = db
-            .run(|txn, _| async move {
-                let result = election_ref
-                    .try_claim_leadership(&txn, new_leader, 0, current_time())
-                    .await?;
-                Ok::<_, FdbBindingError>(result.is_some())
+        let (became_leader, next_obs) = db
+            .run(|txn, _| {
+                let obs = obs.clone();
+                async move {
+                    let (result, next_obs) = election_ref
+                        .try_claim_leadership(&txn, new_leader, 0, current_time(), obs)
+                        .await?;
+                    Ok::<_, FdbBindingError>((result.is_some(), next_obs))
+                }
             })
             .await?;
+        obs = next_obs;
         assert!(
             !became_leader,
-            "New process should not become leader while initial lease is valid"
+            "New process should not become leader on first observation of the incumbent"
         );
 
-        // Wait for lease to expire
+        // Wait longer than the lease so the observation window is satisfied
         sleep(Duration::from_secs(4));
 
         // Keep new_leader alive via heartbeat
@@ -338,19 +373,23 @@ mod leader_election_tests {
         })
         .await?;
 
-        // New leader tries to claim again (should succeed - lease expired)
+        // New leader tries to claim again with the same observation (should
+        // succeed - it has now observed the unrefreshed incumbent for >= lease)
         let election_ref = &election;
         let became_leader = db
-            .run(|txn, _| async move {
-                let result = election_ref
-                    .try_claim_leadership(&txn, new_leader, 0, current_time())
-                    .await?;
-                Ok::<_, FdbBindingError>(result.is_some())
+            .run(|txn, _| {
+                let obs = obs.clone();
+                async move {
+                    let (result, _) = election_ref
+                        .try_claim_leadership(&txn, new_leader, 0, current_time(), obs)
+                        .await?;
+                    Ok::<_, FdbBindingError>(result.is_some())
+                }
             })
             .await?;
         assert!(
             became_leader,
-            "New process should become leader after initial lease expires"
+            "New process should become leader after observing the stale lease for a full lease_duration"
         );
 
         // Verify new leadership
@@ -491,15 +530,23 @@ mod leader_election_tests {
         })
         .await?;
 
-        // Leader claims leadership
+        // Leader claims leadership (ballot 1)
         let election_ref = &election;
-        db.run(|txn, _| async move {
-            election_ref
-                .try_claim_leadership(&txn, leader_id, 0, current_time())
-                .await?;
-            Ok::<_, FdbBindingError>(())
-        })
-        .await?;
+        let leader_ballot = db
+            .run(|txn, _| async move {
+                let (result, _) = election_ref
+                    .try_claim_leadership(
+                        &txn,
+                        leader_id,
+                        0,
+                        current_time(),
+                        LeaseObservation::default(),
+                    )
+                    .await?;
+                Ok::<_, FdbBindingError>(result.map(|s| s.ballot))
+            })
+            .await?;
+        assert_eq!(leader_ballot, Some(1), "First claim should be ballot 1");
 
         // Leader resigns
         let election_ref = &election;
@@ -511,19 +558,27 @@ mod leader_election_tests {
             .await?;
         assert!(resigned, "Leader should be able to resign");
 
-        // Follower can now claim leadership
+        // Follower can now claim leadership immediately (vacant record, no wait).
+        // The ballot must continue from the resigned record, not reset.
         let election_ref = &election;
-        let became_leader = db
+        let follower_ballot = db
             .run(|txn, _| async move {
-                let result = election_ref
-                    .try_claim_leadership(&txn, follower_id, 0, current_time())
+                let (result, _) = election_ref
+                    .try_claim_leadership(
+                        &txn,
+                        follower_id,
+                        0,
+                        current_time(),
+                        LeaseObservation::default(),
+                    )
                     .await?;
-                Ok::<_, FdbBindingError>(result.is_some())
+                Ok::<_, FdbBindingError>(result.map(|s| s.ballot))
             })
             .await?;
-        assert!(
-            became_leader,
-            "Follower should become leader after resignation"
+        assert_eq!(
+            follower_ballot,
+            Some(2),
+            "Ballot must continue across resignation (2, not reset to 1)"
         );
 
         Ok(())
@@ -575,20 +630,32 @@ mod leader_election_tests {
         let election_ref = &election;
         let became_leader = db
             .run(|txn, _| async move {
-                let result = election_ref
-                    .try_claim_leadership(&txn, low_priority, 1, current_time())
+                let (result, _) = election_ref
+                    .try_claim_leadership(
+                        &txn,
+                        low_priority,
+                        1,
+                        current_time(),
+                        LeaseObservation::default(),
+                    )
                     .await?;
                 Ok::<_, FdbBindingError>(result.is_some())
             })
             .await?;
         assert!(became_leader, "Low priority should become leader initially");
 
-        // High priority preempts
+        // High priority preempts (bypasses the observation wait)
         let election_ref = &election;
         let became_leader = db
             .run(|txn, _| async move {
-                let result = election_ref
-                    .try_claim_leadership(&txn, high_priority, 10, current_time())
+                let (result, _) = election_ref
+                    .try_claim_leadership(
+                        &txn,
+                        high_priority,
+                        10,
+                        current_time(),
+                        LeaseObservation::default(),
+                    )
                     .await?;
                 Ok::<_, FdbBindingError>(result.is_some())
             })

--- a/scripts/run_leader_election_simulation.sh
+++ b/scripts/run_leader_election_simulation.sh
@@ -17,6 +17,7 @@ TESTS=(
     "foundationdb-recipes-simulation/test_ballot_stress.toml"
     "foundationdb-recipes-simulation/test_rapid_leadership.toml"
     "foundationdb-recipes-simulation/test_short_lease.toml"
+    "foundationdb-recipes-simulation/test_strict_mutex.toml"
 )
 
 for test in "${TESTS[@]}"; do


### PR DESCRIPTION
## Context

The `leader_election` recipe is heading to production. A review found the simulation that supposedly validates it had real holes (2 of 13 invariants were hardcoded `true`, so true mutual exclusion was never asserted), and the recipe itself had two weaknesses: ballots reset to 1 on resign (unusable as fencing tokens), and lease stealing compared timestamps with zero clock-skew margin.

## Recipe changes (breaking)

- **Ballot-preserving resign**: `resign_leadership` writes a *vacant* record (empty `leader_id`, `lease_expiry_nanos = 0`) that keeps the ballot instead of clearing the key. Ballots are now globally monotonic and stay valid as fencing tokens across resignations. Adds `LeaderState::is_vacant`.
- **Elapsed-time lease stealing** (DynamoDB lock-client style): a new opaque `LeaseObservation` is threaded through `try_claim_leadership` / `run_election_cycle` (now returning `(result, observation)`). A lease is stolen only after observing the same record for `lease_duration` on the caller's own clock, so the protocol does not assume synchronized clocks. Claim policy is factored into a pure, unit-tested `decide_claim`.

**BREAKING CHANGE**: `try_claim_leadership` and `run_election_cycle` take a `LeaseObservation` and return it alongside the result.

### Finding surfaced by the strengthened sim

Belief-level exclusion depends on the caller sampling `current_time` close to the transaction's read. A stale, pre-transaction sample lets retry/clogging latency inflate the observation window and allow a premature steal. Record-level exclusion and the fencing ballot are unaffected. Documented in the recipe docs and sim README.

## Simulation changes

- Replaced the 13 invariants (2 dead) with 10 real ones. `NoBeliefOverlap` reconstructs leadership from the commit-ordered log and asserts every steal lands after the victim's lease horizon; `ProgressMade` fails vacuous runs; ballot invariants dropped the resign carve-outs.
- `check()` runs on **all** clients (previously client 0 only, which Attrition could kill).
- Log entries carry read-anchored `sim_time`; the claim clock is sampled **inside** the transaction so retry/clogging latency cannot inflate the observation. This required deriving `Clone` for `WorkloadContext` in `foundationdb-simulation`.
- New `test_strict_mutex.toml` (preemption off, zero skew) for the strict assertion; new `allowPreemption` / `maxClockSkewSecs` / `min*` options; fixed the `current_time = 0.0` snapshot bug.

## Verification

- 9 recipe unit tests (`decide_claim`) + 7 integration tests against a live cluster (elapsed-time stealing, ballot continuity across resign, preemption).
- Full 5-config sim suite x3 iterations and a 17-seed strict-config stress run all pass (steals land with negative overlap = safety margin).
- `cargo fmt --all` and `cargo clippy-all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)