### PR TITLE
feat: client-side transaction budgets, per-attempt metrics, modular retry runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,12 @@ Layered, bottom to top:
   - `api.rs` - process-global `NetworkLifecycle` state machine managing the C API and the
     network event-loop: safe idempotent `boot()`, lazy start from `Database` constructors,
     automatic stop + join at process exit (atexit hook), explicit `stop_network()`.
-  - `database.rs` - `Database`, plus the closure retry loop `run()` / `instrumented_run()`
-    with backoff and the pluggable `RunnerHooks` trait (no-op vs metrics paths).
+  - `database.rs` - `Database` and the entry points of the retry runner: `run()`,
+    `runner()` (builder), `run_with_hooks()`, `instrumented_run()`.
+  - `runner.rs` - the retry runner itself: one attempt (closure + commit), the retry loop
+    on top of it (classification, `on_error`, backoff), the observational `RunnerHooks`
+    trait with its `()`/`&H`/`Option<H>`/`(A, B)` impls, `MetricsHooks`, and the typed
+    `RetryPolicy` (`NativeRetryPolicy` by default).
   - `transaction.rs` - `Transaction` (get/set/clear/atomic_op), commit/retry error types.
   - `future.rs` - `FdbFuture<T>`: non-blocking poll of `FDBFuture` + waker callback, the
     bridge to async/await across the network thread.

--- a/foundationdb/examples/budgeted_scan.rs
+++ b/foundationdb/examples/budgeted_scan.rs
@@ -1,0 +1,260 @@
+//! Scanning a large range across several transactions, each one bounded by a
+//! [`ClientBudget`].
+//!
+//! FoundationDB transactions may not live longer than five seconds, so a scan
+//! that does not fit in one transaction has to be cut into pages, each page
+//! resuming where the previous one stopped. This example shows the pattern:
+//!
+//! * the closure sets a budget (2.5s, comfortably below the five second limit),
+//! * it reads batch after batch and checks the budget between batches,
+//! * when the budget is exhausted it *stops* instead of failing: the closure
+//!   returns the progress it made, and the transaction commits normally,
+//! * `main` reopens a transaction from the continuation key and keeps going
+//!   until the scan reports it reached the end of the range.
+//!
+//! There is deliberately no helper API for this: the budget is a client-side
+//! estimate you check where it makes sense for your workload, and what to do
+//! when it runs out (stop, commit partial work, checkpoint elsewhere) is an
+//! application decision.
+
+use std::time::{Duration, Instant};
+
+use foundationdb::options::StreamingMode;
+use foundationdb::*;
+use futures_util::TryStreamExt;
+
+/// Keys written by the setup, `PREFIX` .. `END`.
+const PREFIX: &[u8] = b"budgeted_scan/";
+const END: &[u8] = b"budgeted_scan0";
+
+/// Number of rows and value size of the data set. 4000 x 1 KiB is around 4 MiB,
+/// so a scan with a 1 MiB target per batch takes a handful of batches.
+const ROWS: usize = 4000;
+const VALUE_SIZE: usize = 1024;
+/// Rows written per setup transaction, to stay well below the 10 MiB
+/// transaction size limit.
+const ROWS_PER_SETUP_TRX: usize = 500;
+
+fn key_of(index: usize) -> Vec<u8> {
+    let mut key = PREFIX.to_vec();
+    key.extend_from_slice(format!("{index:08}").as_bytes());
+    key
+}
+
+/// What one budgeted transaction managed to do.
+struct Page {
+    /// Rows read by this transaction.
+    rows: usize,
+    /// Last key processed, or `None` if the page read nothing. The next
+    /// transaction resumes *after* it, with `first_greater_than`.
+    last_key: Option<Vec<u8>>,
+    /// `true` when the range was fully consumed, that is when the batch stream
+    /// ended on its own rather than the budget cutting it short.
+    complete: bool,
+}
+
+/// Scans from `after` (exclusive, `None` to start at the beginning of the
+/// range) for as long as `budget` allows.
+async fn scan_page(
+    db: &Database,
+    after: Option<Vec<u8>>,
+    budget: ClientBudget,
+) -> Result<Page, FdbBindingError> {
+    db.run(|trx, _maybe_committed| {
+        let after = after.clone();
+        let budget = budget.clone();
+        async move {
+            // Set the budget first: it starts a fresh accounting generation, and
+            // on a retry the new attempt gets the full allowance again.
+            trx.set_client_budget(budget);
+
+            let begin = match &after {
+                // Exclusive continuation: resume strictly after the last key we
+                // processed, so no row is read twice and none is skipped.
+                Some(last) => KeySelector::first_greater_than(last.as_slice()),
+                None => KeySelector::first_greater_or_equal(PREFIX),
+            };
+            let opt = RangeOption {
+                begin,
+                end: KeySelector::first_greater_or_equal(END),
+                // Serial asks the cluster for the largest batches it will send
+                // (around 80 KiB), which is what we want when the loop, not the
+                // batch size, is deciding when to stop. `target_bytes` is only
+                // an upper cap: it never grows a batch beyond what the mode
+                // asks for.
+                mode: StreamingMode::Serial,
+                target_bytes: 1 << 20,
+                ..RangeOption::default()
+            };
+
+            let mut rows = 0;
+            let mut last_key = None;
+            // The stream ending is the only proof the range is exhausted.
+            let mut complete = true;
+            let mut batches = trx.get_ranges(opt, false);
+
+            while let Some(batch) = batches.try_next().await? {
+                for kv in batch.iter() {
+                    rows += 1;
+                    last_key = Some(kv.key().to_vec());
+                }
+
+                // The budget is checked *between* batches, never inside one: the
+                // batch that was in flight when the budget expired still lands and
+                // is fully processed. Expect an overshoot of up to one batch, and
+                // in time, of however long that batch took to arrive: nothing here
+                // interrupts an await. Size the budget with that margin in mind
+                // (2.5s against a 5s transaction limit).
+                if let Err(exceeded) = trx.check_client_budget() {
+                    // Matched, not propagated with `?`. Returning the error would
+                    // abort the whole `db.run` and throw away both the work of
+                    // this page and the continuation key. Breaking instead lets
+                    // the closure return normally: the transaction commits and the
+                    // caller resumes from `last_key`.
+                    println!("    budget reached: {exceeded}");
+                    complete = false;
+                    break;
+                }
+            }
+
+            Ok::<_, FdbBindingError>(Page {
+                rows,
+                last_key,
+                complete,
+            })
+        }
+    })
+    .await
+}
+
+/// Runs the full scan, one transaction per page, and returns how many rows and
+/// how many transactions it took.
+async fn scan_all(db: &Database, budget: ClientBudget) -> Result<(usize, usize), FdbBindingError> {
+    let mut continuation = None;
+    let mut total_rows = 0;
+    let mut transactions = 0;
+
+    loop {
+        let page = scan_page(db, continuation.clone(), budget.clone()).await?;
+        transactions += 1;
+        total_rows += page.rows;
+        println!(
+            "  transaction {}: {} row(s), {} rows so far",
+            transactions, page.rows, total_rows
+        );
+
+        if page.complete {
+            break;
+        }
+        // A page cut short by the budget always has a continuation key, unless
+        // it read nothing at all, which means there was nothing left to read.
+        match page.last_key {
+            Some(last) => continuation = Some(last),
+            None => break,
+        }
+    }
+
+    Ok((total_rows, transactions))
+}
+
+async fn setup(db: &Database) -> Result<(), FdbBindingError> {
+    let value = vec![b'x'; VALUE_SIZE];
+
+    db.run(|trx, _| async move {
+        trx.clear_range(PREFIX, END);
+        Ok::<_, FdbBindingError>(())
+    })
+    .await?;
+
+    for chunk_start in (0..ROWS).step_by(ROWS_PER_SETUP_TRX) {
+        let value = value.clone();
+        db.run(move |trx, _| {
+            let value = value.clone();
+            async move {
+                for index in chunk_start..(chunk_start + ROWS_PER_SETUP_TRX).min(ROWS) {
+                    trx.set(&key_of(index), &value);
+                }
+                Ok::<_, FdbBindingError>(())
+            }
+        })
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn run_example() -> Result<(), FdbBindingError> {
+    let db = Database::default()?;
+
+    println!("Writing {ROWS} rows of {VALUE_SIZE} bytes...");
+    setup(&db).await?;
+
+    println!("Scanning with a 2.5s per-transaction budget:");
+    let started = Instant::now();
+    let (rows, transactions) = scan_all(
+        &db,
+        ClientBudget {
+            time_limit: Some(Duration::from_millis(2500)),
+            ..ClientBudget::default()
+        },
+    )
+    .await?;
+    println!(
+        "  {rows} row(s) in {transactions} transaction(s), {:?}",
+        started.elapsed()
+    );
+
+    // On a local cluster 4 MiB is read well within 2.5s, so the scan above ends
+    // in a single transaction. The same loop with a byte budget of half a
+    // mebibyte shows the continuation actually resuming, a few batches per
+    // transaction.
+    println!("Scanning again with a 512 KiB read budget, to force continuations:");
+    let (rows, transactions) = scan_all(
+        &db,
+        ClientBudget {
+            max_bytes_read: Some(512 * 1024),
+            ..ClientBudget::default()
+        },
+    )
+    .await?;
+    println!("  {rows} row(s) in {transactions} transaction(s)");
+
+    db.run(|trx, _| async move {
+        trx.clear_range(PREFIX, END);
+        Ok::<_, FdbBindingError>(())
+    })
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    foundationdb::boot().expect("failed to initialize FoundationDB");
+    // The network is stopped and joined automatically at process exit, which is
+    // fine for tests and short-lived tools like this example. In a production
+    // application, prefer a clean teardown: the network thread is the event loop
+    // driving every transaction and you may still have on-going operations at
+    // exit time. Finish or cancel your work, drop the Database handles, then
+    // call `foundationdb::api::stop_network()` yourself (terminal: any
+    // FoundationDB use afterwards fails with error 2025).
+
+    if let Err(e) = run_example().await {
+        eprintln!("Error: {e:?}");
+    }
+}
+
+/*
+// Expected output:
+//
+// Writing 4000 rows of 1024 bytes...
+// Scanning with a 2.5s per-transaction budget:
+//   transaction 1: 4000 row(s), 4000 rows so far
+//   4000 row(s) in 1 transaction(s), 12.147459ms
+// Scanning again with a 512 KiB read budget, to force continuations:
+//     budget reached: client budget exceeded (bytes read): used 549150 bytes, limit 524288 bytes. ...
+//   transaction 1: 525 row(s), 525 rows so far
+//   ...
+//   transaction 8: 325 row(s), 4000 rows so far
+//   4000 row(s) in 8 transaction(s)
+*/

--- a/foundationdb/examples/conflict_reporting.rs
+++ b/foundationdb/examples/conflict_reporting.rs
@@ -10,8 +10,39 @@
 use foundationdb::options::TransactionOption;
 use foundationdb::runner::MetricsHooks;
 use foundationdb::*;
+use foundationdb_macros::cfg_api_versions;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Prints the write conflict ranges the attempt accumulated, which is what the
+/// resolver will check other transactions against.
+///
+/// Before the commit these are an approximate superset when versionstamped keys
+/// are used: the versionstamp is only resolved at commit time.
+///
+/// The `\xff\xff/transaction/write_conflict_range/` special keyspace exists from
+/// API version 630, hence the two variants below.
+#[cfg_api_versions(min = 630)]
+async fn print_write_conflict_ranges(trx: &Transaction, attempt: usize) -> FdbResult<()> {
+    let ranges = trx.write_conflict_ranges().await?;
+    println!(
+        "  before_commit (attempt {attempt}): {} write conflict range(s)",
+        ranges.len()
+    );
+    for range in &ranges {
+        println!(
+            "    {:?} .. {:?}",
+            String::from_utf8_lossy(range.begin()),
+            String::from_utf8_lossy(range.end()),
+        );
+    }
+    Ok(())
+}
+
+#[cfg_api_versions(min = 510, max = 620)]
+async fn print_write_conflict_ranges(_trx: &Transaction, _attempt: usize) -> FdbResult<()> {
+    Ok(())
+}
 
 /// A simple hook implementation that prints each lifecycle event.
 struct PrintHooks;
@@ -19,6 +50,13 @@ struct PrintHooks;
 impl RunnerHooks for PrintHooks {
     fn on_attempt_start(&self, _trx: &Transaction, attempt: usize) {
         println!("  on_attempt_start: attempt {attempt}");
+    }
+
+    /// Last point where the transaction can be inspected inside the attempt:
+    /// the write conflict ranges are complete here, while `conflicting_keys`
+    /// below only tells what actually clashed, and only once the commit failed.
+    async fn before_commit(&self, trx: &Transaction, attempt: usize) -> FdbResult<()> {
+        print_write_conflict_ranges(trx, attempt).await
     }
 
     async fn on_commit_error(&self, err: &TransactionCommitError, attempt: usize) -> FdbResult<()> {
@@ -144,11 +182,15 @@ async fn run_example() -> Result<(), FdbBindingError> {
 // Running transaction with PrintHooks (forcing a conflict)...
 //   on_attempt_start: attempt 0
 //   (injected conflicting write)
+//   before_commit (attempt 0): 1 write conflict range(s)
+//     "example_conflict_key" .. "example_conflict_key\0"
 //   on_commit_error (attempt 0): 1 range(s)
 //     "example_conflict_key" .. "example_conflict_key\0"
 //   on_error_duration (attempt 0): 0ms
 //   on_retry: attempt 0 is over
 //   on_attempt_start: attempt 1
+//   before_commit (attempt 1): 1 write conflict range(s)
+//     "example_conflict_key" .. "example_conflict_key\0"
 //   on_commit_success (attempt 1): committed in 1ms
 //   on_complete
 // Transaction succeeded after conflict!

--- a/foundationdb/examples/conflict_reporting.rs
+++ b/foundationdb/examples/conflict_reporting.rs
@@ -3,8 +3,12 @@
 //!
 //! It creates two transactions that conflict on the same key, showing
 //! the full hook lifecycle: commit error → conflicting keys → retry → success.
+//!
+//! The user hook is stacked with [`MetricsHooks`] in a tuple, so the same run
+//! also produces the per-attempt metrics report of `instrumented_run`.
 
 use foundationdb::options::TransactionOption;
+use foundationdb::runner::MetricsHooks;
 use foundationdb::*;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -13,9 +17,16 @@ use std::sync::atomic::{AtomicU64, Ordering};
 struct PrintHooks;
 
 impl RunnerHooks for PrintHooks {
-    async fn on_commit_error(&self, err: &TransactionCommitError) -> FdbResult<()> {
+    fn on_attempt_start(&self, _trx: &Transaction, attempt: usize) {
+        println!("  on_attempt_start: attempt {attempt}");
+    }
+
+    async fn on_commit_error(&self, err: &TransactionCommitError, attempt: usize) -> FdbResult<()> {
         let keys = err.conflicting_keys().await?;
-        println!("  on_commit_error: {} conflicting range(s)", keys.len());
+        println!(
+            "  on_commit_error (attempt {attempt}): {} range(s)",
+            keys.len()
+        );
         for range in &keys {
             println!(
                 "    {:?} .. {:?}",
@@ -26,20 +37,24 @@ impl RunnerHooks for PrintHooks {
         Ok(())
     }
 
-    fn on_closure_error(&self, err: &FdbError) {
-        println!("  on_closure_error: {}", err.message());
+    fn on_hook_error(&self, err: &FdbError, attempt: usize) {
+        println!("  on_hook_error (attempt {attempt}): {}", err.message());
     }
 
-    fn on_error_duration(&self, ms: u64) {
-        println!("  on_error_duration: {ms}ms");
+    fn on_closure_error(&self, err: &FdbError, attempt: usize) {
+        println!("  on_closure_error (attempt {attempt}): {}", err.message());
     }
 
-    fn on_commit_success(&self, _committed: &TransactionCommitted, ms: u64) {
-        println!("  on_commit_success: committed in {ms}ms");
+    fn on_error_duration(&self, ms: u64, attempt: usize) {
+        println!("  on_error_duration (attempt {attempt}): {ms}ms");
     }
 
-    fn on_retry(&self) {
-        println!("  on_retry");
+    fn on_commit_success(&self, _committed: &TransactionCommitted, ms: u64, attempt: usize) {
+        println!("  on_commit_success (attempt {attempt}): committed in {ms}ms");
+    }
+
+    fn on_retry(&self, attempt: usize) {
+        println!("  on_retry: attempt {attempt} is over");
     }
 
     fn on_complete(&self) {
@@ -69,7 +84,11 @@ async fn run_example() -> Result<(), FdbBindingError> {
 
     println!("Running transaction with PrintHooks (forcing a conflict)...");
 
-    let hooks = PrintHooks;
+    // Both hooks observe the same run: the metrics ones fill the report, the
+    // printing ones comment on it. Callbacks fire left to right.
+    let metrics = TransactionMetrics::new();
+    let hooks = (MetricsHooks::new(&metrics), PrintHooks);
+
     db.run_with_hooks(&hooks, |trx, _| {
         let attempt = attempt.clone();
         async move {
@@ -99,7 +118,23 @@ async fn run_example() -> Result<(), FdbBindingError> {
     })
     .await?;
 
+    let report = metrics.get_metrics_data();
     println!("Transaction succeeded after conflict!");
+    println!(
+        "{} attempt(s), {} conflict(s), total usage: {:?}",
+        report.attempts.len(),
+        report.transaction.conflict_count,
+        report.total_usage(),
+    );
+    for attempt in &report.attempts {
+        println!(
+            "  attempt {}: {:?}, {} conflicting range(s)",
+            attempt.index,
+            attempt.outcome,
+            attempt.conflicting_keys.ranges().len(),
+        );
+    }
+
     Ok(())
 }
 
@@ -107,11 +142,17 @@ async fn run_example() -> Result<(), FdbBindingError> {
 // Expected output:
 //
 // Running transaction with PrintHooks (forcing a conflict)...
+//   on_attempt_start: attempt 0
 //   (injected conflicting write)
-//   on_commit_error: 1 conflicting range(s)
+//   on_commit_error (attempt 0): 1 range(s)
 //     "example_conflict_key" .. "example_conflict_key\0"
-//   on_error_duration: 0ms
-//   on_retry
-//   on_commit_success: committed in 1ms
+//   on_error_duration (attempt 0): 0ms
+//   on_retry: attempt 0 is over
+//   on_attempt_start: attempt 1
+//   on_commit_success (attempt 1): committed in 1ms
+//   on_complete
 // Transaction succeeded after conflict!
+// 2 attempt(s), 1 conflict(s), total usage: UsageSnapshot { .. }
+//   attempt 0: Retried { cause: FdbError { error_code: 1020 } }, 1 conflicting range(s)
+//   attempt 1: Committed, 0 conflicting range(s)
 */

--- a/foundationdb/examples/instrumented.rs
+++ b/foundationdb/examples/instrumented.rs
@@ -37,7 +37,7 @@ async fn instrumented_example() -> Result<(), FdbBindingError> {
             let _ = txn.get(b"instrumented_key", false).await?;
 
             // Register a custom metric directly on the transaction
-            txn.set_custom_metric("operations_count", 1, &[("type", "write")])?;
+            txn.set_custom_metric("operations_count", 1, &[("type", "write")]);
 
             Ok(())
         })
@@ -70,47 +70,53 @@ Running an instrumented transaction...
 Transaction successful!
 --- Metrics Report ---
 MetricsReport {
-    current: CounterMetrics {
-        call_atomic_op: 0,
-        call_clear: 0,
-        call_clear_range: 0,
-        call_get: 1,
-        keys_values_fetched: 1,
-        bytes_read: 34,
-        call_set: 1,
-        bytes_written: 34,
-    },
-    total: CounterMetrics {
-        call_atomic_op: 0,
-        call_clear: 0,
-        call_clear_range: 0,
-        call_get: 1,
-        keys_values_fetched: 1,
-        bytes_read: 34,
-        call_set: 1,
-        bytes_written: 34,
-    },
-    time: TimingMetrics {
-        commit_execution_ms: 2,
-        on_error_execution_ms: [],
-        total_execution_ms: 4,
-    },
-    custom_metrics: {
-        MetricKey {
-            name: "operations_count",
-            labels: [
-                (
-                    "type",
-                    "write",
-                ),
-            ],
-        }: 1,
-    },
+    attempts: [
+        AttemptMetrics {
+            index: 0,
+            usage: UsageSnapshot {
+                elapsed: 11.703552ms,
+                bytes_read: 34,
+                bytes_written: 34,
+                keys_values_fetched: 1,
+                call_get: 1,
+                call_get_range: 0,
+                call_set: 1,
+                call_clear: 0,
+                call_clear_range: 0,
+                call_atomic_op: 0,
+            },
+            custom_metrics: {
+                MetricKey {
+                    name: "operations_count",
+                    labels: [
+                        (
+                            "type",
+                            "write",
+                        ),
+                    ],
+                }: 1,
+            },
+            duration: Some(
+                11.701935ms,
+            ),
+            commit_duration: Some(
+                10.609832ms,
+            ),
+            on_error_duration: None,
+            outcome: Committed,
+            conflicting_keys: NotRequested,
+            read_version: None,
+        },
+    ],
+    total_duration: Some(
+        11.726852ms,
+    ),
     transaction: TransactionInfo {
         retries: 0,
+        conflict_count: 0,
         read_version: None,
         commit_version: Some(
-            21848159754,
+            70442567195,
         ),
     },
 }

--- a/foundationdb/src/budget.rs
+++ b/foundationdb/src/budget.rs
@@ -1,0 +1,502 @@
+// Copyright 2018 foundationdb-rs developers, https://github.com/Clikengo/foundationdb-rs/graphs/contributors
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Per-attempt usage accounting and the client-side budget.
+//!
+//! <div class="warning">
+//!
+//! The budget is a **client-side feature of this Rust binding**, not a native
+//! FoundationDB limit. Nothing here is enforced by the cluster: the binding
+//! counts the bytes and calls that go through [`Transaction`](crate::Transaction)
+//! and compares them with the configured limits when you ask it to, with
+//! [`Transaction::check_client_budget`](crate::Transaction::check_client_budget).
+//! The numbers are therefore an **estimate**, checked *between* operations:
+//! a single operation can overshoot a limit, and reads that are still in flight
+//! are not counted yet.
+//!
+//! It is fully decoupled from
+//! [`TransactionOption::Timeout`](crate::options::TransactionOption::Timeout) and
+//! [`TransactionOption::SizeLimit`](crate::options::TransactionOption::SizeLimit),
+//! which are enforced by the C client. Use those to bound what the database
+//! does; use the budget to bound what your own code does before it reaches
+//! them.
+//!
+//! </div>
+//!
+//! # Per-attempt semantics
+//!
+//! Accounting is always on and scoped to a single *transaction attempt*: usage
+//! is reset whenever the transaction restarts (`on_error`, `reset`), while the
+//! configured limits survive and apply to the new attempt. A retried
+//! transaction therefore gets a fresh time and byte allowance, exactly like it
+//! gets a fresh read version.
+
+use std::fmt;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+/// Client-side limits applied to a single transaction attempt.
+///
+/// Each field is optional, `None` meaning "no limit". A default `ClientBudget`
+/// limits nothing.
+///
+/// See the [module documentation](self): these limits are computed by the
+/// binding from what it observes, not enforced by FoundationDB.
+///
+/// # Example
+///
+/// ```
+/// # use foundationdb::*;
+/// # use std::time::Duration;
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # let db = Database::default()?;
+/// let trx = db.create_trx()?;
+/// trx.set_client_budget(ClientBudget {
+///     time_limit: Some(Duration::from_secs(2)),
+///     max_bytes_read: Some(10 * 1024 * 1024),
+///     ..ClientBudget::default()
+/// });
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct ClientBudget {
+    /// Maximum wall-clock time an attempt may spend, measured from the start of
+    /// the attempt.
+    pub time_limit: Option<Duration>,
+    /// Maximum number of bytes read by an attempt, keys and values summed.
+    pub max_bytes_read: Option<u64>,
+    /// Maximum number of bytes written by an attempt, keys, values and mutation
+    /// parameters summed.
+    pub max_bytes_written: Option<u64>,
+}
+
+impl ClientBudget {
+    /// Checks `usage` against these limits, returning the first exceeded one.
+    pub(crate) fn check(&self, usage: &AttemptUsage) -> Result<(), BudgetExceeded> {
+        if let Some(limit) = self.time_limit {
+            let used = usage.elapsed().as_millis() as u64;
+            let limit = limit.as_millis() as u64;
+            if used > limit {
+                return Err(BudgetExceeded {
+                    kind: BudgetKind::Time,
+                    used,
+                    limit,
+                });
+            }
+        }
+
+        if let Some(limit) = self.max_bytes_read {
+            let used = usage.bytes_read();
+            if used > limit {
+                return Err(BudgetExceeded {
+                    kind: BudgetKind::BytesRead,
+                    used,
+                    limit,
+                });
+            }
+        }
+
+        if let Some(limit) = self.max_bytes_written {
+            let used = usage.bytes_written();
+            if used > limit {
+                return Err(BudgetExceeded {
+                    kind: BudgetKind::BytesWritten,
+                    used,
+                    limit,
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Which [`ClientBudget`] limit was exceeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetKind {
+    /// [`ClientBudget::time_limit`], in milliseconds.
+    Time,
+    /// [`ClientBudget::max_bytes_read`], in bytes.
+    BytesRead,
+    /// [`ClientBudget::max_bytes_written`], in bytes.
+    BytesWritten,
+}
+
+impl fmt::Display for BudgetKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BudgetKind::Time => write!(f, "time"),
+            BudgetKind::BytesRead => write!(f, "bytes read"),
+            BudgetKind::BytesWritten => write!(f, "bytes written"),
+        }
+    }
+}
+
+/// A [`ClientBudget`] limit was exceeded by the current transaction attempt.
+///
+/// `used` and `limit` are expressed in milliseconds for [`BudgetKind::Time`],
+/// in bytes otherwise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BudgetExceeded {
+    /// The limit that was exceeded.
+    pub kind: BudgetKind,
+    /// What the attempt used, milliseconds for [`BudgetKind::Time`], bytes
+    /// otherwise.
+    pub used: u64,
+    /// The configured limit, in the same unit as `used`.
+    pub limit: u64,
+}
+
+impl fmt::Display for BudgetExceeded {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let unit = match self.kind {
+            BudgetKind::Time => "ms",
+            BudgetKind::BytesRead | BudgetKind::BytesWritten => "bytes",
+        };
+        write!(
+            f,
+            "client budget exceeded ({}): used {} {}, limit {} {}. This is a client-side estimate of this binding, not a FoundationDB limit",
+            self.kind, self.used, unit, self.limit, unit
+        )
+    }
+}
+
+impl std::error::Error for BudgetExceeded {}
+
+/// Usage accounted for a single transaction attempt.
+///
+/// Counters are incremented by [`Transaction`](crate::Transaction) as
+/// operations are issued (writes) or resolved (reads). They are always on: no
+/// instrumentation is required to get them.
+///
+/// A new instance is created for every attempt, see the
+/// [module documentation](self).
+#[derive(Debug)]
+pub struct AttemptUsage {
+    started_at: Instant,
+    bytes_read: AtomicU64,
+    bytes_written: AtomicU64,
+    keys_values_fetched: AtomicU64,
+    call_get: AtomicU64,
+    call_get_range: AtomicU64,
+    call_set: AtomicU64,
+    call_clear: AtomicU64,
+    call_clear_range: AtomicU64,
+    call_atomic_op: AtomicU64,
+}
+
+impl Default for AttemptUsage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AttemptUsage {
+    /// Starts a new, empty accounting generation.
+    pub fn new() -> Self {
+        Self {
+            started_at: Instant::now(),
+            bytes_read: AtomicU64::new(0),
+            bytes_written: AtomicU64::new(0),
+            keys_values_fetched: AtomicU64::new(0),
+            call_get: AtomicU64::new(0),
+            call_get_range: AtomicU64::new(0),
+            call_set: AtomicU64::new(0),
+            call_clear: AtomicU64::new(0),
+            call_clear_range: AtomicU64::new(0),
+            call_atomic_op: AtomicU64::new(0),
+        }
+    }
+
+    /// Time elapsed since the attempt started.
+    pub fn elapsed(&self) -> Duration {
+        self.started_at.elapsed()
+    }
+
+    /// Bytes read so far, keys and values summed.
+    pub fn bytes_read(&self) -> u64 {
+        self.bytes_read.load(Ordering::Relaxed)
+    }
+
+    /// Bytes written so far, keys, values and mutation parameters summed.
+    pub fn bytes_written(&self) -> u64 {
+        self.bytes_written.load(Ordering::Relaxed)
+    }
+
+    /// Takes a consistent-enough copy of every counter.
+    ///
+    /// Counters are read one after the other without a lock, so a snapshot
+    /// taken while operations are completing may mix values from slightly
+    /// different instants.
+    pub fn snapshot(&self) -> UsageSnapshot {
+        UsageSnapshot {
+            elapsed: self.elapsed(),
+            bytes_read: self.bytes_read.load(Ordering::Relaxed),
+            bytes_written: self.bytes_written.load(Ordering::Relaxed),
+            keys_values_fetched: self.keys_values_fetched.load(Ordering::Relaxed),
+            call_get: self.call_get.load(Ordering::Relaxed),
+            call_get_range: self.call_get_range.load(Ordering::Relaxed),
+            call_set: self.call_set.load(Ordering::Relaxed),
+            call_clear: self.call_clear.load(Ordering::Relaxed),
+            call_clear_range: self.call_clear_range.load(Ordering::Relaxed),
+            call_atomic_op: self.call_atomic_op.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Records a resolved `get` or `get_key`.
+    pub(crate) fn record_get(&self, bytes: u64, keys_values: u64) {
+        self.bytes_read.fetch_add(bytes, Ordering::Relaxed);
+        self.keys_values_fetched
+            .fetch_add(keys_values, Ordering::Relaxed);
+        self.call_get.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a resolved `get_range` batch.
+    pub(crate) fn record_get_range(&self, bytes: u64, keys_values: u64) {
+        self.bytes_read.fetch_add(bytes, Ordering::Relaxed);
+        self.keys_values_fetched
+            .fetch_add(keys_values, Ordering::Relaxed);
+        self.call_get_range.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a `set`.
+    pub(crate) fn record_set(&self, bytes: u64) {
+        self.bytes_written.fetch_add(bytes, Ordering::Relaxed);
+        self.call_set.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a `clear`.
+    pub(crate) fn record_clear(&self, bytes: u64) {
+        self.bytes_written.fetch_add(bytes, Ordering::Relaxed);
+        self.call_clear.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a `clear_range`.
+    pub(crate) fn record_clear_range(&self, bytes: u64) {
+        self.bytes_written.fetch_add(bytes, Ordering::Relaxed);
+        self.call_clear_range.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records an `atomic_op`.
+    pub(crate) fn record_atomic_op(&self, bytes: u64) {
+        self.bytes_written.fetch_add(bytes, Ordering::Relaxed);
+        self.call_atomic_op.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// A copy of the counters of a single transaction attempt, taken by
+/// [`AttemptUsage::snapshot`] or
+/// [`Transaction::attempt_usage`](crate::Transaction::attempt_usage).
+///
+/// Every byte count is a client-side estimate, see the
+/// [module documentation](self).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct UsageSnapshot {
+    /// Time elapsed since the attempt started.
+    pub elapsed: Duration,
+    /// Bytes read: for each resolved read, the key(s) requested plus the
+    /// key-values returned.
+    pub bytes_read: u64,
+    /// Bytes written: keys, values and mutation parameters handed to the
+    /// client. For `clear_range` only the two boundary keys are counted, **not**
+    /// the volume of data the range deletes.
+    pub bytes_written: u64,
+    /// Number of key-values returned by resolved reads.
+    pub keys_values_fetched: u64,
+    /// Number of `get` and `get_key` calls resolved.
+    pub call_get: u64,
+    /// Number of `get_range` batches resolved. A single `get_ranges` stream
+    /// counts once per underlying FoundationDB batch, not once per stream.
+    pub call_get_range: u64,
+    /// Number of `set` calls.
+    pub call_set: u64,
+    /// Number of `clear` calls.
+    pub call_clear: u64,
+    /// Number of `clear_range` calls.
+    pub call_clear_range: u64,
+    /// Number of `atomic_op` calls.
+    pub call_atomic_op: u64,
+}
+
+/// The accounting generation currently active on a transaction.
+///
+/// Operations clone the `Arc` out of the slot when they are **issued** and
+/// record into that clone when they complete. Starting a new attempt swaps the
+/// slot with a fresh [`AttemptUsage`] instead of zeroing the current one, so a
+/// read issued during attempt N that completes during attempt N+1 records into
+/// the counters of attempt N, which nobody reads anymore, and cannot pollute
+/// N+1.
+#[derive(Debug, Default)]
+pub(crate) struct UsageSlot(Mutex<Arc<AttemptUsage>>);
+
+impl UsageSlot {
+    /// The generation to record into for an operation issued now.
+    pub(crate) fn current(&self) -> Arc<AttemptUsage> {
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    /// Starts a fresh generation, leaving the previous one to the in-flight
+    /// operations still holding it.
+    pub(crate) fn begin(&self) {
+        let mut slot = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *slot = Arc::new(AttemptUsage::new());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_without_limits_never_fails() {
+        let usage = AttemptUsage::new();
+        usage.record_get(1_000_000, 10);
+        usage.record_set(1_000_000);
+
+        assert!(ClientBudget::default().check(&usage).is_ok());
+    }
+
+    #[test]
+    fn budget_allows_usage_up_to_the_limit() {
+        let budget = ClientBudget {
+            max_bytes_read: Some(10),
+            max_bytes_written: Some(10),
+            ..ClientBudget::default()
+        };
+
+        let usage = AttemptUsage::new();
+        usage.record_get(10, 1);
+        usage.record_set(10);
+
+        assert!(budget.check(&usage).is_ok());
+    }
+
+    #[test]
+    fn budget_reports_exceeded_bytes_read() {
+        let budget = ClientBudget {
+            max_bytes_read: Some(10),
+            ..ClientBudget::default()
+        };
+
+        let usage = AttemptUsage::new();
+        usage.record_get(7, 1);
+        assert!(budget.check(&usage).is_ok());
+        usage.record_get_range(5, 2);
+
+        let err = budget.check(&usage).unwrap_err();
+        assert_eq!(err.kind, BudgetKind::BytesRead);
+        assert_eq!(err.used, 12);
+        assert_eq!(err.limit, 10);
+        assert!(err.to_string().contains("client-side estimate"));
+    }
+
+    #[test]
+    fn budget_reports_exceeded_bytes_written() {
+        let budget = ClientBudget {
+            max_bytes_written: Some(4),
+            ..ClientBudget::default()
+        };
+
+        let usage = AttemptUsage::new();
+        usage.record_set(2);
+        usage.record_clear(1);
+        usage.record_clear_range(1);
+        assert!(budget.check(&usage).is_ok());
+        usage.record_atomic_op(1);
+
+        let err = budget.check(&usage).unwrap_err();
+        assert_eq!(err.kind, BudgetKind::BytesWritten);
+        assert_eq!(err.used, 5);
+        assert_eq!(err.limit, 4);
+    }
+
+    #[test]
+    fn budget_reports_exceeded_time() {
+        let budget = ClientBudget {
+            time_limit: Some(Duration::ZERO),
+            ..ClientBudget::default()
+        };
+
+        let usage = AttemptUsage::new();
+        std::thread::sleep(Duration::from_millis(2));
+
+        let err = budget.check(&usage).unwrap_err();
+        assert_eq!(err.kind, BudgetKind::Time);
+        assert!(err.used >= 1, "used {} ms", err.used);
+        assert_eq!(err.limit, 0);
+        assert!(err.to_string().contains("client-side estimate"));
+    }
+
+    #[test]
+    fn snapshot_counts_every_operation() {
+        let usage = AttemptUsage::new();
+        usage.record_get(3, 1);
+        usage.record_get_range(7, 2);
+        usage.record_set(4);
+        usage.record_clear(5);
+        usage.record_clear_range(6);
+        usage.record_atomic_op(7);
+
+        let snapshot = usage.snapshot();
+        assert_eq!(snapshot.bytes_read, 10);
+        assert_eq!(snapshot.bytes_written, 22);
+        assert_eq!(snapshot.keys_values_fetched, 3);
+        assert_eq!(snapshot.call_get, 1);
+        assert_eq!(snapshot.call_get_range, 1);
+        assert_eq!(snapshot.call_set, 1);
+        assert_eq!(snapshot.call_clear, 1);
+        assert_eq!(snapshot.call_clear_range, 1);
+        assert_eq!(snapshot.call_atomic_op, 1);
+    }
+
+    #[test]
+    fn a_new_generation_starts_empty() {
+        let slot = UsageSlot::default();
+        slot.current().record_set(42);
+        assert_eq!(slot.current().snapshot().bytes_written, 42);
+
+        slot.begin();
+
+        let snapshot = slot.current().snapshot();
+        assert_eq!(
+            UsageSnapshot {
+                elapsed: Duration::ZERO,
+                ..snapshot
+            },
+            UsageSnapshot::default()
+        );
+    }
+
+    #[test]
+    fn a_stale_generation_does_not_pollute_the_next_one() {
+        let slot = UsageSlot::default();
+
+        // An operation issued during the first attempt, still in flight.
+        let in_flight = slot.current();
+
+        slot.begin();
+        slot.current().record_get(10, 1);
+
+        // The stale operation completes and records into its own generation.
+        in_flight.record_get(999, 99);
+
+        let snapshot = slot.current().snapshot();
+        assert_eq!(snapshot.bytes_read, 10);
+        assert_eq!(snapshot.keys_values_fetched, 1);
+        assert_eq!(snapshot.call_get, 1);
+        assert_eq!(in_flight.snapshot().bytes_read, 999);
+    }
+}

--- a/foundationdb/src/budget.rs
+++ b/foundationdb/src/budget.rs
@@ -35,11 +35,14 @@
 //! transaction therefore gets a fresh time and byte allowance, exactly like it
 //! gets a fresh read version.
 
+use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
+
+use crate::metrics::MetricKey;
 
 /// Client-side limits applied to a single transaction attempt.
 ///
@@ -178,6 +181,14 @@ impl std::error::Error for BudgetExceeded {}
 ///
 /// A new instance is created for every attempt, see the
 /// [module documentation](self).
+///
+/// The application metrics recorded with
+/// [`Transaction::set_custom_metric`](crate::Transaction::set_custom_metric) are
+/// stored here too, and are therefore per-attempt as well. Their map is
+/// allocated on first use, so a transaction that never records one pays
+/// nothing. Without a metrics consumer collecting them (typically
+/// [`Database::instrumented_run`](crate::Database::instrumented_run)), they are
+/// simply dropped with the generation.
 #[derive(Debug)]
 pub struct AttemptUsage {
     started_at: Instant,
@@ -190,6 +201,8 @@ pub struct AttemptUsage {
     call_clear: AtomicU64,
     call_clear_range: AtomicU64,
     call_atomic_op: AtomicU64,
+    /// Application metrics of this attempt, allocated on first use.
+    custom: Mutex<Option<HashMap<MetricKey, u64>>>,
 }
 
 impl Default for AttemptUsage {
@@ -212,6 +225,7 @@ impl AttemptUsage {
             call_clear: AtomicU64::new(0),
             call_clear_range: AtomicU64::new(0),
             call_atomic_op: AtomicU64::new(0),
+            custom: Mutex::new(None),
         }
     }
 
@@ -288,6 +302,38 @@ impl AttemptUsage {
     pub(crate) fn record_atomic_op(&self, bytes: u64) {
         self.bytes_written.fetch_add(bytes, Ordering::Relaxed);
         self.call_atomic_op.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Sets an application metric of this attempt, replacing any previous value.
+    pub(crate) fn set_custom(&self, key: MetricKey, value: u64) {
+        self.with_custom(|custom| {
+            custom.insert(key, value);
+        });
+    }
+
+    /// Adds `amount` to an application metric of this attempt, starting from
+    /// zero if it was not recorded yet.
+    pub(crate) fn increment_custom(&self, key: MetricKey, amount: u64) {
+        self.with_custom(|custom| {
+            *custom.entry(key).or_insert(0) += amount;
+        });
+    }
+
+    /// The application metrics recorded during this attempt.
+    pub fn custom_metrics(&self) -> HashMap<MetricKey, u64> {
+        self.custom
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .unwrap_or_default()
+    }
+
+    fn with_custom<R>(&self, f: impl FnOnce(&mut HashMap<MetricKey, u64>) -> R) -> R {
+        let mut custom = self
+            .custom
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        f(custom.get_or_insert_with(HashMap::new))
     }
 }
 
@@ -460,6 +506,24 @@ mod tests {
         assert_eq!(snapshot.call_clear, 1);
         assert_eq!(snapshot.call_clear_range, 1);
         assert_eq!(snapshot.call_atomic_op, 1);
+    }
+
+    #[test]
+    fn custom_metrics_are_scoped_to_the_generation() {
+        let slot = UsageSlot::default();
+        let key = MetricKey::new("documents", &[("kind", "user")]);
+
+        assert!(slot.current().custom_metrics().is_empty());
+
+        slot.current().set_custom(key.clone(), 2);
+        slot.current().increment_custom(key.clone(), 3);
+        assert_eq!(slot.current().custom_metrics().get(&key), Some(&5));
+
+        let previous = slot.current();
+        slot.begin();
+
+        assert!(slot.current().custom_metrics().is_empty());
+        assert_eq!(previous.custom_metrics().get(&key), Some(&5));
     }
 
     #[test]

--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -20,12 +20,13 @@ use fdb_sys::if_cfg_api_versions;
 use foundationdb_macros::cfg_api_versions;
 use foundationdb_sys as fdb_sys;
 
-use crate::metrics::{AttemptOutcome, ConflictKeys, MetricsReport, TransactionMetrics};
+use crate::metrics::{MetricsReport, TransactionMetrics};
 use crate::options;
+use crate::runner::{MetricsHooks, RunnerHooks, TransactionRunner};
 use crate::transaction::*;
 use crate::{FdbError, FdbResult, error};
 
-use crate::error::{FdbBindingError, RetryDecision, RetryableError};
+use crate::error::{FdbBindingError, RetryableError};
 use futures::prelude::*;
 
 /// Wrapper around the boolean representing whether the
@@ -36,251 +37,15 @@ use futures::prelude::*;
 /// capturing the environment.
 pub struct MaybeCommitted(bool);
 
+impl MaybeCommitted {
+    pub(crate) fn new(maybe_committed: bool) -> Self {
+        Self(maybe_committed)
+    }
+}
+
 impl From<MaybeCommitted> for bool {
     fn from(value: MaybeCommitted) -> Self {
         value.0
-    }
-}
-
-/// Lifecycle hooks for the transaction retry runner.
-///
-/// All methods have default no-op implementations, so callers only override what they need.
-/// This trait enables a single internal retry loop (`run_with_hooks`) to serve both
-/// `Database::run()` (no-op hooks) and `Database::instrumented_run()` (metrics hooks).
-pub trait RunnerHooks {
-    /// Called when commit fails, **before** `on_error()` resets the transaction.
-    /// This is the only window to read conflicting keys or inspect error state.
-    ///
-    /// Errors are logged (behind `trace` feature) but do not abort the retry loop.
-    fn on_commit_error(
-        &self,
-        _err: &TransactionCommitError,
-    ) -> impl Future<Output = FdbResult<()>> + Send {
-        async { Ok(()) }
-    }
-
-    /// Called when a closure error triggers a retry.
-    ///
-    /// A closure error classified as [`crate::RetryDecision::Retry`] surfaces
-    /// here as a synthetic `FdbError` with code 1020 (not_committed).
-    fn on_closure_error(&self, _err: &FdbError) {}
-
-    /// Called after `on_error()` completes with its duration.
-    fn on_error_duration(&self, _duration_ms: u64) {}
-
-    /// Called after successful commit with the committed transaction and commit duration.
-    fn on_commit_success(&self, _committed: &TransactionCommitted, _commit_duration_ms: u64) {}
-
-    /// Called before the next retry iteration (after `on_error` succeeds).
-    fn on_retry(&self) {}
-
-    /// Called when the runner finishes (success or final failure).
-    fn on_complete(&self) {}
-}
-
-/// No-op hooks — zero overhead. Used by [`Database::run()`].
-#[derive(Debug, Clone, Copy, Default)]
-pub struct NoopHooks;
-impl RunnerHooks for NoopHooks {}
-
-/// Metrics-collecting hooks for `Database::instrumented_run()`.
-pub(crate) struct InstrumentedHooks {
-    pub(crate) metrics: TransactionMetrics,
-    pub(crate) start: Instant,
-}
-
-impl RunnerHooks for InstrumentedHooks {
-    async fn on_commit_error(&self, err: &TransactionCommitError) -> FdbResult<()> {
-        // not_committed (1020) = commit conflict
-        if err.code() == 1020 {
-            self.metrics.increment_conflict_count();
-        }
-        // Reading from the \xff\xff/transaction/conflicting_keys/ special keyspace is
-        // resolved client-side — no network round-trip to the cluster. The future still
-        // goes through the FDB network thread event loop, but the data comes from an
-        // in-memory map populated during the commit response. Returns empty if
-        // ReportConflictingKeys was not set.
-        match err.conflicting_keys().await {
-            Ok(keys) => {
-                self.metrics
-                    .set_conflicting_keys(ConflictKeys::Available(keys));
-                Ok(())
-            }
-            Err(read_error) => {
-                self.metrics
-                    .set_conflicting_keys(ConflictKeys::ReadFailed(read_error));
-                Err(read_error)
-            }
-        }
-    }
-
-    fn on_error_duration(&self, duration_ms: u64) {
-        // `on_error` already pushed the attempt it ended, so this lands on the
-        // last attempt of the report.
-        self.metrics
-            .set_on_error_duration(Duration::from_millis(duration_ms));
-    }
-
-    fn on_commit_success(&self, committed: &TransactionCommitted, _commit_duration_ms: u64) {
-        // The attempt itself was pushed by `Transaction::commit`, which also
-        // recorded how long the commit took.
-        if let Ok(version) = committed.committed_version() {
-            self.metrics.set_commit_version(version);
-        }
-    }
-
-    fn on_complete(&self) {
-        // phase 3: the runner has no hook on its failure paths, so an attempt
-        // still open when it returns is the one that failed. Attempts that
-        // committed or were retried are already pushed, which makes this a
-        // no-op for them.
-        self.metrics.finish_attempt(AttemptOutcome::Failed);
-        self.metrics.set_total_duration(self.start.elapsed());
-    }
-}
-
-/// Single internal retry loop that the public entrypoints (`run`, `instrumented_run`)
-/// delegate to.
-///
-/// # Hook lifecycle per iteration
-///
-/// 1. Execute closure
-/// 2. If closure returns `Err` classified as `Fdb` or `Retry`:
-///    - `on_closure_error` → `on_error()` → `on_error_duration` → `on_retry` → loop
-/// 3. If closure succeeds, attempt commit:
-///    - Commit succeeds → `on_commit_success` → return `Ok`
-///    - Commit fails (retryable) → `on_commit_error` → `on_error()` → `on_error_duration` → `on_retry` → loop
-///    - Commit fails (non-retryable) → return `Err`
-#[cfg_attr(
-    feature = "trace",
-    tracing::instrument(level = "debug", skip(initial_transaction, hooks, closure))
-)]
-pub(crate) async fn run_with_hooks<F, Fut, T, E, H: RunnerHooks>(
-    initial_transaction: RetryableTransaction,
-    hooks: &H,
-    closure: F,
-) -> Result<T, E>
-where
-    F: Fn(RetryableTransaction, MaybeCommitted) -> Fut,
-    Fut: Future<Output = Result<T, E>>,
-    E: RetryableError,
-{
-    let mut maybe_committed = false;
-    let mut transaction = initial_transaction;
-    #[cfg(feature = "trace")]
-    let mut iteration: u64 = 0;
-
-    loop {
-        #[cfg(feature = "trace")]
-        {
-            iteration += 1;
-        }
-
-        let result_closure = closure(transaction.clone(), MaybeCommitted(maybe_committed)).await;
-
-        if let Err(e) = result_closure {
-            let fdb_err = match e.retry_decision() {
-                RetryDecision::Fdb(fdb_err) => {
-                    maybe_committed = fdb_err.is_maybe_committed();
-                    fdb_err
-                }
-                // Synthetic retryable code (1020, not_committed): backoff and
-                // RetryLimit stay governed by fdb_transaction_on_error.
-                // maybe_committed is left untouched: a previous maybe-committed
-                // attempt must stay visible to the closure.
-                RetryDecision::Retry => FdbError::from_code(1020),
-                RetryDecision::Fatal => return Err(e),
-            };
-            hooks.on_closure_error(&fdb_err);
-
-            let now_on_error = Instant::now();
-            match transaction.on_error(fdb_err).await {
-                Ok(Ok(t)) => {
-                    hooks.on_error_duration(now_on_error.elapsed().as_millis() as u64);
-
-                    #[cfg(feature = "trace")]
-                    {
-                        let error_code = fdb_err.code();
-                        tracing::warn!(iteration, error_code, "restarting transaction");
-                    }
-
-                    hooks.on_retry();
-                    transaction = t;
-                    continue;
-                }
-                // Retries exhausted or non-retryable: return the original
-                // closure error, which carries the caller's context.
-                Ok(Err(_non_retryable)) => {
-                    return Err(e);
-                }
-                Err(binding_err) => {
-                    return Err(E::from(binding_err));
-                }
-            }
-        }
-
-        #[cfg(feature = "trace")]
-        tracing::info!(iteration, "closure executed, checking result...");
-
-        let now_commit = Instant::now();
-        let commit_result = transaction.commit().await;
-        let commit_duration = now_commit.elapsed().as_millis() as u64;
-
-        match commit_result {
-            Err(err) => {
-                #[cfg(feature = "trace")]
-                tracing::error!(
-                    iteration,
-                    "transaction reference kept, aborting transaction"
-                );
-                return Err(E::from(err));
-            }
-            Ok(Ok(committed)) => {
-                hooks.on_commit_success(&committed, commit_duration);
-
-                #[cfg(feature = "trace")]
-                tracing::info!(iteration, "success, returning result");
-
-                return result_closure;
-            }
-            Ok(Err(commit_error)) => {
-                #[cfg(feature = "trace")]
-                let error_code = commit_error.code();
-
-                maybe_committed = commit_error.is_maybe_committed();
-                if let Err(_e) = hooks.on_commit_error(&commit_error).await {
-                    #[cfg(feature = "trace")]
-                    tracing::debug!(error_code = _e.code(), "on_commit_error hook failed");
-                }
-
-                let now_on_error = Instant::now();
-                match commit_error.on_error().await {
-                    Ok(t) => {
-                        hooks.on_error_duration(now_on_error.elapsed().as_millis() as u64);
-
-                        #[cfg(feature = "trace")]
-                        tracing::warn!(iteration, error_code, "restarting transaction");
-
-                        hooks.on_retry();
-                        transaction = RetryableTransaction::new(t);
-                        continue;
-                    }
-                    Err(non_retryable) => {
-                        #[cfg(feature = "trace")]
-                        {
-                            let error_code = non_retryable.code();
-                            tracing::error!(
-                                iteration,
-                                error_code,
-                                "could not commit, non retryable error"
-                            );
-                        }
-
-                        return Err(E::from(FdbBindingError::from(non_retryable)));
-                    }
-                }
-            }
-        }
     }
 }
 
@@ -422,28 +187,8 @@ impl Database {
     }
 
     #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
-    fn create_retryable_trx(&self) -> FdbResult<RetryableTransaction> {
+    pub(crate) fn create_retryable_trx(&self) -> FdbResult<RetryableTransaction> {
         Ok(RetryableTransaction::new(self.create_trx()?))
-    }
-
-    /// Creates a new retryable transaction on the given database with metrics collection.
-    ///
-    /// This method is similar to `create_retryable_trx()` but additionally collects metrics about
-    /// the transaction execution, including operation counts, bytes read/written, and retry counts.
-    ///
-    /// # Arguments
-    /// * `metrics` - A TransactionMetrics instance to collect metrics
-    ///
-    /// # Returns
-    /// * `Result<RetryableTransaction, (FdbBindingError, MetricsData)>` - A retryable transaction with metrics collection enabled
-    #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
-    pub fn create_intrumented_retryable_trx(
-        &self,
-        metrics: TransactionMetrics,
-    ) -> Result<RetryableTransaction, FdbBindingError> {
-        Ok(RetryableTransaction::new(
-            self.create_instrumented_trx(metrics.clone())?,
-        ))
     }
 
     /// `transact` returns a future which retries on error. It tries to resolve a future created by
@@ -648,6 +393,13 @@ impl Database {
     ///
     /// A closure that never names an error type is ambiguous; pin it on the
     /// tail expression, for example `Ok::<_, FdbBindingError>(value)`.
+    ///
+    /// # Hooks and retry policy
+    ///
+    /// This is [`runner()`](Self::runner) with its defaults: no hooks and the
+    /// native retry policy. Use the builder to observe the run with
+    /// [`RunnerHooks`] or to decide the retries with a
+    /// [`RetryPolicy`](crate::runner::RetryPolicy).
     #[cfg_attr(
         feature = "trace",
         tracing::instrument(level = "debug", skip(self, closure))
@@ -658,23 +410,43 @@ impl Database {
         Fut: Future<Output = Result<T, E>>,
         E: RetryableError,
     {
-        let transaction = self.create_retryable_trx()?;
-        run_with_hooks(transaction, &NoopHooks, closure).await
+        self.runner().run(closure).await
+    }
+
+    /// A builder for a transactional run, to plug [`RunnerHooks`] and a
+    /// [`RetryPolicy`](crate::runner::RetryPolicy) into it.
+    ///
+    /// ```no_run
+    /// # use foundationdb::*;
+    /// # use foundationdb::runner::MetricsHooks;
+    /// # async fn example(db: &Database) -> Result<(), FdbBindingError> {
+    /// let metrics = TransactionMetrics::new();
+    /// db.runner()
+    ///     .hooks(&MetricsHooks::new(&metrics))
+    ///     .run(|trx, _| async move {
+    ///         trx.set(b"key", b"value");
+    ///         Ok::<_, FdbBindingError>(())
+    ///     })
+    ///     .await
+    /// # }
+    /// ```
+    pub fn runner(&self) -> TransactionRunner<'_> {
+        TransactionRunner::new(self)
     }
 
     /// Runs a transactional function against this Database with retry logic and custom hooks.
     ///
-    /// This is the most flexible entrypoint — implement [`RunnerHooks`] to observe
-    /// or react to each phase of the retry loop (commit errors, retries, success).
+    /// Sugar for `db.runner().hooks(hooks).run(closure)`. Stack several hooks
+    /// with a tuple: `db.run_with_hooks(&(first, second), closure)`.
     ///
-    /// See [`RunnerHooks`] for the hook lifecycle documentation.
+    /// See [`RunnerHooks`] for what each hook observes and in which order.
     #[cfg_attr(
         feature = "trace",
         tracing::instrument(level = "debug", skip(self, hooks, closure))
     )]
-    pub async fn run_with_hooks<F, Fut, T, E, H: RunnerHooks>(
-        &self,
-        hooks: &H,
+    pub async fn run_with_hooks<'a, F, Fut, T, E, H: RunnerHooks>(
+        &'a self,
+        hooks: &'a H,
         closure: F,
     ) -> Result<T, E>
     where
@@ -682,8 +454,7 @@ impl Database {
         Fut: Future<Output = Result<T, E>>,
         E: RetryableError,
     {
-        let transaction = self.create_retryable_trx()?;
-        run_with_hooks(transaction, hooks, closure).await
+        self.runner().hooks(hooks).run(closure).await
     }
 
     /// Runs a transactional function against this Database with retry logic and metrics collection.
@@ -692,6 +463,9 @@ impl Database {
     ///
     /// This method is similar to `run()` but additionally collects and returns metrics about
     /// the transaction execution, including operation counts, bytes read/written, and retry counts.
+    /// It is [`MetricsHooks`] plugged into [`runner()`](Self::runner): stack them
+    /// on your own hooks with `db.run_with_hooks(&(MetricsHooks::new(&metrics), my_hooks), closure)`
+    /// to get the same report out of a run you observe yourself.
     ///
     /// # Arguments
     /// * `closure` - A function that takes a RetryableTransaction and MaybeCommitted flag and returns a Future
@@ -725,27 +499,11 @@ impl Database {
         E: RetryableError,
     {
         let metrics = TransactionMetrics::new();
-        let hooks = InstrumentedHooks {
-            metrics: metrics.clone(),
-            start: Instant::now(),
-        };
-        let transaction = match self.create_intrumented_retryable_trx(metrics.clone()) {
-            Ok(trx) => trx,
-            Err(err) => {
-                hooks.on_complete();
-                return Err((E::from(err), metrics.get_metrics_data()));
-            }
-        };
+        let hooks = MetricsHooks::new(&metrics);
 
-        match run_with_hooks(transaction, &hooks, closure).await {
-            Ok(val) => {
-                hooks.on_complete();
-                Ok((val, metrics.get_metrics_data()))
-            }
-            Err(err) => {
-                hooks.on_complete();
-                Err((err, metrics.get_metrics_data()))
-            }
+        match self.runner().hooks(&hooks).run(closure).await {
+            Ok(value) => Ok((value, metrics.get_metrics_data())),
+            Err(err) => Err((err, metrics.get_metrics_data())),
         }
     }
 

--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -20,7 +20,7 @@ use fdb_sys::if_cfg_api_versions;
 use foundationdb_macros::cfg_api_versions;
 use foundationdb_sys as fdb_sys;
 
-use crate::metrics::{MetricsReport, TransactionMetrics};
+use crate::metrics::{AttemptOutcome, ConflictKeys, MetricsReport, TransactionMetrics};
 use crate::options;
 use crate::transaction::*;
 use crate::{FdbError, FdbResult, error};
@@ -100,31 +100,42 @@ impl RunnerHooks for InstrumentedHooks {
         // goes through the FDB network thread event loop, but the data comes from an
         // in-memory map populated during the commit response. Returns empty if
         // ReportConflictingKeys was not set.
-        let keys = err.conflicting_keys().await?;
-        if !keys.is_empty() {
-            self.metrics.set_conflicting_keys(keys);
+        match err.conflicting_keys().await {
+            Ok(keys) => {
+                self.metrics
+                    .set_conflicting_keys(ConflictKeys::Available(keys));
+                Ok(())
+            }
+            Err(read_error) => {
+                self.metrics
+                    .set_conflicting_keys(ConflictKeys::ReadFailed(read_error));
+                Err(read_error)
+            }
         }
-        Ok(())
     }
 
     fn on_error_duration(&self, duration_ms: u64) {
-        self.metrics.add_error_time(duration_ms);
+        // `on_error` already pushed the attempt it ended, so this lands on the
+        // last attempt of the report.
+        self.metrics
+            .set_on_error_duration(Duration::from_millis(duration_ms));
     }
 
-    fn on_commit_success(&self, committed: &TransactionCommitted, commit_duration_ms: u64) {
-        self.metrics.record_commit_time(commit_duration_ms);
+    fn on_commit_success(&self, committed: &TransactionCommitted, _commit_duration_ms: u64) {
+        // The attempt itself was pushed by `Transaction::commit`, which also
+        // recorded how long the commit took.
         if let Ok(version) = committed.committed_version() {
             self.metrics.set_commit_version(version);
         }
     }
 
-    fn on_retry(&self) {
-        self.metrics.reset_current();
-    }
-
     fn on_complete(&self) {
-        let total_duration = self.start.elapsed().as_millis() as u64;
-        self.metrics.set_execution_time(total_duration);
+        // phase 3: the runner has no hook on its failure paths, so an attempt
+        // still open when it returns is the one that failed. Attempts that
+        // committed or were retried are already pushed, which makes this a
+        // no-op for them.
+        self.metrics.finish_attempt(AttemptOutcome::Failed);
+        self.metrics.set_total_duration(self.start.elapsed());
     }
 }
 

--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -26,7 +26,7 @@ use crate::runner::{MetricsHooks, RunnerHooks, TransactionRunner};
 use crate::transaction::*;
 use crate::{FdbError, FdbResult, error};
 
-use crate::error::{FdbBindingError, RetryableError};
+use crate::error::RetryableError;
 use futures::prelude::*;
 
 /// Wrapper around the boolean representing whether the
@@ -159,31 +159,6 @@ impl Database {
         Ok(Transaction::new(NonNull::new(trx).expect(
             "fdb_database_create_transaction to not return null if there is no error",
         )))
-    }
-
-    /// Creates a new transaction on the given database with metrics collection.
-    ///
-    /// This method is similar to `create_trx()` but additionally collects metrics about
-    /// the transaction execution, including operation counts, bytes read/written, and retry counts.
-    ///
-    /// # Arguments
-    /// * `metrics` - A TransactionMetrics instance to collect metrics
-    ///
-    /// # Returns
-    /// * `Result<Transaction, (FdbBindingError, MetricsData)>` - A transaction with metrics collection enabled
-    #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
-    pub fn create_instrumented_trx(
-        &self,
-        metrics: TransactionMetrics,
-    ) -> Result<Transaction, FdbBindingError> {
-        let mut trx: *mut fdb_sys::FDBTransaction = std::ptr::null_mut();
-        let err =
-            unsafe { fdb_sys::fdb_database_create_transaction(self.inner.as_ptr(), &mut trx) };
-        error::eval(err)?;
-
-        let inner = NonNull::new(trx)
-            .expect("fdb_database_create_transaction to not return null if there is no error");
-        Ok(Transaction::new_instrumented(inner, metrics))
     }
 
     #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]

--- a/foundationdb/src/error.rs
+++ b/foundationdb/src/error.rs
@@ -27,38 +27,6 @@ pub(crate) fn eval(error_code: fdb_sys::fdb_error_t) -> FdbResult<()> {
     }
 }
 
-/// Error returned when attempting to access metrics on a transaction that wasn't created with metrics instrumentation.
-///
-/// This error occurs when calling methods like `set_custom_metric` or `increment_custom_metric` on a
-/// transaction that was created without metrics instrumentation (i.e., using `create_trx` instead of
-/// `create_instrumented_trx`).
-///
-/// # Example
-/// ```
-/// # use foundationdb::*;
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let db = Database::default()?;
-///
-/// // This transaction doesn't have metrics instrumentation
-/// let txn = db.create_trx()?;
-///
-/// // This will return a TransactionMetricsNotFound error
-/// let result = txn.set_custom_metric("my_metric", 42, &[("label", "value")]);
-/// assert!(result.is_err());
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug)]
-pub struct TransactionMetricsNotFound;
-
-impl std::fmt::Display for TransactionMetricsNotFound {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Transaction metrics not found")
-    }
-}
-
-impl std::error::Error for TransactionMetricsNotFound {}
-
 /// The Standard Error type of FoundationDB
 #[derive(Debug, Copy, Clone)]
 pub struct FdbError {
@@ -139,8 +107,6 @@ pub enum FdbBindingError {
     /// Never box a stringified error (`e.to_string().into()`): the conversion
     /// destroys the source chain, and a retryable error becomes fatal.
     CustomError(Box<dyn std::error::Error + Send + Sync>),
-    /// Error returned when attempting to access metrics on a transaction that wasn't created with metrics instrumentation
-    TransactionMetricsNotFound,
     /// The client-side budget of the transaction attempt was exceeded, as
     /// reported by [`crate::Transaction::check_client_budget`]
     ClientBudgetExceeded(BudgetExceeded),
@@ -208,12 +174,6 @@ impl From<BudgetExceeded> for FdbBindingError {
     }
 }
 
-impl From<TransactionMetricsNotFound> for FdbBindingError {
-    fn from(_e: TransactionMetricsNotFound) -> Self {
-        Self::TransactionMetricsNotFound
-    }
-}
-
 #[cfg(feature = "recipes-leader-election")]
 impl From<crate::recipes::leader_election::LeaderElectionError> for FdbBindingError {
     fn from(error: crate::recipes::leader_election::LeaderElectionError) -> Self {
@@ -239,9 +199,6 @@ impl Debug for FdbBindingError {
                 write!(f, "Reference to transaction kept")
             }
             FdbBindingError::CustomError(err) => write!(f, "{err:?}"),
-            FdbBindingError::TransactionMetricsNotFound => {
-                write!(f, "Transaction metrics not found")
-            }
             FdbBindingError::ClientBudgetExceeded(err) => write!(f, "{err}"),
             #[cfg(feature = "recipes-leader-election")]
             FdbBindingError::LeaderElectionError(err) => write!(f, "{err:?}"),
@@ -264,7 +221,7 @@ impl std::error::Error for FdbBindingError {
             Self::PackError(e) => Some(e),
             Self::CustomError(e) => Some(e.as_ref()),
             Self::ClientBudgetExceeded(e) => Some(e),
-            Self::ReferenceToTransactionKept | Self::TransactionMetricsNotFound => None,
+            Self::ReferenceToTransactionKept => None,
             #[cfg(feature = "recipes-leader-election")]
             Self::LeaderElectionError(e) => Some(e),
         }

--- a/foundationdb/src/error.rs
+++ b/foundationdb/src/error.rs
@@ -8,6 +8,7 @@
 
 //! Error types for the Fdb crate
 
+use crate::budget::BudgetExceeded;
 use crate::directory::DirectoryError;
 use crate::options;
 use crate::tuple::PackError;
@@ -140,6 +141,9 @@ pub enum FdbBindingError {
     CustomError(Box<dyn std::error::Error + Send + Sync>),
     /// Error returned when attempting to access metrics on a transaction that wasn't created with metrics instrumentation
     TransactionMetricsNotFound,
+    /// The client-side budget of the transaction attempt was exceeded, as
+    /// reported by [`crate::Transaction::check_client_budget`]
+    ClientBudgetExceeded(BudgetExceeded),
     #[cfg(feature = "recipes-leader-election")]
     /// Leader election specific error
     LeaderElectionError(crate::recipes::leader_election::LeaderElectionError),
@@ -198,6 +202,12 @@ impl From<DirectoryError> for FdbBindingError {
     }
 }
 
+impl From<BudgetExceeded> for FdbBindingError {
+    fn from(e: BudgetExceeded) -> Self {
+        Self::ClientBudgetExceeded(e)
+    }
+}
+
 impl From<TransactionMetricsNotFound> for FdbBindingError {
     fn from(_e: TransactionMetricsNotFound) -> Self {
         Self::TransactionMetricsNotFound
@@ -232,6 +242,7 @@ impl Debug for FdbBindingError {
             FdbBindingError::TransactionMetricsNotFound => {
                 write!(f, "Transaction metrics not found")
             }
+            FdbBindingError::ClientBudgetExceeded(err) => write!(f, "{err}"),
             #[cfg(feature = "recipes-leader-election")]
             FdbBindingError::LeaderElectionError(err) => write!(f, "{err:?}"),
         }
@@ -252,6 +263,7 @@ impl std::error::Error for FdbBindingError {
             Self::DirectoryError(e) => Some(e),
             Self::PackError(e) => Some(e),
             Self::CustomError(e) => Some(e.as_ref()),
+            Self::ClientBudgetExceeded(e) => Some(e),
             Self::ReferenceToTransactionKept | Self::TransactionMetricsNotFound => None,
             #[cfg(feature = "recipes-leader-election")]
             Self::LeaderElectionError(e) => Some(e),

--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -12,6 +12,8 @@ use foundationdb_sys::if_cfg_api_versions;
 extern crate static_assertions;
 
 pub mod api;
+#[deny(missing_docs)]
+pub mod budget;
 if_cfg_api_versions! {min = 510, max = 600 =>
     pub mod cluster;
 }
@@ -53,6 +55,7 @@ if_cfg_api_versions! {min = 510, max = 600 =>
     pub use crate::cluster::Cluster;
 }
 
+pub use crate::budget::{AttemptUsage, BudgetExceeded, BudgetKind, ClientBudget, UsageSnapshot};
 pub use crate::database::*;
 pub use crate::error::{FdbBindingError, RetryDecision, RetryableError};
 pub use crate::error::{FdbError, FdbResult};

--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -41,7 +41,13 @@ pub mod options;
 pub mod recipes;
 
 // Re-export metrics types for convenience
-pub use crate::metrics::TransactionMetrics;
+pub use crate::metrics::{
+    AttemptMetrics, AttemptOutcome, ConflictKeys, MetricsReport, TransactionMetrics,
+};
+
+#[deny(missing_docs)]
+pub mod runner;
+
 pub mod timekeeper;
 mod transaction;
 mod tuple_ext;
@@ -60,6 +66,9 @@ pub use crate::database::*;
 pub use crate::error::{FdbBindingError, RetryDecision, RetryableError};
 pub use crate::error::{FdbError, FdbResult};
 pub use crate::keyselector::*;
+pub use crate::runner::{
+    AttemptFailure, MetricsHooks, NativeRetryPolicy, RetryPolicy, RunnerHooks, TransactionRunner,
+};
 pub use crate::transaction::*;
 
 /// Initialize the FoundationDB Client API and start the network thread.

--- a/foundationdb/src/metrics.rs
+++ b/foundationdb/src/metrics.rs
@@ -243,7 +243,28 @@ impl TransactionMetrics {
     /// [`Transaction::set_client_budget`](crate::Transaction::set_client_budget)
     /// or [`Transaction::reset`](crate::Transaction::reset) was called.
     pub(crate) fn begin_attempt(&self, usage: Arc<AttemptUsage>) {
-        *self.open() = OpenAttempt {
+        let mut open = self.open();
+
+        #[cfg(feature = "trace")]
+        if let Some(dropped) = open.usage.as_ref() {
+            // `elapsed` always moves, so the counters are what tells whether
+            // the attempt being dropped did anything worth reporting.
+            let snapshot = dropped.snapshot();
+            let idle = snapshot
+                == UsageSnapshot {
+                    elapsed: snapshot.elapsed,
+                    ..UsageSnapshot::default()
+                }
+                && dropped.custom_metrics().is_empty();
+
+            if !idle {
+                tracing::warn!(
+                    "a new attempt was opened while the previous one was still open, its usage and custom metrics are dropped (set_client_budget or reset called mid-attempt)"
+                );
+            }
+        }
+
+        *open = OpenAttempt {
             usage: Some(usage),
             ..OpenAttempt::default()
         };

--- a/foundationdb/src/metrics.rs
+++ b/foundationdb/src/metrics.rs
@@ -248,14 +248,21 @@ impl TransactionMetrics {
         #[cfg(feature = "trace")]
         if let Some(dropped) = open.usage.as_ref() {
             // `elapsed` always moves, so the counters are what tells whether
-            // the attempt being dropped did anything worth reporting.
+            // the attempt being dropped did anything worth reporting. Some
+            // activity is recorded straight on `OpenAttempt` instead of
+            // `AttemptUsage` (read version, conflicting keys, commit
+            // duration), so it has to be checked too.
             let snapshot = dropped.snapshot();
             let idle = snapshot
                 == UsageSnapshot {
                     elapsed: snapshot.elapsed,
                     ..UsageSnapshot::default()
                 }
-                && dropped.custom_metrics().is_empty();
+                && dropped.custom_metrics().is_empty()
+                && open.read_version.is_none()
+                && open.duration.is_none()
+                && open.commit_duration.is_none()
+                && matches!(open.conflicting_keys, ConflictKeys::NotRequested);
 
             if !idle {
                 tracing::warn!(
@@ -548,5 +555,41 @@ mod tests {
 
         assert_eq!(report.total_usage().bytes_written, 14);
         assert_eq!(report.total_usage().call_set, 2);
+    }
+
+    /// An attempt whose only activity was `set_read_version` (no counter
+    /// touched, no custom metric) must not be silently dropped: it should be
+    /// discarded the same way a busy attempt is when a new one starts before
+    /// `finish_attempt` was called, and the crate must keep working normally
+    /// afterwards. This covers the state side of the `idle` heuristic in
+    /// `begin_attempt`; the `#[cfg(feature = "trace")]` warning itself is not
+    /// asserted here as the crate has no test pattern capturing `tracing`
+    /// output content (see `tests/trace.rs`, which only checks the writer
+    /// doesn't panic).
+    #[test]
+    fn dropped_attempt_with_only_read_version_is_handled() {
+        let metrics = TransactionMetrics::new();
+
+        let first = Arc::new(AttemptUsage::new());
+        metrics.begin_attempt(first.clone());
+        metrics.set_read_version(42);
+
+        // A new attempt starts (e.g. `set_client_budget`/`reset`) without the
+        // first one ever reaching `finish_attempt`: it must be dropped
+        // cleanly, no panic.
+        let second = Arc::new(AttemptUsage::new());
+        metrics.begin_attempt(second.clone());
+        second.record_set(1);
+        metrics.finish_attempt(AttemptOutcome::Committed);
+
+        let report = metrics.get_metrics_data();
+        assert_eq!(report.attempts.len(), 1);
+        let only = &report.attempts[0];
+        assert_eq!(only.usage.bytes_written, 1);
+        assert!(matches!(only.outcome, AttemptOutcome::Committed));
+
+        // The read version set on the dropped attempt is still reflected at
+        // the transaction level.
+        assert_eq!(report.transaction.read_version, Some(42));
     }
 }

--- a/foundationdb/src/metrics.rs
+++ b/foundationdb/src/metrics.rs
@@ -1,6 +1,18 @@
+//! Per-attempt metrics collected by [`Database::instrumented_run`](crate::Database::instrumented_run).
+//!
+//! The report is a list of [`AttemptMetrics`], one per transaction attempt, in
+//! order: a retried transaction keeps everything it did in its earlier
+//! attempts. Operation counters come from the always-on
+//! [`UsageSnapshot`] of the attempt, so
+//! instrumentation only adds the timings, the outcome and the aggregates on
+//! top of what the binding already counts.
+
+use crate::budget::{AttemptUsage, UsageSnapshot};
+use crate::error::FdbError;
 use crate::transaction::ConflictingKeyRange;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 /// Label key-value pairs for metrics
 pub type Labels = Vec<(String, String)>;
@@ -38,393 +50,309 @@ impl MetricKey {
     }
 }
 
-/// Tracks metrics for a transaction.
+/// How a transaction attempt ended.
 ///
-/// This struct maintains transaction metrics protected by a mutex to allow safe concurrent access.
-#[derive(Debug, Clone, Default)]
-pub struct TransactionMetrics {
-    /// All metrics for the transaction, organized by category
-    pub metrics: Arc<Mutex<MetricsReport>>,
+/// Marked non exhaustive: finer-grained failure reporting is expected to add
+/// variants.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum AttemptOutcome {
+    /// The attempt committed. For a run, only the last attempt can be in this
+    /// state.
+    Committed,
+    /// The attempt was retried, `cause` being the error handed to `on_error`.
+    /// A closure error asking for a retry without a native error underneath
+    /// surfaces here as code 1020 (`not_committed`).
+    Retried { cause: FdbError },
+    /// The attempt ended the run without committing: the error was not
+    /// retryable, or the retries were exhausted.
+    Failed,
 }
 
-/// Transaction-level information that persists across retries
+/// The conflicting key ranges of a transaction attempt.
+///
+/// They are only read after a commit conflict, and only carry ranges when
+/// [`TransactionOption::ReportConflictingKeys`](crate::options::TransactionOption::ReportConflictingKeys)
+/// was set on the transaction.
+#[derive(Debug, Clone, Default)]
+pub enum ConflictKeys {
+    /// The attempt did not fail on a commit conflict, so nothing was read.
+    #[default]
+    NotRequested,
+    /// The special keyspace was read. The list is empty when
+    /// `ReportConflictingKeys` was not enabled.
+    Available(Vec<ConflictingKeyRange>),
+    /// The special keyspace read failed.
+    ReadFailed(FdbError),
+}
+
+impl ConflictKeys {
+    /// The conflicting ranges, empty unless they were read successfully.
+    pub fn ranges(&self) -> &[ConflictingKeyRange] {
+        match self {
+            ConflictKeys::Available(ranges) => ranges,
+            ConflictKeys::NotRequested | ConflictKeys::ReadFailed(_) => &[],
+        }
+    }
+}
+
+/// Everything recorded about a single transaction attempt.
+///
+/// One is pushed to [`MetricsReport::attempts`] when the attempt ends, so an
+/// attempt that was retried keeps its own counters, timings and custom metrics
+/// instead of being overwritten by the next one.
+#[derive(Debug, Clone)]
+pub struct AttemptMetrics {
+    /// Position of the attempt in the run, starting at 0.
+    pub index: usize,
+    /// Operation counters and bytes of the attempt, from the always-on
+    /// accounting. See [`crate::budget`] for how precise they are.
+    pub usage: UsageSnapshot,
+    /// Application metrics recorded during the attempt with
+    /// [`Transaction::set_custom_metric`](crate::Transaction::set_custom_metric).
+    pub custom_metrics: HashMap<MetricKey, u64>,
+    /// Wall clock of the attempt, measured from its start to the end of its
+    /// work: the retry backoff performed by `on_error` is **not** included.
+    pub duration: Option<Duration>,
+    /// Time spent in `commit`, `None` if the attempt never reached it.
+    pub commit_duration: Option<Duration>,
+    /// Time spent in `on_error`, backoff included. `None` if `on_error` did not
+    /// run, which is the case for the last attempt of a run.
+    pub on_error_duration: Option<Duration>,
+    /// How the attempt ended.
+    pub outcome: AttemptOutcome,
+    /// Conflicting key ranges, only read after a commit conflict.
+    pub conflicting_keys: ConflictKeys,
+    /// Read version of the attempt, recorded when
+    /// [`Transaction::get_read_version`](crate::Transaction::get_read_version)
+    /// is called. The binding never fetches it on its own.
+    pub read_version: Option<i64>,
+}
+
+/// Transaction-level information that spans attempts
 #[derive(Debug, Default, Clone)]
 pub struct TransactionInfo {
-    /// Number of retries performed
+    /// Number of retries performed, that is `attempts.len() - 1` for a
+    /// completed run
     pub retries: u64,
     /// Number of retries caused by commit conflicts (`not_committed`, error 1020)
     pub conflict_count: u64,
-    /// Transaction read version
+    /// Last read version observed, see [`AttemptMetrics::read_version`]
     pub read_version: Option<i64>,
-    /// Transaction commit version
+    /// Commit version of the committed attempt
     pub commit_version: Option<i64>,
 }
 
-/// Data structure containing the actual metrics for a transaction,
-/// organized into different categories
+/// The metrics of a whole `instrumented_run`: the detail of every attempt plus
+/// the aggregates that only make sense for the run as a whole.
 #[derive(Debug, Clone, Default)]
 pub struct MetricsReport {
-    /// Metrics for the current transaction attempt
-    pub current: CounterMetrics,
-    /// Aggregated metrics across all transaction attempts, including retries
-    pub total: CounterMetrics,
-    /// Time-related metrics for performance analysis
-    pub time: TimingMetrics,
-    /// Custom metrics for the current transaction attempt
-    pub custom_metrics: HashMap<MetricKey, u64>,
-    /// Transaction-level information
+    /// One entry per transaction attempt, in order. Nothing is lost across
+    /// retries.
+    pub attempts: Vec<AttemptMetrics>,
+    /// Wall clock of the whole run, every attempt and backoff included.
+    pub total_duration: Option<Duration>,
+    /// Information that spans attempts.
     pub transaction: TransactionInfo,
-    /// Conflicting key ranges from the last commit conflict.
-    /// Empty if `TransactionOption::ReportConflictingKeys` was not enabled or the read failed.
-    pub conflicting_keys: Vec<ConflictingKeyRange>,
 }
 
 impl MetricsReport {
-    /// Set the read version for the transaction
+    /// Sums the usage of every attempt, retries included.
     ///
-    /// # Arguments
-    /// * `version` - The read version
-    pub fn set_read_version(&mut self, version: i64) {
-        self.transaction.read_version = Some(version);
+    /// `elapsed` is the sum of the attempt durations, which is shorter than
+    /// [`total_duration`](Self::total_duration): the retry backoffs are not
+    /// part of any attempt.
+    pub fn total_usage(&self) -> UsageSnapshot {
+        self.attempts
+            .iter()
+            .fold(UsageSnapshot::default(), |mut total, attempt| {
+                let usage = &attempt.usage;
+                total.elapsed += usage.elapsed;
+                total.bytes_read += usage.bytes_read;
+                total.bytes_written += usage.bytes_written;
+                total.keys_values_fetched += usage.keys_values_fetched;
+                total.call_get += usage.call_get;
+                total.call_get_range += usage.call_get_range;
+                total.call_set += usage.call_set;
+                total.call_clear += usage.call_clear;
+                total.call_clear_range += usage.call_clear_range;
+                total.call_atomic_op += usage.call_atomic_op;
+                total
+            })
     }
 
-    /// Set the commit version for the transaction
-    ///
-    /// # Arguments
-    /// * `version` - The commit version
-    pub fn set_commit_version(&mut self, version: i64) {
-        self.transaction.commit_version = Some(version);
-    }
-
-    /// Increment the retry counter
-    pub fn increment_retries(&mut self) {
-        self.transaction.retries += 1;
+    /// The attempt that ended the run, `None` if no attempt was ever started.
+    pub fn last_attempt(&self) -> Option<&AttemptMetrics> {
+        self.attempts.last()
     }
 }
 
-/// Time-related metrics for performance analysis of transaction execution phases
-#[derive(Debug, Default, Clone)]
-pub struct TimingMetrics {
-    /// Time spent in commit phase execution
-    pub commit_execution_ms: u64,
-    /// Time spent handling errors and retries
-    pub on_error_execution_ms: Vec<u64>,
-    /// Total transaction duration from start to finish
-    pub total_execution_ms: u64,
+/// The attempt currently being recorded.
+///
+/// Holds the accounting generation of the transaction, so that the attempt can
+/// be pushed to the report even after the transaction itself is gone (a
+/// non-retryable `on_error` consumes it), and the pieces that are known before
+/// the attempt ends.
+#[derive(Debug, Default)]
+struct OpenAttempt {
+    usage: Option<Arc<AttemptUsage>>,
+    duration: Option<Duration>,
+    commit_duration: Option<Duration>,
+    conflicting_keys: ConflictKeys,
+    read_version: Option<i64>,
 }
 
-impl TimingMetrics {
-    /// Record commit execution time
-    ///
-    /// # Arguments
-    /// * `duration_ms` - The duration of the commit execution in milliseconds
-    pub fn record_commit_time(&mut self, duration_ms: u64) {
-        self.commit_execution_ms = duration_ms;
-    }
-
-    /// Add an error execution time to the list
-    ///
-    /// # Arguments
-    /// * `duration_ms` - The duration of the error handling in milliseconds
-    pub fn add_error_time(&mut self, duration_ms: u64) {
-        self.on_error_execution_ms.push(duration_ms);
-    }
-
-    /// Set the total execution time
-    ///
-    /// # Arguments
-    /// * `duration_ms` - The total duration of the transaction in milliseconds
-    pub fn set_execution_time(&mut self, duration_ms: u64) {
-        self.total_execution_ms = duration_ms;
-    }
-
-    /// Get the sum of all error handling times
-    ///
-    /// # Returns
-    /// * `u64` - The total time spent handling errors in milliseconds
-    pub fn get_total_error_time(&self) -> u64 {
-        self.on_error_execution_ms.iter().sum()
-    }
+/// Collects the metrics of a transaction, attempt after attempt.
+///
+/// This is the handle shared between the transaction, the runner hooks and the
+/// caller: cloning it clones the handle, not the data. The recording methods
+/// are called by the binding as the transaction progresses, the report is read
+/// back with [`get_metrics_data`](Self::get_metrics_data).
+#[derive(Debug, Clone, Default)]
+pub struct TransactionMetrics {
+    /// The report being built.
+    pub metrics: Arc<Mutex<MetricsReport>>,
+    /// The attempt being recorded, pushed to the report when it ends.
+    open: Arc<Mutex<OpenAttempt>>,
 }
-
-/// Represents a FoundationDB command.
-pub enum FdbCommand {
-    /// Atomic operation
-    Atomic,
-    /// Clear operation
-    Clear,
-    /// Clear range operation
-    ClearRange,
-    /// Get operation
-    Get(u64, u64),
-    GetRange(u64, u64),
-    Set(u64),
-}
-
-const INCREMENT: u64 = 1;
 
 impl TransactionMetrics {
     /// Create a new instance of TransactionMetrics
     pub fn new() -> Self {
-        Self {
-            metrics: Arc::new(Mutex::new(MetricsReport::default())),
+        Self::default()
+    }
+
+    fn report(&self) -> std::sync::MutexGuard<'_, MetricsReport> {
+        self.metrics
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn open(&self) -> std::sync::MutexGuard<'_, OpenAttempt> {
+        self.open
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Starts recording a new attempt, on the accounting generation the
+    /// transaction just entered.
+    ///
+    /// Anything recorded on a previous attempt that was not ended with
+    /// [`finish_attempt`](Self::finish_attempt) is dropped: the transaction
+    /// restarted without reaching a conclusion, typically because
+    /// [`Transaction::set_client_budget`](crate::Transaction::set_client_budget)
+    /// or [`Transaction::reset`](crate::Transaction::reset) was called.
+    pub(crate) fn begin_attempt(&self, usage: Arc<AttemptUsage>) {
+        *self.open() = OpenAttempt {
+            usage: Some(usage),
+            ..OpenAttempt::default()
+        };
+    }
+
+    /// Freezes the duration of the attempt at the current elapsed time, so that
+    /// what happens next (retry backoff, error handling) is not counted as part
+    /// of it. Later calls do not move it.
+    pub(crate) fn mark_attempt_end(&self) {
+        let mut open = self.open();
+        if open.duration.is_none() {
+            open.duration = open.usage.as_ref().map(|usage| usage.elapsed());
         }
     }
 
-    /// Set the read version for the transaction
+    /// Records the time spent in `commit`, whatever its result, and ends the
+    /// attempt's work.
+    pub(crate) fn record_commit(&self, duration: Duration) {
+        let mut open = self.open();
+        open.commit_duration = Some(duration);
+        if open.duration.is_none() {
+            open.duration = open.usage.as_ref().map(|usage| usage.elapsed());
+        }
+    }
+
+    /// Ends the current attempt and pushes it to the report.
     ///
-    /// # Arguments
-    /// * `version` - The read version
+    /// Does nothing when no attempt is being recorded, which makes it safe to
+    /// call on the exit paths of a runner that may already have ended it.
+    pub fn finish_attempt(&self, outcome: AttemptOutcome) {
+        let (usage, open) = {
+            let mut open = self.open();
+            match open.usage.take() {
+                // `usage` was taken above, so this leaves the scratch empty.
+                Some(usage) => (usage, std::mem::take(&mut *open)),
+                None => return,
+            }
+        };
+
+        let retried = matches!(outcome, AttemptOutcome::Retried { .. });
+
+        let mut report = self.report();
+        let index = report.attempts.len();
+        report.attempts.push(AttemptMetrics {
+            index,
+            usage: usage.snapshot(),
+            custom_metrics: usage.custom_metrics(),
+            duration: open.duration.or_else(|| Some(usage.elapsed())),
+            commit_duration: open.commit_duration,
+            on_error_duration: None,
+            outcome,
+            conflicting_keys: open.conflicting_keys,
+            read_version: open.read_version,
+        });
+
+        if retried {
+            report.transaction.retries += 1;
+        }
+    }
+
+    /// Records the time spent in `on_error` for the attempt that just ended.
+    ///
+    /// The runner measures it after `on_error` returned, hence after the
+    /// attempt was pushed: it lands on the last attempt of the report.
+    pub fn set_on_error_duration(&self, duration: Duration) {
+        if let Some(attempt) = self.report().attempts.last_mut() {
+            attempt.on_error_duration = Some(duration);
+        }
+    }
+
+    /// Records the total duration of the run.
+    pub fn set_total_duration(&self, duration: Duration) {
+        self.report().total_duration = Some(duration);
+    }
+
+    /// Records the read version of the current attempt.
     pub fn set_read_version(&self, version: i64) {
-        let mut data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.set_read_version(version);
+        self.open().read_version = Some(version);
+        self.report().transaction.read_version = Some(version);
     }
 
-    /// Set the commit version for the transaction
-    ///
-    /// # Arguments
-    /// * `version` - The commit version
+    /// Records the commit version of the transaction.
     pub fn set_commit_version(&self, version: i64) {
-        let mut data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.set_commit_version(version);
+        self.report().transaction.commit_version = Some(version);
     }
 
-    /// Resets the current metrics and increments the retry counter in total metrics.
-    ///
-    /// This method is called when a transaction is retried due to a conflict or other retryable error.
-    /// It increments the retry count in the transaction info and resets the current metrics to zero.
-    /// It also merges current custom metrics into total custom metrics before clearing them.
-    pub fn reset_current(&self) {
-        let mut data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.increment_retries();
-        data.current = CounterMetrics::default();
-        data.custom_metrics.clear();
-    }
-
-    /// Increment the retry counter
-    pub fn increment_retries(&self) {
-        let mut data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.increment_retries();
+    /// Records the conflicting key ranges of the current attempt.
+    pub fn set_conflicting_keys(&self, keys: ConflictKeys) {
+        self.open().conflicting_keys = keys;
     }
 
     /// Increment the conflict counter
     pub fn increment_conflict_count(&self) {
-        let mut data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.transaction.conflict_count += 1;
-    }
-
-    /// Reports metrics for a specific FDB command by incrementing the appropriate counters.
-    ///
-    /// This method updates both the current and total metrics for the given command.
-    ///
-    /// # Arguments
-    /// * `fdb_command` - The FDB command to report metrics for
-    pub fn report_metrics(&self, fdb_command: FdbCommand) {
-        let mut data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.current.increment(&fdb_command);
-        data.total.increment(&fdb_command);
+        self.report().transaction.conflict_count += 1;
     }
 
     /// Get the number of retries
-    ///
-    /// # Returns
-    /// * `u64` - The number of retries
     pub fn get_retries(&self) -> u64 {
-        let data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.transaction.retries
+        self.report().transaction.retries
     }
 
-    /// Returns a clone of all metrics data.
-    ///
-    /// # Returns
-    /// * `MetricsData` - A clone of all metrics data
+    /// Returns a clone of the report built so far.
     pub fn get_metrics_data(&self) -> MetricsReport {
-        let data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.clone()
+        self.report().clone()
     }
 
     /// Returns a clone of the transaction information.
-    ///
-    /// # Returns
-    /// * `TransactionInfo` - A clone of the transaction information
     pub fn get_transaction_info(&self) -> TransactionInfo {
-        let data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.transaction.clone()
-    }
-
-    /// Set a custom metric
-    ///
-    /// # Arguments
-    /// * `name` - The name of the metric
-    /// * `value` - The value to set
-    /// * `labels` - Key-value pairs for labeling the metric
-    pub fn set_custom(&self, name: &str, value: u64, labels: &[(&str, &str)]) {
-        let mut data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let key = MetricKey::new(name, labels);
-        data.custom_metrics.insert(key.clone(), value);
-    }
-
-    /// Increment a custom metric
-    ///
-    /// # Arguments
-    /// * `name` - The name of the metric
-    /// * `amount` - The amount to increment by
-    /// * `labels` - Key-value pairs for labeling the metric
-    pub fn increment_custom(&self, name: &str, amount: u64, labels: &[(&str, &str)]) {
-        let mut data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let key = MetricKey::new(name, labels);
-        // Increment in both current and total custom metrics
-        *data.custom_metrics.entry(key.clone()).or_insert(0) += amount;
-    }
-
-    /// Set the conflicting key ranges from a commit conflict.
-    pub fn set_conflicting_keys(&self, keys: Vec<ConflictingKeyRange>) {
-        let mut data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.conflicting_keys = keys;
-    }
-
-    /// Record commit execution time
-    ///
-    /// # Arguments
-    /// * `duration_ms` - The duration of the commit execution in milliseconds
-    pub fn record_commit_time(&self, duration_ms: u64) {
-        let mut data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.time.commit_execution_ms = duration_ms;
-    }
-
-    /// Add an error execution time to the list
-    ///
-    /// # Arguments
-    /// * `duration_ms` - The duration of the error handling in milliseconds
-    pub fn add_error_time(&self, duration_ms: u64) {
-        let mut data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.time.on_error_execution_ms.push(duration_ms);
-    }
-
-    /// Set the total execution time
-    ///
-    /// # Arguments
-    /// * `duration_ms` - The total duration of the transaction in milliseconds
-    pub fn set_execution_time(&self, duration_ms: u64) {
-        let mut data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.time.set_execution_time(duration_ms);
-    }
-
-    /// Get the sum of all error handling times
-    ///
-    /// # Returns
-    /// * `u64` - The total time spent handling errors in milliseconds
-    pub fn get_total_error_time(&self) -> u64 {
-        let data = self
-            .metrics
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        data.time.on_error_execution_ms.iter().sum()
-    }
-}
-
-/// `CounterMetrics` is used in two contexts within the metrics system:
-/// - As `current` metrics: tracking operations for the current transaction attempt
-/// - As `total` metrics: aggregating operations across all transaction attempts including retries
-///
-/// Each counter is incremented when the corresponding operation is performed, allowing
-/// for detailed analysis of transaction behavior and performance characteristics.
-#[derive(Debug, Default, Clone)]
-pub struct CounterMetrics {
-    // ATOMIC OP
-    /// Number of atomic operations performed (add, and, or, etc.)
-    pub call_atomic_op: u64,
-    // CLEAR
-    /// Number of key clear operations performed
-    pub call_clear: u64,
-    // CLEAR RANGE
-    /// Number of range clear operations performed
-    pub call_clear_range: u64,
-    // GET
-    /// Number of get operations performed
-    pub call_get: u64,
-    /// Total number of key-value pairs fetched across all read operations
-    pub keys_values_fetched: u64,
-    /// Total number of bytes read from the database
-    pub bytes_read: u64,
-    // SET
-    /// Number of set operations performed
-    pub call_set: u64,
-    /// Total number of bytes written to the database
-    pub bytes_written: u64,
-}
-
-impl CounterMetrics {
-    /// Increments the metrics for a given FDB command.
-    ///
-    /// This method updates the metrics counters based on the type of FDB command.
-    ///
-    /// # Arguments
-    /// * `fdb_command` - The FDB command to increment metrics for
-    pub fn increment(&mut self, fdb_command: &FdbCommand) {
-        match fdb_command {
-            FdbCommand::Atomic => self.call_atomic_op += INCREMENT,
-            FdbCommand::Clear => self.call_clear += INCREMENT,
-            FdbCommand::ClearRange => self.call_clear_range += INCREMENT,
-            FdbCommand::Get(bytes_count, kv_fetched) => {
-                self.keys_values_fetched += *kv_fetched;
-                self.bytes_read += *bytes_count;
-                self.call_get += INCREMENT
-            }
-            FdbCommand::GetRange(bytes_count, keys_values_fetched) => {
-                self.keys_values_fetched += *keys_values_fetched;
-                self.bytes_read += *bytes_count;
-            }
-            FdbCommand::Set(bytes_count) => {
-                self.bytes_written += *bytes_count;
-                self.call_set += INCREMENT
-            }
-        }
+        self.report().transaction.clone()
     }
 }
 
@@ -545,46 +473,59 @@ mod tests {
         assert_eq!(unique_keys.len(), 1);
     }
 
+    /// Every attempt keeps its own counters and custom metrics, and the report
+    /// aggregates them.
     #[test]
-    fn test_custom_metrics_operations() {
-        // Create a metrics instance
+    fn attempts_are_recorded_one_by_one() {
         let metrics = TransactionMetrics::new();
+        let key = MetricKey::new("documents", &[]);
 
-        // Set initial value for a custom metric
-        metrics.set_custom(
-            "api_calls",
-            100,
-            &[("endpoint", "users"), ("method", "GET")],
-        );
+        // Nothing to push before an attempt is opened.
+        metrics.finish_attempt(AttemptOutcome::Failed);
+        assert!(metrics.get_metrics_data().attempts.is_empty());
 
-        // Get the metrics data and verify the value was set
-        let data = metrics.get_metrics_data();
-        let key = MetricKey::new("api_calls", &[("endpoint", "users"), ("method", "GET")]);
-        assert_eq!(data.custom_metrics.get(&key).copied(), Some(100));
+        let first = Arc::new(AttemptUsage::new());
+        metrics.begin_attempt(first.clone());
+        first.record_set(10);
+        first.increment_custom(key.clone(), 1);
+        metrics.record_commit(Duration::from_millis(3));
+        metrics.finish_attempt(AttemptOutcome::Retried {
+            cause: FdbError::from_code(1020),
+        });
+        metrics.set_on_error_duration(Duration::from_millis(7));
 
-        // Increment the same metric
-        metrics.increment_custom("api_calls", 50, &[("endpoint", "users"), ("method", "GET")]);
+        let second = Arc::new(AttemptUsage::new());
+        metrics.begin_attempt(second.clone());
+        second.record_set(4);
+        second.increment_custom(key.clone(), 2);
+        metrics.finish_attempt(AttemptOutcome::Committed);
 
-        // Verify the value was incremented
-        let data = metrics.get_metrics_data();
-        assert_eq!(data.custom_metrics.get(&key).copied(), Some(150));
+        // A second end is a no-op: an attempt is pushed exactly once.
+        metrics.finish_attempt(AttemptOutcome::Failed);
 
-        // Set the same metric to a new value (overwrite)
-        metrics.set_custom(
-            "api_calls",
-            200,
-            &[("endpoint", "users"), ("method", "GET")],
-        );
+        let report = metrics.get_metrics_data();
+        assert_eq!(report.attempts.len(), 2);
+        assert_eq!(report.transaction.retries, 1);
 
-        // Verify the value was overwritten
-        let data = metrics.get_metrics_data();
-        assert_eq!(data.custom_metrics.get(&key).copied(), Some(200));
+        let first = &report.attempts[0];
+        assert_eq!(first.index, 0);
+        assert_eq!(first.usage.bytes_written, 10);
+        assert_eq!(first.custom_metrics.get(&key), Some(&1));
+        assert_eq!(first.commit_duration, Some(Duration::from_millis(3)));
+        assert_eq!(first.on_error_duration, Some(Duration::from_millis(7)));
+        assert!(matches!(
+            first.outcome,
+            AttemptOutcome::Retried { cause } if cause.code() == 1020
+        ));
 
-        // Test with different label order
-        metrics.increment_custom("api_calls", 75, &[("method", "GET"), ("endpoint", "users")]);
+        let second = &report.attempts[1];
+        assert_eq!(second.index, 1);
+        assert_eq!(second.usage.bytes_written, 4);
+        assert_eq!(second.custom_metrics.get(&key), Some(&2));
+        assert!(second.commit_duration.is_none());
+        assert!(matches!(second.outcome, AttemptOutcome::Committed));
 
-        // Verify the value was incremented regardless of label order
-        let data = metrics.get_metrics_data();
-        assert_eq!(data.custom_metrics.get(&key).copied(), Some(275));
+        assert_eq!(report.total_usage().bytes_written, 14);
+        assert_eq!(report.total_usage().call_set, 2);
     }
 }

--- a/foundationdb/src/runner.rs
+++ b/foundationdb/src/runner.rs
@@ -1,0 +1,856 @@
+// Copyright 2026 foundationdb-rs developers, https://github.com/Clikengo/foundationdb-rs/graphs/contributors
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! The retry runner behind [`Database::run`](crate::Database::run).
+//!
+//! The runner is built from three independent pieces:
+//!
+//! * the **attempt**: run the closure on a transaction, then commit it. One
+//!   attempt does exactly one pass and never retries.
+//! * the **hooks** ([`RunnerHooks`]): purely observational callbacks fired
+//!   around each attempt. They cannot change what the runner decides.
+//! * the **policy** ([`RetryPolicy`]): the only thing that can change a
+//!   decision. It sees the failure and the decision the runner proposes, and
+//!   returns the decision to apply.
+//!
+//! They are assembled by [`TransactionRunner`], the builder returned by
+//! [`Database::runner`](crate::Database::runner):
+//!
+//! ```no_run
+//! # use foundationdb::*;
+//! # use foundationdb::runner::MetricsHooks;
+//! # async fn example(db: &Database) -> Result<(), FdbBindingError> {
+//! let metrics = TransactionMetrics::new();
+//! db.runner()
+//!     .hooks(&MetricsHooks::new(&metrics))
+//!     .run(|trx, _maybe_committed| async move {
+//!         trx.set(b"key", b"value");
+//!         Ok::<_, FdbBindingError>(())
+//!     })
+//!     .await?;
+//! let report = metrics.get_metrics_data();
+//! # let _ = report;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Retry semantics
+//!
+//! `fdb_transaction_on_error` remains the single retry governor: backoff, max
+//! retry delay and [`TransactionOption::RetryLimit`](crate::options::TransactionOption::RetryLimit)
+//! are applied by the C API, never by a Rust-side budget. A closure error asking
+//! for a retry without a native error underneath
+//! ([`RetryDecision::Retry`]) is routed through `on_error` with code 1020
+//! (`not_committed`) so that it obeys the same budget.
+
+use std::time::{Duration, Instant};
+
+use crate::database::{Database, MaybeCommitted};
+use crate::error::{FdbBindingError, FdbError, FdbResult, RetryDecision, RetryableError};
+use crate::metrics::{AttemptOutcome, ConflictKeys, TransactionMetrics};
+use crate::transaction::{
+    RetryableTransaction, Transaction, TransactionCommitError, TransactionCommitted,
+};
+
+/// `not_committed`: the retryable error code a [`RetryDecision::Retry`] is
+/// routed through.
+const NOT_COMMITTED: i32 = 1020;
+
+/// Observation points of the retry runner.
+///
+/// Hooks are **purely observational**: nothing they do or return changes what
+/// the runner decides. Use a [`RetryPolicy`] to influence retries. Every method
+/// has a no-op default, so an implementation only overrides what it needs.
+///
+/// # Ordering
+///
+/// Every callback receives the index of the attempt it belongs to, starting at
+/// `0` and matching [`AttemptMetrics::index`](crate::metrics::AttemptMetrics::index).
+/// Per attempt, in order:
+///
+/// 1. [`on_attempt_start`](Self::on_attempt_start)
+/// 2. the closure runs
+/// 3. if the closure succeeded: [`before_commit`](Self::before_commit), then
+///    the commit
+///    * commit succeeded: [`on_commit_success`](Self::on_commit_success), the
+///      run is over
+///    * commit failed: [`on_commit_error`](Self::on_commit_error), then
+///      `on_error`, then [`on_error_duration`](Self::on_error_duration) and
+///      [`on_retry`](Self::on_retry) if the transaction was retried
+/// 4. if the closure failed: [`on_closure_error`](Self::on_closure_error) (only
+///    when the error maps to an [`FdbError`], that is when the runner is about
+///    to call `on_error`), then `on_error`, then
+///    [`on_error_duration`](Self::on_error_duration) and
+///    [`on_retry`](Self::on_retry) if the transaction was retried
+///
+/// [`on_complete`](Self::on_complete) fires exactly once per run, on **every**
+/// exit path: success, non-retryable error, exhausted retries or binding error.
+///
+/// The two fallible hooks ([`before_commit`](Self::before_commit) and
+/// [`on_commit_error`](Self::on_commit_error)) never abort the runner: their
+/// error is reported to [`on_hook_error`](Self::on_hook_error) and the run
+/// continues exactly as if they had succeeded.
+///
+/// # Transaction access
+///
+/// Hooks see a `&Transaction`, never the clonable
+/// [`RetryableTransaction`]: a hook that could
+/// keep a reference to it would make the runner fail with
+/// [`FdbBindingError::ReferenceToTransactionKept`].
+///
+/// # Composition
+///
+/// [`RunnerHooks`] is implemented for `()` (no-op), `&H`, `Option<H>` (`None`
+/// is a no-op) and `(A, B)`, which nest for any arity: `(a, (b, c))`. In a
+/// tuple, callbacks fire left to right, and both sides always run even if the
+/// left one returned an error, the first error being the one reported.
+pub trait RunnerHooks {
+    /// Called when an attempt starts, before the closure runs.
+    fn on_attempt_start(&self, _trx: &Transaction, _attempt: usize) {}
+
+    /// Called after the closure succeeded, before the transaction is committed.
+    ///
+    /// This is the last point where the transaction can be read or written
+    /// inside the attempt. Returning an error does **not** abort the commit: it
+    /// is reported through [`on_hook_error`](Self::on_hook_error) and the
+    /// transaction is committed anyway.
+    fn before_commit(
+        &self,
+        _trx: &Transaction,
+        _attempt: usize,
+    ) -> impl Future<Output = FdbResult<()>> + Send {
+        async { Ok(()) }
+    }
+
+    /// Called with the error of a hook that failed, right after it failed.
+    fn on_hook_error(&self, _err: &FdbError, _attempt: usize) {}
+
+    /// Called after a successful commit, with the time the commit took.
+    fn on_commit_success(
+        &self,
+        _committed: &TransactionCommitted,
+        _commit_duration_ms: u64,
+        _attempt: usize,
+    ) {
+    }
+
+    /// Called when the commit failed, **before** `on_error` resets the
+    /// transaction. This is the only window to read conflicting keys or inspect
+    /// the state of the failed attempt.
+    ///
+    /// It fires whatever the runner does next, including when the
+    /// [`RetryPolicy`] turns the failure into a fatal one. An error returned
+    /// here is reported through [`on_hook_error`](Self::on_hook_error) and
+    /// changes nothing else.
+    fn on_commit_error(
+        &self,
+        _err: &TransactionCommitError,
+        _attempt: usize,
+    ) -> impl Future<Output = FdbResult<()>> + Send {
+        async { Ok(()) }
+    }
+
+    /// Called when a closure error is about to be handed to `on_error`.
+    ///
+    /// A closure error classified as [`RetryDecision::Retry`] surfaces here as
+    /// a synthetic `FdbError` with code 1020 (`not_committed`). A fatal error
+    /// never reaches this hook.
+    fn on_closure_error(&self, _err: &FdbError, _attempt: usize) {}
+
+    /// Called after `on_error` returned, with the time it took, backoff
+    /// included.
+    fn on_error_duration(&self, _duration_ms: u64, _attempt: usize) {}
+
+    /// Called when the attempt is about to be retried, that is once `on_error`
+    /// accepted to retry it.
+    fn on_retry(&self, _attempt: usize) {}
+
+    /// Called exactly once when the run ends, whatever its outcome.
+    fn on_complete(&self) {}
+}
+
+impl RunnerHooks for () {}
+
+impl<H: RunnerHooks + Sync> RunnerHooks for &H {
+    fn on_attempt_start(&self, trx: &Transaction, attempt: usize) {
+        (*self).on_attempt_start(trx, attempt)
+    }
+
+    fn before_commit(
+        &self,
+        trx: &Transaction,
+        attempt: usize,
+    ) -> impl Future<Output = FdbResult<()>> + Send {
+        (*self).before_commit(trx, attempt)
+    }
+
+    fn on_hook_error(&self, err: &FdbError, attempt: usize) {
+        (*self).on_hook_error(err, attempt)
+    }
+
+    fn on_commit_success(
+        &self,
+        committed: &TransactionCommitted,
+        commit_duration_ms: u64,
+        attempt: usize,
+    ) {
+        (*self).on_commit_success(committed, commit_duration_ms, attempt)
+    }
+
+    fn on_commit_error(
+        &self,
+        err: &TransactionCommitError,
+        attempt: usize,
+    ) -> impl Future<Output = FdbResult<()>> + Send {
+        (*self).on_commit_error(err, attempt)
+    }
+
+    fn on_closure_error(&self, err: &FdbError, attempt: usize) {
+        (*self).on_closure_error(err, attempt)
+    }
+
+    fn on_error_duration(&self, duration_ms: u64, attempt: usize) {
+        (*self).on_error_duration(duration_ms, attempt)
+    }
+
+    fn on_retry(&self, attempt: usize) {
+        (*self).on_retry(attempt)
+    }
+
+    fn on_complete(&self) {
+        (*self).on_complete()
+    }
+}
+
+impl<H: RunnerHooks + Sync> RunnerHooks for Option<H> {
+    fn on_attempt_start(&self, trx: &Transaction, attempt: usize) {
+        if let Some(hooks) = self {
+            hooks.on_attempt_start(trx, attempt);
+        }
+    }
+
+    async fn before_commit(&self, trx: &Transaction, attempt: usize) -> FdbResult<()> {
+        match self {
+            Some(hooks) => hooks.before_commit(trx, attempt).await,
+            None => Ok(()),
+        }
+    }
+
+    fn on_hook_error(&self, err: &FdbError, attempt: usize) {
+        if let Some(hooks) = self {
+            hooks.on_hook_error(err, attempt);
+        }
+    }
+
+    fn on_commit_success(
+        &self,
+        committed: &TransactionCommitted,
+        commit_duration_ms: u64,
+        attempt: usize,
+    ) {
+        if let Some(hooks) = self {
+            hooks.on_commit_success(committed, commit_duration_ms, attempt);
+        }
+    }
+
+    async fn on_commit_error(&self, err: &TransactionCommitError, attempt: usize) -> FdbResult<()> {
+        match self {
+            Some(hooks) => hooks.on_commit_error(err, attempt).await,
+            None => Ok(()),
+        }
+    }
+
+    fn on_closure_error(&self, err: &FdbError, attempt: usize) {
+        if let Some(hooks) = self {
+            hooks.on_closure_error(err, attempt);
+        }
+    }
+
+    fn on_error_duration(&self, duration_ms: u64, attempt: usize) {
+        if let Some(hooks) = self {
+            hooks.on_error_duration(duration_ms, attempt);
+        }
+    }
+
+    fn on_retry(&self, attempt: usize) {
+        if let Some(hooks) = self {
+            hooks.on_retry(attempt);
+        }
+    }
+
+    fn on_complete(&self) {
+        if let Some(hooks) = self {
+            hooks.on_complete();
+        }
+    }
+}
+
+impl<A: RunnerHooks + Sync, B: RunnerHooks + Sync> RunnerHooks for (A, B) {
+    fn on_attempt_start(&self, trx: &Transaction, attempt: usize) {
+        self.0.on_attempt_start(trx, attempt);
+        self.1.on_attempt_start(trx, attempt);
+    }
+
+    async fn before_commit(&self, trx: &Transaction, attempt: usize) -> FdbResult<()> {
+        let first = self.0.before_commit(trx, attempt).await;
+        let second = self.1.before_commit(trx, attempt).await;
+        first.and(second)
+    }
+
+    fn on_hook_error(&self, err: &FdbError, attempt: usize) {
+        self.0.on_hook_error(err, attempt);
+        self.1.on_hook_error(err, attempt);
+    }
+
+    fn on_commit_success(
+        &self,
+        committed: &TransactionCommitted,
+        commit_duration_ms: u64,
+        attempt: usize,
+    ) {
+        self.0
+            .on_commit_success(committed, commit_duration_ms, attempt);
+        self.1
+            .on_commit_success(committed, commit_duration_ms, attempt);
+    }
+
+    async fn on_commit_error(&self, err: &TransactionCommitError, attempt: usize) -> FdbResult<()> {
+        let first = self.0.on_commit_error(err, attempt).await;
+        let second = self.1.on_commit_error(err, attempt).await;
+        first.and(second)
+    }
+
+    fn on_closure_error(&self, err: &FdbError, attempt: usize) {
+        self.0.on_closure_error(err, attempt);
+        self.1.on_closure_error(err, attempt);
+    }
+
+    fn on_error_duration(&self, duration_ms: u64, attempt: usize) {
+        self.0.on_error_duration(duration_ms, attempt);
+        self.1.on_error_duration(duration_ms, attempt);
+    }
+
+    fn on_retry(&self, attempt: usize) {
+        self.0.on_retry(attempt);
+        self.1.on_retry(attempt);
+    }
+
+    fn on_complete(&self) {
+        self.0.on_complete();
+        self.1.on_complete();
+    }
+}
+
+/// Hooks collecting a [`MetricsReport`](crate::metrics::MetricsReport) into a
+/// [`TransactionMetrics`].
+///
+/// They are what [`Database::instrumented_run`](crate::Database::instrumented_run)
+/// is made of, and can be stacked on any other hooks to get the same report out
+/// of a plain [`run`](crate::Database::run):
+///
+/// ```no_run
+/// # use foundationdb::*;
+/// # use foundationdb::runner::MetricsHooks;
+/// # struct MyHooks;
+/// # impl foundationdb::runner::RunnerHooks for MyHooks {}
+/// # async fn example(db: &Database) -> Result<(), FdbBindingError> {
+/// let metrics = TransactionMetrics::new();
+/// db.run_with_hooks(&(MetricsHooks::new(&metrics), MyHooks), |trx, _| async move {
+///     trx.set(b"key", b"value");
+///     Ok::<_, FdbBindingError>(())
+/// })
+/// .await?;
+///
+/// let report = metrics.get_metrics_data();
+/// # let _ = report;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// The run is timed from the construction of the hooks, so build one per run.
+///
+/// The collector is attached to the transaction when the first attempt starts,
+/// which is what makes the counters of a plain `run` land in the report. A
+/// transaction only ever reports to one collector: stacking two `MetricsHooks`
+/// leaves the second one empty.
+pub struct MetricsHooks {
+    metrics: TransactionMetrics,
+    start: Instant,
+}
+
+impl MetricsHooks {
+    /// Collects the metrics of a run into `metrics`.
+    ///
+    /// The handle is cloned, so the caller keeps reading the report from its
+    /// own [`TransactionMetrics`] once the run is over.
+    pub fn new(metrics: &TransactionMetrics) -> Self {
+        Self {
+            metrics: metrics.clone(),
+            start: Instant::now(),
+        }
+    }
+}
+
+impl RunnerHooks for MetricsHooks {
+    fn on_attempt_start(&self, trx: &Transaction, _attempt: usize) {
+        // Wires the collector onto the transaction the runner created, which is
+        // what makes the counters of every attempt land in the report. A no-op
+        // from the second attempt on: the transaction keeps its collector
+        // across retries.
+        trx.attach_metrics(&self.metrics);
+    }
+
+    async fn on_commit_error(
+        &self,
+        err: &TransactionCommitError,
+        _attempt: usize,
+    ) -> FdbResult<()> {
+        // not_committed (1020) = commit conflict
+        if err.code() == NOT_COMMITTED {
+            self.metrics.increment_conflict_count();
+        }
+        // Reading from the \xff\xff/transaction/conflicting_keys/ special keyspace is
+        // resolved client-side — no network round-trip to the cluster. The future still
+        // goes through the FDB network thread event loop, but the data comes from an
+        // in-memory map populated during the commit response. Returns empty if
+        // ReportConflictingKeys was not set.
+        match err.conflicting_keys().await {
+            Ok(keys) => {
+                self.metrics
+                    .set_conflicting_keys(ConflictKeys::Available(keys));
+                Ok(())
+            }
+            Err(read_error) => {
+                self.metrics
+                    .set_conflicting_keys(ConflictKeys::ReadFailed(read_error));
+                Err(read_error)
+            }
+        }
+    }
+
+    fn on_error_duration(&self, duration_ms: u64, _attempt: usize) {
+        // `on_error` already pushed the attempt it ended, so this lands on the
+        // last attempt of the report.
+        self.metrics
+            .set_on_error_duration(Duration::from_millis(duration_ms));
+    }
+
+    fn on_commit_success(
+        &self,
+        committed: &TransactionCommitted,
+        _commit_duration_ms: u64,
+        _attempt: usize,
+    ) {
+        // The attempt itself was pushed by `Transaction::commit`, which also
+        // recorded how long the commit took.
+        if let Ok(version) = committed.committed_version() {
+            self.metrics.set_commit_version(version);
+        }
+    }
+
+    fn on_complete(&self) {
+        // An attempt still open when the run ends is the one that failed:
+        // attempts that committed or were retried were pushed by the
+        // transaction itself, which makes this a no-op for them.
+        self.metrics.finish_attempt(AttemptOutcome::Failed);
+        self.metrics.set_total_duration(self.start.elapsed());
+    }
+}
+
+/// The failure a [`RetryPolicy`] is asked about.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum AttemptFailure<'a, E> {
+    /// The closure returned an error, the transaction was not committed.
+    Closure(&'a E),
+    /// The closure succeeded but the commit failed.
+    Commit(&'a TransactionCommitError),
+}
+
+/// Decides what the runner does with a failed attempt.
+///
+/// The runner classifies the failure on its own and passes its verdict as
+/// `proposed`; the policy returns the decision to apply, which is `proposed`
+/// itself unless it wants to override it:
+///
+/// * [`RetryDecision::Fatal`] ends the run and returns the original error, the
+///   one the closure produced or the commit error, never something the policy
+///   made up.
+/// * [`RetryDecision::Fdb`] hands that error to `fdb_transaction_on_error`,
+///   which judges retryability and applies the backoff.
+/// * [`RetryDecision::Retry`] does the same with code 1020 (`not_committed`),
+///   which is retryable by definition.
+///
+/// A policy cannot corrupt the
+/// [`MaybeCommitted`] flag handed to the closure: it is
+/// computed from the original error before the policy is consulted.
+///
+/// # Example: cap the number of attempts
+///
+/// ```
+/// use foundationdb::runner::{AttemptFailure, RetryPolicy};
+/// use foundationdb::{FdbBindingError, RetryDecision};
+///
+/// struct MaxAttempts(usize);
+///
+/// impl RetryPolicy<FdbBindingError> for MaxAttempts {
+///     fn decide(
+///         &self,
+///         _failure: AttemptFailure<'_, FdbBindingError>,
+///         proposed: RetryDecision,
+///         attempt: usize,
+///     ) -> RetryDecision {
+///         if attempt + 1 >= self.0 {
+///             RetryDecision::Fatal
+///         } else {
+///             proposed
+///         }
+///     }
+/// }
+/// ```
+pub trait RetryPolicy<E> {
+    /// Returns the decision to apply for `failure`, `proposed` being what the
+    /// runner would do on its own.
+    fn decide(
+        &self,
+        failure: AttemptFailure<'_, E>,
+        proposed: RetryDecision,
+        attempt: usize,
+    ) -> RetryDecision;
+}
+
+/// The default policy: it always applies what the runner proposes, leaving
+/// `fdb_transaction_on_error` the last word on retries.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NativeRetryPolicy;
+
+impl<E> RetryPolicy<E> for NativeRetryPolicy {
+    fn decide(
+        &self,
+        _failure: AttemptFailure<'_, E>,
+        proposed: RetryDecision,
+        _attempt: usize,
+    ) -> RetryDecision {
+        proposed
+    }
+}
+
+/// How a single attempt ended, carrying whatever still owns the transaction.
+enum Attempt<T, E> {
+    /// The closure succeeded and the transaction committed.
+    Committed {
+        committed: TransactionCommitted,
+        value: T,
+        commit_duration_ms: u64,
+    },
+    /// The closure failed, the transaction is untouched and can be retried.
+    ClosureFailed {
+        transaction: RetryableTransaction,
+        error: E,
+    },
+    /// The commit failed, the transaction is owned by the error.
+    CommitFailed(TransactionCommitError),
+    /// The runner could not get the transaction back from the closure.
+    BindingFailed(FdbBindingError),
+}
+
+/// Runs the closure once and commits, without any retry logic.
+///
+/// The closure future is built by the caller so that the runner keeps owning
+/// the closure itself: an attempt that borrowed it would make every `run`
+/// future require `F: Sync`.
+async fn run_attempt<Fut, T, E, H>(
+    transaction: RetryableTransaction,
+    hooks: &H,
+    closure_result: Fut,
+    attempt: usize,
+) -> Attempt<T, E>
+where
+    Fut: Future<Output = Result<T, E>>,
+    H: RunnerHooks,
+{
+    hooks.on_attempt_start(&transaction, attempt);
+
+    let value = match closure_result.await {
+        Ok(value) => value,
+        Err(error) => return Attempt::ClosureFailed { transaction, error },
+    };
+
+    // Observational: a failing hook is reported, the commit happens anyway.
+    if let Err(hook_error) = hooks.before_commit(&transaction, attempt).await {
+        hooks.on_hook_error(&hook_error, attempt);
+    }
+
+    let now_commit = Instant::now();
+    match transaction.commit().await {
+        Ok(Ok(committed)) => Attempt::Committed {
+            committed,
+            value,
+            commit_duration_ms: now_commit.elapsed().as_millis() as u64,
+        },
+        Ok(Err(commit_error)) => Attempt::CommitFailed(commit_error),
+        Err(binding_error) => Attempt::BindingFailed(binding_error),
+    }
+}
+
+/// The retry loop: classification, policy, `on_error` and backoff on top of
+/// [`run_attempt`].
+///
+/// Wrapped by [`run_with_hooks`], which owns firing
+/// [`RunnerHooks::on_complete`] on every exit path.
+async fn retry_loop<F, Fut, T, E, H, P>(
+    initial_transaction: RetryableTransaction,
+    hooks: &H,
+    policy: &P,
+    closure: F,
+) -> Result<T, E>
+where
+    F: Fn(RetryableTransaction, MaybeCommitted) -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: RetryableError,
+    H: RunnerHooks,
+    P: RetryPolicy<E>,
+{
+    let mut maybe_committed = false;
+    let mut transaction = initial_transaction;
+    let mut attempt: usize = 0;
+
+    loop {
+        let closure_result = closure(transaction.clone(), MaybeCommitted::new(maybe_committed));
+
+        let (retried_transaction, _fdb_err) =
+            match run_attempt(transaction, hooks, closure_result, attempt).await {
+                Attempt::Committed {
+                    committed,
+                    value,
+                    commit_duration_ms,
+                } => {
+                    hooks.on_commit_success(&committed, commit_duration_ms, attempt);
+
+                    #[cfg(feature = "trace")]
+                    tracing::info!(attempt, "success, returning result");
+
+                    return Ok(value);
+                }
+
+                Attempt::BindingFailed(binding_error) => {
+                    #[cfg(feature = "trace")]
+                    tracing::error!(attempt, "transaction reference kept, aborting transaction");
+
+                    return Err(E::from(binding_error));
+                }
+
+                Attempt::ClosureFailed { transaction, error } => {
+                    let proposed = error.retry_decision();
+                    // maybe_committed is computed from the original error only,
+                    // before the policy is consulted: a previous maybe-committed
+                    // attempt must stay visible to the closure whatever the
+                    // policy decides. The synthetic 1020 of `Retry` leaves it
+                    // untouched on purpose.
+                    if let RetryDecision::Fdb(fdb_err) = proposed {
+                        maybe_committed = fdb_err.is_maybe_committed();
+                    }
+
+                    let fdb_err =
+                        match policy.decide(AttemptFailure::Closure(&error), proposed, attempt) {
+                            RetryDecision::Fdb(fdb_err) => fdb_err,
+                            // Synthetic retryable code (1020, not_committed): backoff and
+                            // RetryLimit stay governed by fdb_transaction_on_error.
+                            RetryDecision::Retry => FdbError::from_code(NOT_COMMITTED),
+                            RetryDecision::Fatal => return Err(error),
+                        };
+                    hooks.on_closure_error(&fdb_err, attempt);
+
+                    let now_on_error = Instant::now();
+                    match transaction.on_error(fdb_err).await {
+                        Ok(Ok(transaction)) => {
+                            hooks.on_error_duration(
+                                now_on_error.elapsed().as_millis() as u64,
+                                attempt,
+                            );
+                            (transaction, fdb_err)
+                        }
+                        // Retries exhausted or non-retryable: return the original
+                        // closure error, which carries the caller's context.
+                        Ok(Err(_non_retryable)) => return Err(error),
+                        Err(binding_error) => return Err(E::from(binding_error)),
+                    }
+                }
+
+                Attempt::CommitFailed(commit_error) => {
+                    maybe_committed = commit_error.is_maybe_committed();
+                    let proposed = RetryDecision::Fdb(*commit_error);
+
+                    // Fires before the policy is consulted: a hook reading the
+                    // conflicting keys must see them even when the run is about
+                    // to end.
+                    if let Err(hook_error) = hooks.on_commit_error(&commit_error, attempt).await {
+                        hooks.on_hook_error(&hook_error, attempt);
+                    }
+
+                    let fdb_err = match policy.decide(
+                        AttemptFailure::Commit(&commit_error),
+                        proposed,
+                        attempt,
+                    ) {
+                        RetryDecision::Fdb(fdb_err) => fdb_err,
+                        RetryDecision::Retry => FdbError::from_code(NOT_COMMITTED),
+                        RetryDecision::Fatal => {
+                            return Err(E::from(FdbBindingError::from(*commit_error)));
+                        }
+                    };
+
+                    // The transaction is taken out of the error so that the
+                    // error handed to `on_error` is the one the policy chose.
+                    let (transaction, _commit_err) = commit_error.into_parts();
+                    let now_on_error = Instant::now();
+                    match transaction.on_error(fdb_err).await {
+                        Ok(transaction) => {
+                            hooks.on_error_duration(
+                                now_on_error.elapsed().as_millis() as u64,
+                                attempt,
+                            );
+                            (RetryableTransaction::new(transaction), fdb_err)
+                        }
+                        Err(non_retryable) => {
+                            #[cfg(feature = "trace")]
+                            tracing::error!(
+                                attempt,
+                                error_code = non_retryable.code(),
+                                "could not commit, non retryable error"
+                            );
+
+                            return Err(E::from(FdbBindingError::from(non_retryable)));
+                        }
+                    }
+                }
+            };
+
+        #[cfg(feature = "trace")]
+        tracing::warn!(
+            attempt,
+            error_code = _fdb_err.code(),
+            "restarting transaction"
+        );
+
+        hooks.on_retry(attempt);
+        transaction = retried_transaction;
+        attempt += 1;
+    }
+}
+
+/// The retry runner: [`retry_loop`] plus the guarantee that
+/// [`RunnerHooks::on_complete`] fires exactly once.
+#[cfg_attr(
+    feature = "trace",
+    tracing::instrument(level = "debug", skip(initial_transaction, hooks, policy, closure))
+)]
+pub(crate) async fn run_with_hooks<F, Fut, T, E, H, P>(
+    initial_transaction: RetryableTransaction,
+    hooks: &H,
+    policy: &P,
+    closure: F,
+) -> Result<T, E>
+where
+    F: Fn(RetryableTransaction, MaybeCommitted) -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: RetryableError,
+    H: RunnerHooks,
+    P: RetryPolicy<E>,
+{
+    let result = retry_loop(initial_transaction, hooks, policy, closure).await;
+    hooks.on_complete();
+    result
+}
+
+/// Builder for a transactional run, returned by
+/// [`Database::runner`](crate::Database::runner).
+///
+/// It assembles the [`RunnerHooks`] and the [`RetryPolicy`] of a single call to
+/// [`run`](Self::run): no hooks and [`NativeRetryPolicy`] by default. Both are
+/// borrowed, so the same hooks and policy can be reused across runs (mind
+/// [`MetricsHooks`], which times the run from its own construction).
+///
+/// ```no_run
+/// # use foundationdb::*;
+/// # async fn example(db: &Database) -> Result<(), FdbBindingError> {
+/// db.runner()
+///     .run(|trx, _| async move {
+///         trx.set(b"key", b"value");
+///         Ok::<_, FdbBindingError>(())
+///     })
+///     .await
+/// # }
+/// ```
+pub struct TransactionRunner<'a, H = (), P = NativeRetryPolicy> {
+    db: &'a Database,
+    hooks: &'a H,
+    policy: &'a P,
+}
+
+impl<'a> TransactionRunner<'a, (), NativeRetryPolicy> {
+    /// A runner on `db` with no hooks and the native retry policy.
+    pub(crate) fn new(db: &'a Database) -> Self {
+        Self {
+            db,
+            hooks: &(),
+            policy: &NativeRetryPolicy,
+        }
+    }
+}
+
+impl<'a, H, P> TransactionRunner<'a, H, P> {
+    /// Observes the run with `hooks`, replacing any hooks set before.
+    ///
+    /// Stack several of them with a tuple: `.hooks(&(first, second))`.
+    pub fn hooks<H2>(self, hooks: &'a H2) -> TransactionRunner<'a, H2, P> {
+        TransactionRunner {
+            db: self.db,
+            hooks,
+            policy: self.policy,
+        }
+    }
+
+    /// Decides the retries with `policy` instead of [`NativeRetryPolicy`].
+    pub fn retry_policy<P2>(self, policy: &'a P2) -> TransactionRunner<'a, H, P2> {
+        TransactionRunner {
+            db: self.db,
+            hooks: self.hooks,
+            policy,
+        }
+    }
+
+    /// Runs `closure` in a transaction, retrying it until it commits or the
+    /// error is fatal.
+    ///
+    /// See [`Database::run`](crate::Database::run) for the semantics of the
+    /// closure, its error type and the retries.
+    #[cfg_attr(
+        feature = "trace",
+        tracing::instrument(level = "debug", skip(self, closure))
+    )]
+    pub async fn run<F, Fut, T, E>(self, closure: F) -> Result<T, E>
+    where
+        F: Fn(RetryableTransaction, MaybeCommitted) -> Fut,
+        Fut: Future<Output = Result<T, E>>,
+        E: RetryableError,
+        H: RunnerHooks,
+        P: RetryPolicy<E>,
+    {
+        let transaction = match self.db.create_retryable_trx() {
+            Ok(transaction) => transaction,
+            // The run is over before it started, but it did start: hooks that
+            // report on completion must still be called exactly once.
+            Err(err) => {
+                self.hooks.on_complete();
+                return Err(E::from(err));
+            }
+        };
+
+        run_with_hooks(transaction, self.hooks, self.policy, closure).await
+    }
+}

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -15,17 +15,18 @@ use std::fmt;
 use std::ops::{Deref, Range, RangeInclusive};
 use std::ptr::NonNull;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use crate::budget::{AttemptUsage, BudgetExceeded, ClientBudget, UsageSlot, UsageSnapshot};
 use crate::future::*;
 use crate::keyselector::*;
-use crate::metrics::{FdbCommand, TransactionMetrics};
+use crate::metrics::{AttemptOutcome, MetricKey, TransactionMetrics};
 use crate::options;
 
 use crate::{FdbError, FdbResult, error};
 use foundationdb_macros::cfg_api_versions;
 
-use crate::error::{FdbBindingError, TransactionMetricsNotFound};
+use crate::error::FdbBindingError;
 
 use futures::{
     Future, FutureExt, Stream, TryFutureExt, TryStreamExt, future, future::Either, stream,
@@ -142,10 +143,14 @@ impl TransactionCommitError {
     /// [usage](Transaction::attempt_usage) restarts from zero, while its
     /// [client budget](Transaction::set_client_budget) is kept.
     pub fn on_error(self) -> impl Future<Output = FdbResult<Transaction>> {
+        self.tr.mark_attempt_end();
+        let cause = self.err;
+
         FdbFuture::<()>::new(unsafe {
             fdb_sys::fdb_transaction_on_error(self.tr.inner.as_ptr(), self.err.code())
         })
-        .map_ok(|()| {
+        .map_ok(move |()| {
+            self.tr.end_attempt(AttemptOutcome::Retried { cause });
             self.tr.begin_attempt_usage();
             self.tr
         })
@@ -455,11 +460,36 @@ impl Transaction {
         inner: NonNull<fdb_sys::FDBTransaction>,
         metrics: TransactionMetrics,
     ) -> Self {
-        Self {
+        let transaction = Self {
             inner,
             metrics: Some(metrics),
             usage: UsageSlot::default(),
             budget: Mutex::new(ClientBudget::default()),
+        };
+        transaction.open_metrics_attempt();
+        transaction
+    }
+
+    /// Points the metrics at the accounting generation of the current attempt,
+    /// so that whatever happens from now on is recorded there.
+    fn open_metrics_attempt(&self) {
+        if let Some(metrics) = &self.metrics {
+            metrics.begin_attempt(self.usage.current());
+        }
+    }
+
+    /// Freezes the duration of the current attempt: it is over, only the retry
+    /// machinery runs from here.
+    fn mark_attempt_end(&self) {
+        if let Some(metrics) = &self.metrics {
+            metrics.mark_attempt_end();
+        }
+    }
+
+    /// Pushes the current attempt to the metrics report.
+    fn end_attempt(&self, outcome: AttemptOutcome) {
+        if let Some(metrics) = &self.metrics {
+            metrics.finish_attempt(outcome);
         }
     }
 
@@ -476,8 +506,13 @@ impl Transaction {
     ///
     /// Usage counters restart from zero and the elapsed time is measured from
     /// here. The client budget, being configuration, is left untouched.
+    ///
+    /// An instrumented transaction also starts recording a new attempt: call
+    /// [`end_attempt`](Self::end_attempt) first when the attempt that is ending
+    /// must appear in the report.
     pub(crate) fn begin_attempt_usage(&self) {
         self.usage.begin();
+        self.open_metrics_attempt();
     }
 
     /// Returns the usage accounted for the current transaction attempt.
@@ -499,6 +534,10 @@ impl Transaction {
     /// Setting a budget starts a fresh accounting generation, so the limits
     /// apply to what happens from now on. They then survive `on_error` and
     /// `reset`, and apply to each subsequent attempt with usage back at zero.
+    ///
+    /// On an instrumented transaction, set the budget before doing anything
+    /// else: the new generation is also the one the metrics record into, so
+    /// operations performed before this call are not reported.
     #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
     pub fn set_client_budget(&self, budget: ClientBudget) {
         self.begin_attempt_usage();
@@ -625,10 +664,6 @@ impl Transaction {
         }
 
         self.usage().record_set((key.len() + value.len()) as u64);
-
-        if let Some(metrics) = &self.metrics {
-            metrics.report_metrics(FdbCommand::Set((key.len() + value.len()) as u64));
-        }
     }
 
     /// Modify the database snapshot represented by transaction to remove the given key from the
@@ -655,10 +690,6 @@ impl Transaction {
         }
 
         self.usage().record_clear(key.len() as u64);
-
-        if let Some(metrics) = &self.metrics {
-            metrics.report_metrics(FdbCommand::Clear);
-        }
     }
 
     /// Reads a value from the database snapshot represented by transaction.
@@ -683,7 +714,6 @@ impl Transaction {
         key: &[u8],
         snapshot: bool,
     ) -> impl Future<Output = FdbResult<Option<FdbSlice>>> + Send + Sync + Unpin + use<> {
-        let metrics = self.metrics.clone();
         let usage = self.usage();
         let lenght_key = key.len();
 
@@ -704,10 +734,6 @@ impl Transaction {
                 };
 
                 usage.record_get(bytes_count, kv_fetched);
-
-                if let Some(metrics) = metrics.as_ref() {
-                    metrics.report_metrics(FdbCommand::Get(bytes_count, kv_fetched));
-                }
             }
             result
         })
@@ -755,10 +781,6 @@ impl Transaction {
 
         self.usage()
             .record_atomic_op((key.len() + param.len()) as u64);
-
-        if let Some(metrics) = &self.metrics {
-            metrics.report_metrics(FdbCommand::Atomic);
-        }
     }
 
     /// Resolves a key selector against the keys in the database snapshot represented by
@@ -936,8 +958,6 @@ impl Transaction {
         let key_begin = begin.key();
         let key_end = end.key();
 
-        let metrics = self.metrics.clone();
-
         FdbFuture::<FdbValues>::new(unsafe {
             fdb_sys::fdb_transaction_get_range(
                 self.inner.as_ptr(),
@@ -971,10 +991,6 @@ impl Transaction {
 
                 if let Some(usage) = usage.as_ref() {
                     usage.record_get_range(bytes_count, kv_fetched as u64);
-                }
-
-                if let Some(metrics) = metrics.as_ref() {
-                    metrics.report_metrics(FdbCommand::GetRange(bytes_count, kv_fetched as u64));
                 }
             };
 
@@ -1146,10 +1162,6 @@ impl Transaction {
 
         self.usage()
             .record_clear_range((begin.len() + end.len()) as u64);
-
-        if let Some(metrics) = &self.metrics {
-            metrics.report_metrics(FdbCommand::ClearRange);
-        }
     }
 
     /// Get the estimated byte size of the key range based on the byte sample collected by FDB
@@ -1193,12 +1205,28 @@ impl Transaction {
     /// Normally, commit will wait for outstanding reads to return. However, if those reads were
     /// snapshot reads or the transaction option for disabling “read-your-writes” has been invoked,
     /// any outstanding reads will immediately return errors.
+    ///
+    /// On an instrumented transaction, the commit ends the current attempt: its
+    /// duration is recorded whatever the result, and a successful commit pushes
+    /// the attempt to the metrics report as
+    /// [`AttemptOutcome::Committed`](crate::metrics::AttemptOutcome::Committed).
     #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
     pub fn commit(self) -> impl Future<Output = TransactionResult> + Send + Sync + Unpin {
+        let metrics = self.metrics.clone();
+        let started_at = Instant::now();
+
         FdbFuture::<()>::new(unsafe { fdb_sys::fdb_transaction_commit(self.inner.as_ptr()) }).map(
-            move |r| match r {
-                Ok(()) => Ok(TransactionCommitted { tr: self }),
-                Err(err) => Err(TransactionCommitError { tr: self, err }),
+            move |r| {
+                if let Some(metrics) = &metrics {
+                    metrics.record_commit(started_at.elapsed());
+                }
+                match r {
+                    Ok(()) => {
+                        self.end_attempt(AttemptOutcome::Committed);
+                        Ok(TransactionCommitted { tr: self })
+                    }
+                    Err(err) => Err(TransactionCommitError { tr: self, err }),
+                }
             },
         )
     }
@@ -1223,10 +1251,13 @@ impl Transaction {
         self,
         err: FdbError,
     ) -> impl Future<Output = FdbResult<Transaction>> + Send + Sync + Unpin {
+        self.mark_attempt_end();
+
         FdbFuture::<()>::new(unsafe {
             fdb_sys::fdb_transaction_on_error(self.inner.as_ptr(), err.code())
         })
-        .map_ok(|()| {
+        .map_ok(move |()| {
+            self.end_attempt(AttemptOutcome::Retried { cause: err });
             self.begin_attempt_usage();
             self
         })
@@ -1241,59 +1272,49 @@ impl Transaction {
         TransactionCancelled { tr: self }
     }
 
-    /// Sets a custom metric for the transaction with the specified name, value, and labels.
+    /// Records an application metric for the current attempt, replacing any
+    /// value previously recorded under the same name and labels.
     ///
-    /// Custom metrics allow you to track application-specific metrics during transaction execution.
-    /// These metrics are collected alongside the standard FoundationDB metrics and can be used
-    /// for monitoring, debugging, and performance analysis.
+    /// Custom metrics are always on, like the [usage](Self::attempt_usage)
+    /// counters, and scoped to the current attempt: a retry starts from an
+    /// empty set, and the values of the attempt that ended stay attached to it
+    /// in the report. Recording one on a transaction nobody collects metrics
+    /// from is free of consequence: the values are dropped along with the
+    /// attempt.
     ///
     /// # Arguments
     /// * `name` - The name of the metric (e.g., "query_time", "cache_hits")
-    /// * `value` - The value to set for the metric
+    /// * `value` - The value to record
     /// * `labels` - Key-value pairs for labeling the metric, allowing for dimensional metrics
     ///   (e.g., `[("operation", "read"), ("region", "us-west")]`)
-    ///
-    /// # Returns
-    /// * `Ok(())` if the metric was set successfully
-    /// * `Err(TransactionMetricsNotFound)` if this transaction was not created with metrics instrumentation
     ///
     /// # Example
     /// ```
     /// # use foundationdb::*;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let db = Database::default()?;
-    /// let metrics = TransactionMetrics::new();
-    /// let txn = db.create_instrumented_trx(metrics)?;
+    /// let (_, metrics) = db
+    ///     .instrumented_run(|txn, _| async move {
+    ///         txn.set_custom_metric("documents_indexed", 42, &[("kind", "user")]);
+    ///         Ok::<_, FdbBindingError>(())
+    ///     })
+    ///     .await
+    ///     .map_err(|(err, _)| err)?;
     ///
-    /// // Set a custom metric with labels
-    /// txn.set_custom_metric("query_processing_time", 42, &[("query_type", "select"), ("table", "users")])?;
+    /// // The values are attached to the attempt that recorded them.
+    /// let attempt = metrics.attempts.last().expect("one attempt");
+    /// # let _ = attempt;
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// # Note
-    /// This method only works on transactions created with `create_instrumented_trx()` or within
-    /// `instrumented_run()`. For regular transactions created with `create_trx()`, this will
-    /// return `Err(TransactionMetricsNotFound)`.
-    pub fn set_custom_metric(
-        &self,
-        name: &str,
-        value: u64,
-        labels: &[(&str, &str)],
-    ) -> Result<(), TransactionMetricsNotFound> {
-        if let Some(metrics) = &self.metrics {
-            metrics.set_custom(name, value, labels);
-            Ok(())
-        } else {
-            Err(TransactionMetricsNotFound)
-        }
+    pub fn set_custom_metric(&self, name: &str, value: u64, labels: &[(&str, &str)]) {
+        self.usage().set_custom(MetricKey::new(name, labels), value);
     }
 
-    /// Increments a custom metric for the transaction by the specified amount.
+    /// Adds `amount` to an application metric of the current attempt, starting
+    /// from zero if it was not recorded yet.
     ///
-    /// This is useful for counting events or accumulating values during transaction execution.
-    /// If the metric doesn't exist yet, it will be created with the specified amount.
-    /// If it already exists with the same labels, its value will be incremented.
+    /// Same per-attempt semantics as [`set_custom_metric`](Self::set_custom_metric).
     ///
     /// # Arguments
     /// * `name` - The name of the metric to increment (e.g., "requests", "bytes_processed")
@@ -1301,45 +1322,22 @@ impl Transaction {
     /// * `labels` - Key-value pairs for labeling the metric, allowing for dimensional metrics
     ///   (e.g., `[("status", "success"), ("endpoint", "api/v1/users")]`)
     ///
-    /// # Returns
-    /// * `Ok(())` if the metric was incremented successfully
-    /// * `Err(TransactionMetricsNotFound)` if this transaction was not created with metrics instrumentation
-    ///
     /// # Example
     /// ```
     /// # use foundationdb::*;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let db = Database::default()?;
-    /// let metrics = TransactionMetrics::new();
-    /// let txn = db.create_instrumented_trx(metrics)?;
+    /// let txn = db.create_trx()?;
     ///
-    /// // Increment a counter each time a specific operation occurs
-    /// txn.increment_custom_metric("cache_misses", 1, &[("cache", "user_data")])?;
-    ///
-    /// // Later in the transaction, increment it again
-    /// txn.increment_custom_metric("cache_misses", 1, &[("cache", "user_data")])?;
-    ///
-    /// // The final value will be 2
+    /// txn.increment_custom_metric("cache_misses", 1, &[("cache", "user_data")]);
+    /// txn.increment_custom_metric("cache_misses", 1, &[("cache", "user_data")]);
+    /// // The metric of the current attempt is now 2.
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// # Note
-    /// This method only works on transactions created with `create_instrumented_trx()` or within
-    /// `instrumented_run()`. For regular transactions created with `create_trx()`, this will
-    /// return `Err(TransactionMetricsNotFound)`.
-    pub fn increment_custom_metric(
-        &self,
-        name: &str,
-        amount: u64,
-        labels: &[(&str, &str)],
-    ) -> Result<(), TransactionMetricsNotFound> {
-        if let Some(metrics) = &self.metrics {
-            metrics.increment_custom(name, amount, labels);
-            Ok(())
-        } else {
-            Err(TransactionMetricsNotFound)
-        }
+    pub fn increment_custom_metric(&self, name: &str, amount: u64, labels: &[(&str, &str)]) {
+        self.usage()
+            .increment_custom(MetricKey::new(name, labels), amount);
     }
 
     /// Returns a list of public network addresses as strings, one for each of the storage servers
@@ -1449,10 +1447,24 @@ impl Transaction {
     /// to `get_*()` (including this one) and (unless causal consistency has been deliberately
     /// compromised by transaction options) is guaranteed to represent all transactions which were
     /// reported committed before that call.
+    ///
+    /// On an instrumented transaction, the version is recorded in the metrics of
+    /// the current attempt. It is only ever recorded when this method is called:
+    /// the binding never fetches a read version on its own.
     pub fn get_read_version(
         &self,
     ) -> impl Future<Output = FdbResult<i64>> + Send + Sync + Unpin + use<> {
-        FdbFuture::new(unsafe { fdb_sys::fdb_transaction_get_read_version(self.inner.as_ptr()) })
+        let metrics = self.metrics.clone();
+
+        FdbFuture::<i64>::new(unsafe {
+            fdb_sys::fdb_transaction_get_read_version(self.inner.as_ptr())
+        })
+        .map_ok(move |version| {
+            if let Some(metrics) = &metrics {
+                metrics.set_read_version(version);
+            }
+            version
+        })
     }
 
     /// Sets the snapshot read version used by a transaction.
@@ -1523,7 +1535,9 @@ impl Transaction {
     /// transaction has already been reset.
     ///
     /// This starts a new attempt: the [usage](Self::attempt_usage) restarts from
-    /// zero, while the [client budget](Self::set_client_budget) is kept.
+    /// zero, while the [client budget](Self::set_client_budget) is kept. On an
+    /// instrumented transaction, the attempt being recorded is abandoned rather
+    /// than reported: it reached no conclusion.
     pub fn reset(&mut self) {
         unsafe { fdb_sys::fdb_transaction_reset(self.inner.as_ptr()) }
         self.begin_attempt_usage();

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -40,34 +40,47 @@ const CONFLICTING_KEYS_PREFIX: &[u8] = b"\xff\xff/transaction/conflicting_keys/"
 // Matches C++ SystemData.cpp conflictingKeysRange end key.
 const CONFLICTING_KEYS_END: &[u8] = b"\xff\xff/transaction/conflicting_keys/\xff\xff";
 
-/// A key range that conflicted during a transaction commit.
+/// Special keyspace prefix for the read conflict ranges of a transaction.
+#[cfg_api_versions(min = 630)]
+const READ_CONFLICT_RANGE_PREFIX: &[u8] = b"\xff\xff/transaction/read_conflict_range/";
+#[cfg_api_versions(min = 630)]
+const READ_CONFLICT_RANGE_END: &[u8] = b"\xff\xff/transaction/read_conflict_range/\xff\xff";
+
+/// Special keyspace prefix for the write conflict ranges of a transaction.
+#[cfg_api_versions(min = 630)]
+const WRITE_CONFLICT_RANGE_PREFIX: &[u8] = b"\xff\xff/transaction/write_conflict_range/";
+#[cfg_api_versions(min = 630)]
+const WRITE_CONFLICT_RANGE_END: &[u8] = b"\xff\xff/transaction/write_conflict_range/\xff\xff";
+
+/// A key range reported by one of the conflict-range special keyspaces.
 ///
-/// Returned by [`Transaction::conflicting_keys`] after a commit conflict
-/// when [`TransactionOption::ReportConflictingKeys`](crate::options::TransactionOption::ReportConflictingKeys)
-/// is enabled.
+/// Returned by [`Transaction::conflicting_keys`] (the ranges that made a commit
+/// fail), [`Transaction::read_conflict_ranges`] and
+/// [`Transaction::write_conflict_ranges`] (the ranges the transaction has
+/// accumulated so far).
 ///
-/// The special keyspace encodes conflicting ranges using boundary markers:
-/// - Value `b"1"` marks the inclusive start of a conflicting range
-/// - Value `b"0"` marks the exclusive end of a conflicting range
+/// Those keyspaces all encode ranges using boundary markers:
+/// - Value `b"1"` marks the inclusive start of a range
+/// - Value `b"0"` marks the exclusive end of a range
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ConflictingKeyRange {
+pub struct ConflictRange {
     begin: Vec<u8>,
     end: Vec<u8>,
 }
 
-impl ConflictingKeyRange {
-    /// The inclusive begin of the conflicting key range.
+impl ConflictRange {
+    /// The inclusive begin of the range.
     pub fn begin(&self) -> &[u8] {
         &self.begin
     }
 
-    /// The exclusive end of the conflicting key range.
+    /// The exclusive end of the range.
     pub fn end(&self) -> &[u8] {
         &self.end
     }
 }
 
-impl fmt::Display for ConflictingKeyRange {
+impl fmt::Display for ConflictRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -75,6 +88,70 @@ impl fmt::Display for ConflictingKeyRange {
             String::from_utf8_lossy(&self.begin),
             String::from_utf8_lossy(&self.end),
         )
+    }
+}
+
+/// The range type returned by [`Transaction::conflicting_keys`], an alias of
+/// [`ConflictRange`] which all three conflict-range readers share.
+pub type ConflictingKeyRange = ConflictRange;
+
+/// Incremental parser of the `b"1"` / `b"0"` boundary encoding used by the
+/// `\xff\xff/transaction/*` conflict-range special keyspaces.
+///
+/// A range is only emitted once its end marker arrives, and the open begin
+/// marker survives across [`feed`](Self::feed) calls: a `b"1"` and its matching
+/// `b"0"` can land in two different `get_range` batches, so the parser is fed
+/// batch after batch and the caller paginates until the keyspace is exhausted.
+///
+/// A begin marker whose end marker never arrives is dropped: only complete
+/// ranges are returned, in every build profile.
+struct ConflictRangeParser {
+    prefix_len: usize,
+    ranges: Vec<ConflictRange>,
+    open_begin: Option<Vec<u8>>,
+}
+
+impl ConflictRangeParser {
+    /// `prefix` is the special keyspace prefix to strip from the keys fed in.
+    fn new(prefix: &[u8]) -> Self {
+        Self {
+            prefix_len: prefix.len(),
+            ranges: Vec::new(),
+            open_begin: None,
+        }
+    }
+
+    /// Feeds one batch of `(key, value)` pairs, in keyspace order.
+    fn feed<'a, I>(&mut self, batch: I)
+    where
+        I: IntoIterator<Item = (&'a [u8], &'a [u8])>,
+    {
+        for (raw_key, value) in batch {
+            let key = raw_key.get(self.prefix_len..).unwrap_or_default().to_vec();
+
+            match value {
+                b"1" => self.open_begin = Some(key),
+                b"0" => {
+                    if let Some(begin) = self.open_begin.take() {
+                        self.ranges.push(ConflictRange { begin, end: key });
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Returns the complete ranges parsed so far, dropping a begin marker left
+    /// open by the end of the stream.
+    fn finish(self) -> Vec<ConflictRange> {
+        #[cfg(feature = "trace")]
+        if self.open_begin.is_some() {
+            tracing::warn!(
+                "unpaired '1' marker at the end of a conflict range keyspace, range dropped"
+            );
+        }
+
+        self.ranges
     }
 }
 
@@ -1581,50 +1658,105 @@ impl Transaction {
     /// [`TransactionOption::ReportConflictingKeys`](crate::options::TransactionOption::ReportConflictingKeys)
     /// was not set.
     ///
+    /// Requires API version 630 or later: the special keyspace does not exist on
+    /// older versions, where this read fails.
+    ///
+    /// Only complete ranges are returned. A begin marker whose end marker never
+    /// arrives is dropped, identically in debug and release builds.
+    ///
     /// # Errors
     ///
     /// Returns an `FdbError` if the special keyspace read fails.
     #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
     pub async fn conflicting_keys(&self) -> FdbResult<Vec<ConflictingKeyRange>> {
-        let opt = RangeOption::from((CONFLICTING_KEYS_PREFIX, CONFLICTING_KEYS_END));
-        // Client-side read of the special keyspace, performed by the binding
-        // itself: it is not part of the user's attempt usage.
-        let range_result = self.get_range_unmetered(&opt, 1, false).await?;
+        self.read_conflict_range_keyspace(CONFLICTING_KEYS_PREFIX, CONFLICTING_KEYS_END)
+            .await
+    }
 
-        let prefix_len = CONFLICTING_KEYS_PREFIX.len();
-        let mut ranges = Vec::new();
-        let mut current_begin: Option<Vec<u8>> = None;
+    /// Reads the read conflict ranges accumulated by this transaction so far.
+    ///
+    /// These are the ranges the resolver will check for conflicts at commit
+    /// time: every key read by the transaction, plus the ranges added with
+    /// [`add_conflict_range`](Self::add_conflict_range). A point read of `k`
+    /// shows up as `k..k\x00`.
+    ///
+    /// <div class="warning">
+    /// Reading this keyspace waits for every pending read of the transaction to
+    /// settle, since a read that has not returned yet has not registered its
+    /// conflict range. Called in the middle of a batch of concurrent reads, it
+    /// is therefore as slow as the slowest of them.
+    /// </div>
+    ///
+    /// The read itself is performed by the binding on your behalf: it is not
+    /// accounted in the [attempt usage](Self::attempt_usage) and does not
+    /// consume the [client budget](Self::set_client_budget).
+    ///
+    /// Only complete ranges are returned, see [`conflicting_keys`](Self::conflicting_keys).
+    ///
+    /// # Errors
+    ///
+    /// Returns an `FdbError` if the special keyspace read fails.
+    #[cfg_api_versions(min = 630)]
+    #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
+    pub async fn read_conflict_ranges(&self) -> FdbResult<Vec<ConflictRange>> {
+        self.read_conflict_range_keyspace(READ_CONFLICT_RANGE_PREFIX, READ_CONFLICT_RANGE_END)
+            .await
+    }
 
-        for kv in range_result.iter() {
-            let raw_key = kv.key();
-            let actual_key = if raw_key.len() > prefix_len {
-                raw_key[prefix_len..].to_vec()
-            } else {
-                Vec::new()
-            };
+    /// Reads the write conflict ranges accumulated by this transaction so far.
+    ///
+    /// These are the ranges the transaction will conflict *other* transactions
+    /// on: every key it wrote, plus the ranges added with
+    /// [`add_conflict_range`](Self::add_conflict_range). A single `set` of `k`
+    /// shows up as `k..k\x00`.
+    ///
+    /// <div class="warning">
+    /// Before the commit, this is an approximate <em>superset</em> of the final
+    /// write conflict ranges when the transaction uses versionstamped keys: the
+    /// versionstamp is only known at commit time, so the incomplete key is
+    /// reported with its placeholder bytes.
+    /// </div>
+    ///
+    /// The read itself is performed by the binding on your behalf: it is not
+    /// accounted in the [attempt usage](Self::attempt_usage) and does not
+    /// consume the [client budget](Self::set_client_budget).
+    ///
+    /// Only complete ranges are returned, see [`conflicting_keys`](Self::conflicting_keys).
+    ///
+    /// # Errors
+    ///
+    /// Returns an `FdbError` if the special keyspace read fails.
+    #[cfg_api_versions(min = 630)]
+    #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
+    pub async fn write_conflict_ranges(&self) -> FdbResult<Vec<ConflictRange>> {
+        self.read_conflict_range_keyspace(WRITE_CONFLICT_RANGE_PREFIX, WRITE_CONFLICT_RANGE_END)
+            .await
+    }
 
-            match kv.value() {
-                b"1" => {
-                    current_begin = Some(actual_key);
-                }
-                b"0" => {
-                    if let Some(begin) = current_begin.take() {
-                        ranges.push(ConflictingKeyRange {
-                            begin,
-                            end: actual_key,
-                        });
-                    }
-                }
-                _ => {}
-            }
+    /// Reads one conflict-range special keyspace to its end and parses it.
+    ///
+    /// The reads go through the unmetered path: they are performed by the
+    /// binding itself and must not show up in the user's usage or budget. The
+    /// keyspace is paginated because a marker pair can straddle two batches,
+    /// which [`ConflictRangeParser`] handles by carrying the open begin marker
+    /// from one batch to the next.
+    async fn read_conflict_range_keyspace(
+        &self,
+        prefix: &[u8],
+        end: &[u8],
+    ) -> FdbResult<Vec<ConflictRange>> {
+        let mut parser = ConflictRangeParser::new(prefix);
+        let mut next = Some(RangeOption::from((prefix, end)));
+        let mut iteration = 1;
+
+        while let Some(opt) = next {
+            let values = self.get_range_unmetered(&opt, iteration, false).await?;
+            parser.feed(values.iter().map(|kv| (kv.key(), kv.value())));
+            next = opt.next_range(&values);
+            iteration += 1;
         }
 
-        debug_assert!(
-            current_begin.is_none(),
-            "unpaired '1' marker in conflicting keys response"
-        );
-
-        Ok(ranges)
+        Ok(parser.finish())
     }
 
     /// Adds a conflict range to a transaction without performing the associated read or write.
@@ -1702,5 +1834,98 @@ impl RetryableTransaction {
         self,
     ) -> Result<Result<TransactionCommitted, TransactionCommitError>, FdbBindingError> {
         Ok(self.take()?.commit().await)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CONFLICTING_KEYS_PREFIX, ConflictRangeParser};
+
+    /// Builds a marker as the special keyspace returns it: the prefix, the key
+    /// it is a boundary of, and the `1`/`0` value.
+    fn marker(key: &str, value: &'static [u8]) -> (Vec<u8>, &'static [u8]) {
+        let mut full = CONFLICTING_KEYS_PREFIX.to_vec();
+        full.extend_from_slice(key.as_bytes());
+        (full, value)
+    }
+
+    fn feed(parser: &mut ConflictRangeParser, batch: &[(Vec<u8>, &'static [u8])]) {
+        parser.feed(batch.iter().map(|(k, v)| (k.as_slice(), *v)));
+    }
+
+    #[test]
+    fn parses_ranges_within_one_batch() {
+        let mut parser = ConflictRangeParser::new(CONFLICTING_KEYS_PREFIX);
+        feed(
+            &mut parser,
+            &[
+                marker("a", b"1"),
+                marker("b", b"0"),
+                marker("c", b"1"),
+                marker("d", b"0"),
+            ],
+        );
+
+        let ranges = parser.finish();
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0].begin(), b"a");
+        assert_eq!(ranges[0].end(), b"b");
+        assert_eq!(ranges[1].begin(), b"c");
+        assert_eq!(ranges[1].end(), b"d");
+    }
+
+    /// The whole point of the incremental parser: a begin marker in one batch
+    /// and its end marker in the next one still make a single range.
+    #[test]
+    fn open_range_survives_across_batches() {
+        let mut parser = ConflictRangeParser::new(CONFLICTING_KEYS_PREFIX);
+        feed(&mut parser, &[marker("a", b"1")]);
+        feed(&mut parser, &[marker("b", b"0"), marker("c", b"1")]);
+        feed(&mut parser, &[marker("d", b"0")]);
+
+        let ranges = parser.finish();
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0].begin(), b"a");
+        assert_eq!(ranges[0].end(), b"b");
+        assert_eq!(ranges[1].begin(), b"c");
+        assert_eq!(ranges[1].end(), b"d");
+    }
+
+    #[test]
+    fn empty_input_yields_no_range() {
+        let mut parser = ConflictRangeParser::new(CONFLICTING_KEYS_PREFIX);
+        feed(&mut parser, &[]);
+        assert!(parser.finish().is_empty());
+    }
+
+    /// A begin marker whose end marker never arrives is dropped, in every build
+    /// profile: the guarantee is that only complete ranges come out.
+    #[test]
+    fn unmatched_begin_at_end_of_stream_is_dropped() {
+        let mut parser = ConflictRangeParser::new(CONFLICTING_KEYS_PREFIX);
+        feed(
+            &mut parser,
+            &[marker("a", b"1"), marker("b", b"0"), marker("c", b"1")],
+        );
+
+        let ranges = parser.finish();
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].begin(), b"a");
+        assert_eq!(ranges[0].end(), b"b");
+    }
+
+    /// Values that are neither `1` nor `0` are not boundaries and are ignored.
+    #[test]
+    fn unknown_marker_values_are_ignored() {
+        let mut parser = ConflictRangeParser::new(CONFLICTING_KEYS_PREFIX);
+        feed(
+            &mut parser,
+            &[marker("a", b"1"), marker("x", b"?"), marker("b", b"0")],
+        );
+
+        let ranges = parser.finish();
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].begin(), b"a");
+        assert_eq!(ranges[0].end(), b"b");
     }
 }

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -130,7 +130,16 @@ impl ConflictRangeParser {
             let key = raw_key.get(self.prefix_len..).unwrap_or_default().to_vec();
 
             match value {
-                b"1" => self.open_begin = Some(key),
+                b"1" => {
+                    #[cfg(feature = "trace")]
+                    if self.open_begin.is_some() {
+                        tracing::warn!(
+                            "'1' marker following an unpaired one in a conflict range keyspace, range dropped"
+                        );
+                    }
+
+                    self.open_begin = Some(key);
+                }
                 b"0" => {
                     if let Some(begin) = self.open_begin.take() {
                         self.ranges.push(ConflictRange { begin, end: key });
@@ -623,6 +632,7 @@ impl Transaction {
     /// Accounting is always on, no instrumentation needed. The counters are
     /// client-side estimates and are reset on every new attempt, see
     /// [`crate::budget`].
+    #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
     pub fn attempt_usage(&self) -> UsageSnapshot {
         self.usage().snapshot()
     }
@@ -698,6 +708,7 @@ impl Transaction {
     ///
     /// Returns the first [`BudgetExceeded`] limit found, checked in order:
     /// time, bytes read, bytes written.
+    #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
     pub fn check_client_budget(&self) -> Result<(), BudgetExceeded> {
         let budget = self
             .budget
@@ -1410,6 +1421,10 @@ impl Transaction {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg_attr(
+        feature = "trace",
+        tracing::instrument(level = "debug", skip(self, labels))
+    )]
     pub fn set_custom_metric(&self, name: &str, value: u64, labels: &[(&str, &str)]) {
         self.usage().set_custom(MetricKey::new(name, labels), value);
     }
@@ -1438,6 +1453,10 @@ impl Transaction {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg_attr(
+        feature = "trace",
+        tracing::instrument(level = "debug", skip(self, labels))
+    )]
     pub fn increment_custom_metric(&self, name: &str, amount: u64, labels: &[(&str, &str)]) {
         self.usage()
             .increment_custom(MetricKey::new(name, labels), amount);
@@ -1912,6 +1931,22 @@ mod tests {
         assert_eq!(ranges.len(), 1);
         assert_eq!(ranges[0].begin(), b"a");
         assert_eq!(ranges[0].end(), b"b");
+    }
+
+    /// A begin marker arriving while one is still open replaces it: the range
+    /// the dropped marker opened is never emitted.
+    #[test]
+    fn a_second_begin_marker_replaces_the_open_one() {
+        let mut parser = ConflictRangeParser::new(CONFLICTING_KEYS_PREFIX);
+        feed(
+            &mut parser,
+            &[marker("a", b"1"), marker("b", b"1"), marker("c", b"0")],
+        );
+
+        let ranges = parser.finish();
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].begin(), b"b");
+        assert_eq!(ranges[0].end(), b"c");
     }
 
     /// Values that are neither `1` nor `0` are not boundaries and are ignored.

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -14,8 +14,9 @@ use foundationdb_sys as fdb_sys;
 use std::fmt;
 use std::ops::{Deref, Range, RangeInclusive};
 use std::ptr::NonNull;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
+use crate::budget::{AttemptUsage, BudgetExceeded, ClientBudget, UsageSlot, UsageSnapshot};
 use crate::future::*;
 use crate::keyselector::*;
 use crate::metrics::{FdbCommand, TransactionMetrics};
@@ -136,11 +137,18 @@ impl TransactionCommitError {
     ///
     /// You should not call this method most of the times and use `Database::transact` which
     /// implements a retry loop strategy for you.
+    ///
+    /// On success the transaction enters a new attempt: its
+    /// [usage](Transaction::attempt_usage) restarts from zero, while its
+    /// [client budget](Transaction::set_client_budget) is kept.
     pub fn on_error(self) -> impl Future<Output = FdbResult<Transaction>> {
         FdbFuture::<()>::new(unsafe {
             fdb_sys::fdb_transaction_on_error(self.tr.inner.as_ptr(), self.err.code())
         })
-        .map_ok(|()| self.tr)
+        .map_ok(|()| {
+            self.tr.begin_attempt_usage();
+            self.tr
+        })
     }
 
     /// Reads the conflicting key ranges that caused this commit failure.
@@ -234,6 +242,11 @@ pub struct Transaction {
     // transaction should be dropped before cluster.
     inner: NonNull<fdb_sys::FDBTransaction>,
     metrics: Option<TransactionMetrics>,
+    /// Always-on accounting of the current attempt, see [`crate::budget`].
+    usage: UsageSlot,
+    /// Client-side limits applied to the current attempt. Unlike `usage`, they
+    /// are configuration: they survive `on_error` and `reset`.
+    budget: Mutex<ClientBudget>,
 }
 unsafe impl Send for Transaction {}
 unsafe impl Sync for Transaction {}
@@ -433,6 +446,8 @@ impl Transaction {
         Self {
             inner,
             metrics: None,
+            usage: UsageSlot::default(),
+            budget: Mutex::new(ClientBudget::default()),
         }
     }
 
@@ -443,7 +458,111 @@ impl Transaction {
         Self {
             inner,
             metrics: Some(metrics),
+            usage: UsageSlot::default(),
+            budget: Mutex::new(ClientBudget::default()),
         }
+    }
+
+    /// The accounting generation an operation issued now must record into.
+    ///
+    /// Callers of asynchronous operations must capture it when the operation is
+    /// **issued** and record into that clone on completion, so that a future
+    /// outliving its attempt cannot pollute the next one.
+    fn usage(&self) -> Arc<AttemptUsage> {
+        self.usage.current()
+    }
+
+    /// Starts a fresh accounting generation for a new transaction attempt.
+    ///
+    /// Usage counters restart from zero and the elapsed time is measured from
+    /// here. The client budget, being configuration, is left untouched.
+    pub(crate) fn begin_attempt_usage(&self) {
+        self.usage.begin();
+    }
+
+    /// Returns the usage accounted for the current transaction attempt.
+    ///
+    /// Accounting is always on, no instrumentation needed. The counters are
+    /// client-side estimates and are reset on every new attempt, see
+    /// [`crate::budget`].
+    pub fn attempt_usage(&self) -> UsageSnapshot {
+        self.usage().snapshot()
+    }
+
+    /// Sets the client-side budget of this transaction.
+    ///
+    /// The limits are **not** enforced by FoundationDB and not enforced
+    /// automatically: they are checked when you call
+    /// [`check_client_budget`](Self::check_client_budget). See [`crate::budget`]
+    /// for what is counted and how precise it is.
+    ///
+    /// Setting a budget starts a fresh accounting generation, so the limits
+    /// apply to what happens from now on. They then survive `on_error` and
+    /// `reset`, and apply to each subsequent attempt with usage back at zero.
+    #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
+    pub fn set_client_budget(&self, budget: ClientBudget) {
+        self.begin_attempt_usage();
+        *self
+            .budget
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = budget;
+    }
+
+    /// Removes every client-side limit of this transaction.
+    ///
+    /// Accounting keeps running: only the limits are dropped.
+    #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
+    pub fn clear_client_budget(&self) {
+        *self
+            .budget
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = ClientBudget::default();
+    }
+
+    /// Checks the usage of the current attempt against the client-side budget.
+    ///
+    /// This is a synchronous, cheap check: a few atomic loads and an `Instant`
+    /// comparison, no call to the database. Nothing calls it for you, so call it
+    /// between the operations of your transaction, typically inside a
+    /// [`Database::run`](crate::Database::run) closure where
+    /// [`FdbBindingError`](crate::FdbBindingError) makes `?` work:
+    ///
+    /// ```
+    /// # use foundationdb::*;
+    /// # use std::time::Duration;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = Database::default()?;
+    /// # let keys: Vec<Vec<u8>> = vec![];
+    /// db.run(|trx, _| {
+    ///     let keys = keys.clone();
+    ///     async move {
+    ///         trx.set_client_budget(ClientBudget {
+    ///             max_bytes_read: Some(1024 * 1024),
+    ///             ..ClientBudget::default()
+    ///         });
+    ///         for key in keys {
+    ///             trx.get(&key, false).await?;
+    ///             trx.check_client_budget()?;
+    ///         }
+    ///         Ok::<_, FdbBindingError>(())
+    ///     }
+    /// })
+    /// .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`BudgetExceeded`] limit found, checked in order:
+    /// time, bytes read, bytes written.
+    pub fn check_client_budget(&self) -> Result<(), BudgetExceeded> {
+        let budget = self
+            .budget
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        budget.check(&self.usage())
     }
 
     /// Called to set an option on an FDBTransaction.
@@ -505,6 +624,8 @@ impl Transaction {
             )
         }
 
+        self.usage().record_set((key.len() + value.len()) as u64);
+
         if let Some(metrics) = &self.metrics {
             metrics.report_metrics(FdbCommand::Set((key.len() + value.len()) as u64));
         }
@@ -533,6 +654,8 @@ impl Transaction {
             )
         }
 
+        self.usage().record_clear(key.len() as u64);
+
         if let Some(metrics) = &self.metrics {
             metrics.report_metrics(FdbCommand::Clear);
         }
@@ -546,6 +669,11 @@ impl Transaction {
     ///
     /// * `key` - the name of the key to be looked up in the database
     /// * `snapshot` - `true` if this is a [snapshot read](https://apple.github.io/foundationdb/api-c.html#snapshots)
+    ///
+    /// The [attempt usage](Self::attempt_usage) is recorded when the future
+    /// resolves successfully, into the attempt that issued the read: a read
+    /// still in flight is not visible to
+    /// [`check_client_budget`](Self::check_client_budget) yet.
     #[cfg_attr(
         feature = "trace",
         tracing::instrument(level = "debug", skip(self, key))
@@ -556,6 +684,7 @@ impl Transaction {
         snapshot: bool,
     ) -> impl Future<Output = FdbResult<Option<FdbSlice>>> + Send + Sync + Unpin + use<> {
         let metrics = self.metrics.clone();
+        let usage = self.usage();
         let lenght_key = key.len();
 
         FdbFuture::<Option<FdbSlice>>::new(unsafe {
@@ -568,12 +697,15 @@ impl Transaction {
         })
         .map(move |result| {
             if let Ok(value) = &result {
+                let (bytes_count, kv_fetched) = if let Some(values) = value {
+                    ((lenght_key + values.len()) as u64, 1)
+                } else {
+                    (lenght_key as u64, 0)
+                };
+
+                usage.record_get(bytes_count, kv_fetched);
+
                 if let Some(metrics) = metrics.as_ref() {
-                    let (bytes_count, kv_fetched) = if let Some(values) = value {
-                        ((lenght_key + values.len()) as u64, 1)
-                    } else {
-                        (lenght_key as u64, 0)
-                    };
                     metrics.report_metrics(FdbCommand::Get(bytes_count, kv_fetched));
                 }
             }
@@ -621,6 +753,9 @@ impl Transaction {
             )
         }
 
+        self.usage()
+            .record_atomic_op((key.len() + param.len()) as u64);
+
         if let Some(metrics) = &self.metrics {
             metrics.report_metrics(FdbCommand::Atomic);
         }
@@ -636,6 +771,10 @@ impl Transaction {
     ///
     /// * `selector`: the key selector
     /// * `snapshot`: `true` if this is a [snapshot read](https://apple.github.io/foundationdb/api-c.html#snapshots)
+    ///
+    /// In the [attempt usage](Self::attempt_usage), this counts as a `get` of
+    /// the selector key plus the resolved key, recorded when the future
+    /// resolves successfully.
     #[cfg_attr(
         feature = "trace",
         tracing::instrument(level = "debug", skip(self, selector, snapshot))
@@ -646,7 +785,10 @@ impl Transaction {
         snapshot: bool,
     ) -> impl Future<Output = FdbResult<FdbSlice>> + Send + Sync + Unpin + use<> {
         let key = selector.key();
-        FdbFuture::new(unsafe {
+        let usage = self.usage();
+        let length_key = key.len();
+
+        FdbFuture::<FdbSlice>::new(unsafe {
             fdb_sys::fdb_transaction_get_key(
                 self.inner.as_ptr(),
                 key.as_ptr(),
@@ -655,6 +797,12 @@ impl Transaction {
                 selector.offset(),
                 fdb_bool(snapshot),
             )
+        })
+        .map(move |result| {
+            if let Ok(resolved_key) = &result {
+                usage.record_get((length_key + resolved_key.len()) as u64, 0);
+            }
+            result
         })
     }
 
@@ -742,6 +890,10 @@ impl Transaction {
     /// * `iteration`: If opt.mode is Iterator, this parameter should start at 1 and be incremented
     ///   by 1 for each successive call while reading this range. In all other cases it is ignored.
     /// * `snapshot`: `true` if this is a [snapshot read](https://apple.github.io/foundationdb/api-c.html#snapshots)
+    ///
+    /// In the [attempt usage](Self::attempt_usage), each resolved batch counts
+    /// as one `call_get_range`: a full range scan through
+    /// [`get_ranges`](Self::get_ranges) counts once per underlying batch.
     #[cfg_attr(
         feature = "trace",
         tracing::instrument(level = "debug", skip(self, opt, snapshot))
@@ -751,6 +903,33 @@ impl Transaction {
         opt: &RangeOption,
         iteration: usize,
         snapshot: bool,
+    ) -> impl Future<Output = FdbResult<FdbValues>> + Send + Sync + Unpin + use<> {
+        self.get_range_impl(opt, iteration, snapshot, Some(self.usage()))
+    }
+
+    /// Same as [`get_range`](Self::get_range), but not accounted in the
+    /// [attempt usage](Self::attempt_usage).
+    ///
+    /// For reads the binding performs on behalf of the user, on the special
+    /// keyspace, which should neither consume the client budget nor show up in
+    /// the usage of the user's own operations.
+    pub(crate) fn get_range_unmetered(
+        &self,
+        opt: &RangeOption,
+        iteration: usize,
+        snapshot: bool,
+    ) -> impl Future<Output = FdbResult<FdbValues>> + Send + Sync + Unpin + use<> {
+        self.get_range_impl(opt, iteration, snapshot, None)
+    }
+
+    /// `usage` is the accounting generation to record into, `None` to skip
+    /// accounting entirely.
+    fn get_range_impl(
+        &self,
+        opt: &RangeOption,
+        iteration: usize,
+        snapshot: bool,
+        usage: Option<Arc<AttemptUsage>>,
     ) -> impl Future<Output = FdbResult<FdbValues>> + Send + Sync + Unpin + use<> {
         let begin = &opt.begin;
         let end = &opt.end;
@@ -779,7 +958,7 @@ impl Transaction {
             )
         })
         .map(move |result| {
-            if let (Ok(values), Some(metrics)) = (&result, metrics) {
+            if let Ok(values) = &result {
                 let kv_fetched = values.len();
                 let mut bytes_count = 0;
 
@@ -790,7 +969,13 @@ impl Transaction {
                     bytes_count += (key_len + value_len) as u64
                 }
 
-                metrics.report_metrics(FdbCommand::GetRange(bytes_count, kv_fetched as u64));
+                if let Some(usage) = usage.as_ref() {
+                    usage.record_get_range(bytes_count, kv_fetched as u64);
+                }
+
+                if let Some(metrics) = metrics.as_ref() {
+                    metrics.report_metrics(FdbCommand::GetRange(bytes_count, kv_fetched as u64));
+                }
             };
 
             result
@@ -818,6 +1003,10 @@ impl Transaction {
     /// More info can be found in the relevant [documentation](https://github.com/apple/foundationdb/wiki/Everything-about-GetMappedRange#input).
     ///
     /// This is the "raw" version, users are expected to use [Transaction::get_mapped_ranges]
+    ///
+    /// In the [attempt usage](Self::attempt_usage), a resolved batch counts as
+    /// one `call_get_range` and as the bytes of the primary key-values plus the
+    /// nested key-values returned by the secondary queries.
     #[cfg_api_versions(min = 710)]
     #[cfg_attr(
         feature = "trace",
@@ -835,7 +1024,9 @@ impl Transaction {
         let key_begin = begin.key();
         let key_end = end.key();
 
-        FdbFuture::new(unsafe {
+        let usage = self.usage();
+
+        FdbFuture::<MappedKeyValues>::new(unsafe {
             fdb_sys::fdb_transaction_get_mapped_range(
                 self.inner.as_ptr(),
                 key_begin.as_ptr(),
@@ -855,6 +1046,28 @@ impl Transaction {
                 fdb_bool(snapshot),
                 fdb_bool(opt.reverse),
             )
+        })
+        .map(move |result| {
+            if let Ok(values) = &result {
+                let mut bytes_count = 0;
+                let mut kv_fetched = 0;
+
+                for mapped_key_value in values.as_ref() {
+                    bytes_count += (mapped_key_value.parent_key().len()
+                        + mapped_key_value.parent_value().len())
+                        as u64;
+                    kv_fetched += 1;
+
+                    for key_value in mapped_key_value.key_values() {
+                        bytes_count += (key_value.key().len() + key_value.value().len()) as u64;
+                        kv_fetched += 1;
+                    }
+                }
+
+                usage.record_get_range(bytes_count, kv_fetched);
+            }
+
+            result
         })
     }
 
@@ -912,6 +1125,10 @@ impl Transaction {
     ///
     /// The modification affects the actual database only if transaction is later committed with
     /// `Transaction::commit`.
+    ///
+    /// In the [attempt usage](Self::attempt_usage), this counts as the two
+    /// boundary keys only: the volume of data actually deleted is unknown to
+    /// the client.
     #[cfg_attr(
         feature = "trace",
         tracing::instrument(level = "debug", skip(self, begin, end))
@@ -926,6 +1143,9 @@ impl Transaction {
                 fdb_len(end.len(), "end"),
             )
         }
+
+        self.usage()
+            .record_clear_range((begin.len() + end.len()) as u64);
 
         if let Some(metrics) = &self.metrics {
             metrics.report_metrics(FdbCommand::ClearRange);
@@ -995,6 +1215,10 @@ impl Transaction {
     ///
     /// You should not call this method most of the times and use `Database::transact` which
     /// implements a retry loop strategy for you.
+    ///
+    /// On success the transaction enters a new attempt: its
+    /// [usage](Self::attempt_usage) restarts from zero, while its
+    /// [client budget](Self::set_client_budget) is kept.
     pub fn on_error(
         self,
         err: FdbError,
@@ -1002,7 +1226,10 @@ impl Transaction {
         FdbFuture::<()>::new(unsafe {
             fdb_sys::fdb_transaction_on_error(self.inner.as_ptr(), err.code())
         })
-        .map_ok(|()| self)
+        .map_ok(|()| {
+            self.begin_attempt_usage();
+            self
+        })
     }
 
     /// Cancels the transaction. All pending or future uses of the transaction will return a
@@ -1294,8 +1521,12 @@ impl Transaction {
     ///
     /// It is not necessary to call `reset()` when handling an error with `on_error()` since the
     /// transaction has already been reset.
+    ///
+    /// This starts a new attempt: the [usage](Self::attempt_usage) restarts from
+    /// zero, while the [client budget](Self::set_client_budget) is kept.
     pub fn reset(&mut self) {
         unsafe { fdb_sys::fdb_transaction_reset(self.inner.as_ptr()) }
+        self.begin_attempt_usage();
     }
 
     /// Reads the conflicting key ranges from the special keyspace after a commit conflict.
@@ -1316,7 +1547,9 @@ impl Transaction {
     #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
     pub async fn conflicting_keys(&self) -> FdbResult<Vec<ConflictingKeyRange>> {
         let opt = RangeOption::from((CONFLICTING_KEYS_PREFIX, CONFLICTING_KEYS_END));
-        let range_result = self.get_range(&opt, 1, false).await?;
+        // Client-side read of the special keyspace, performed by the binding
+        // itself: it is not part of the user's attempt usage.
+        let range_result = self.get_range_unmetered(&opt, 1, false).await?;
 
         let prefix_len = CONFLICTING_KEYS_PREFIX.len();
         let mut ranges = Vec::new();

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -14,7 +14,7 @@ use foundationdb_sys as fdb_sys;
 use std::fmt;
 use std::ops::{Deref, Range, RangeInclusive};
 use std::ptr::NonNull;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 
 use crate::budget::{AttemptUsage, BudgetExceeded, ClientBudget, UsageSlot, UsageSnapshot};
@@ -179,6 +179,16 @@ impl TransactionCommitError {
         self.tr.reset();
         self.tr
     }
+
+    /// Splits the error into the transaction it failed on and the error itself,
+    /// without resetting anything.
+    ///
+    /// Used by the retry runner to hand `on_error` an error chosen by a
+    /// [`RetryPolicy`](crate::runner::RetryPolicy) rather than the commit error
+    /// itself.
+    pub(crate) fn into_parts(self) -> (Transaction, FdbError) {
+        (self.tr, self.err)
+    }
 }
 
 impl Deref for TransactionCommitError {
@@ -246,7 +256,9 @@ pub struct Transaction {
     // Order of fields should not be changed, because Rust drops field top-to-bottom, and
     // transaction should be dropped before cluster.
     inner: NonNull<fdb_sys::FDBTransaction>,
-    metrics: Option<TransactionMetrics>,
+    /// Metrics collector of the transaction, attached at creation or by a
+    /// runner hook, see [`Transaction::attach_metrics`]. Set at most once.
+    metrics: OnceLock<TransactionMetrics>,
     /// Always-on accounting of the current attempt, see [`crate::budget`].
     usage: UsageSlot,
     /// Client-side limits applied to the current attempt. Unlike `usage`, they
@@ -450,7 +462,7 @@ impl Transaction {
     pub(crate) fn new(inner: NonNull<fdb_sys::FDBTransaction>) -> Self {
         Self {
             inner,
-            metrics: None,
+            metrics: OnceLock::new(),
             usage: UsageSlot::default(),
             budget: Mutex::new(ClientBudget::default()),
         }
@@ -460,20 +472,34 @@ impl Transaction {
         inner: NonNull<fdb_sys::FDBTransaction>,
         metrics: TransactionMetrics,
     ) -> Self {
-        let transaction = Self {
-            inner,
-            metrics: Some(metrics),
-            usage: UsageSlot::default(),
-            budget: Mutex::new(ClientBudget::default()),
-        };
-        transaction.open_metrics_attempt();
+        let transaction = Self::new(inner);
+        transaction.attach_metrics(&metrics);
         transaction
+    }
+
+    /// Attaches a metrics collector to this transaction and opens its first
+    /// attempt on the accounting generation currently in use.
+    ///
+    /// A transaction collects metrics for at most one
+    /// [`TransactionMetrics`]: attaching a second one does nothing, the first
+    /// collector keeps receiving everything. This is what
+    /// [`MetricsHooks`](crate::runner::MetricsHooks) uses to wire itself onto a
+    /// transaction created by the runner.
+    pub(crate) fn attach_metrics(&self, metrics: &TransactionMetrics) {
+        if self.metrics.set(metrics.clone()).is_ok() {
+            self.open_metrics_attempt();
+        }
+    }
+
+    /// The metrics collector of the transaction, if one is attached.
+    fn metrics(&self) -> Option<&TransactionMetrics> {
+        self.metrics.get()
     }
 
     /// Points the metrics at the accounting generation of the current attempt,
     /// so that whatever happens from now on is recorded there.
     fn open_metrics_attempt(&self) {
-        if let Some(metrics) = &self.metrics {
+        if let Some(metrics) = self.metrics() {
             metrics.begin_attempt(self.usage.current());
         }
     }
@@ -481,14 +507,14 @@ impl Transaction {
     /// Freezes the duration of the current attempt: it is over, only the retry
     /// machinery runs from here.
     fn mark_attempt_end(&self) {
-        if let Some(metrics) = &self.metrics {
+        if let Some(metrics) = self.metrics() {
             metrics.mark_attempt_end();
         }
     }
 
     /// Pushes the current attempt to the metrics report.
     fn end_attempt(&self, outcome: AttemptOutcome) {
-        if let Some(metrics) = &self.metrics {
+        if let Some(metrics) = self.metrics() {
             metrics.finish_attempt(outcome);
         }
     }
@@ -1212,7 +1238,7 @@ impl Transaction {
     /// [`AttemptOutcome::Committed`](crate::metrics::AttemptOutcome::Committed).
     #[cfg_attr(feature = "trace", tracing::instrument(level = "debug", skip(self)))]
     pub fn commit(self) -> impl Future<Output = TransactionResult> + Send + Sync + Unpin {
-        let metrics = self.metrics.clone();
+        let metrics = self.metrics().cloned();
         let started_at = Instant::now();
 
         FdbFuture::<()>::new(unsafe { fdb_sys::fdb_transaction_commit(self.inner.as_ptr()) }).map(
@@ -1454,7 +1480,7 @@ impl Transaction {
     pub fn get_read_version(
         &self,
     ) -> impl Future<Output = FdbResult<i64>> + Send + Sync + Unpin + use<> {
-        let metrics = self.metrics.clone();
+        let metrics = self.metrics().cloned();
 
         FdbFuture::<i64>::new(unsafe {
             fdb_sys::fdb_transaction_get_read_version(self.inner.as_ptr())

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -554,15 +554,6 @@ impl Transaction {
         }
     }
 
-    pub fn new_instrumented(
-        inner: NonNull<fdb_sys::FDBTransaction>,
-        metrics: TransactionMetrics,
-    ) -> Self {
-        let transaction = Self::new(inner);
-        transaction.attach_metrics(&metrics);
-        transaction
-    }
-
     /// Attaches a metrics collector to this transaction and opens its first
     /// attempt on the accounting generation currently in use.
     ///

--- a/foundationdb/tests/budget.rs
+++ b/foundationdb/tests/budget.rs
@@ -1,0 +1,289 @@
+// Copyright 2018 foundationdb-rs developers, https://github.com/Clikengo/foundationdb-rs/graphs/contributors
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Per-attempt usage accounting and client-side budget, against a live cluster.
+
+use foundationdb::options::StreamingMode;
+use foundationdb::*;
+use std::time::Duration;
+
+mod common;
+
+/// `transaction_too_old`, retryable, retried without any backoff.
+const TRANSACTION_TOO_OLD: i32 = 1007;
+
+/// Writes are accounted as soon as they are issued, no commit needed.
+#[tokio::test]
+async fn usage_counts_writes() -> FdbResult<()> {
+    const KEY: &[u8] = b"test-budget-writes-key";
+    const VALUE: &[u8] = b"value";
+    const PARAM: &[u8] = b"\x01\x00\x00\x00\x00\x00\x00\x00";
+    const BEGIN: &[u8] = b"test-budget-writes-";
+    const END: &[u8] = b"test-budget-writes.";
+
+    let db = common::database().await?;
+    let trx = db.create_trx()?;
+
+    trx.set(KEY, VALUE);
+    trx.clear(KEY);
+    trx.clear_range(BEGIN, END);
+    trx.atomic_op(KEY, PARAM, options::MutationType::Add);
+
+    let usage = trx.attempt_usage();
+    assert_eq!(usage.call_set, 1);
+    assert_eq!(usage.call_clear, 1);
+    assert_eq!(usage.call_clear_range, 1);
+    assert_eq!(usage.call_atomic_op, 1);
+    assert_eq!(
+        usage.bytes_written,
+        (KEY.len() + VALUE.len() + KEY.len() + BEGIN.len() + END.len() + KEY.len() + PARAM.len())
+            as u64
+    );
+    assert_eq!(usage.bytes_read, 0);
+
+    Ok(())
+}
+
+/// Reads are accounted when their future resolves.
+#[tokio::test]
+async fn usage_counts_reads() -> FdbResult<()> {
+    const PREFIX: &[u8] = b"test-budget-reads-";
+    const MISSING: &[u8] = b"test-budget-reads-missing-key";
+    const VALUE: &[u8] = b"value";
+
+    let keys: Vec<Vec<u8>> = (0..3)
+        .map(|i| [PREFIX, format!("{i}").as_bytes()].concat())
+        .collect();
+
+    let db = common::database().await?;
+
+    {
+        let trx = db.create_trx()?;
+        trx.clear_range(PREFIX, b"test-budget-reads.");
+        for key in &keys {
+            trx.set(key, VALUE);
+        }
+        trx.commit().await.expect("failed to commit");
+    }
+
+    // get, on an existing then on a missing key.
+    let trx = db.create_trx()?;
+    trx.get(&keys[0], false).await?;
+    trx.get(MISSING, false).await?;
+
+    let usage = trx.attempt_usage();
+    assert_eq!(usage.call_get, 2);
+    assert_eq!(usage.keys_values_fetched, 1);
+    assert_eq!(
+        usage.bytes_read,
+        (keys[0].len() + VALUE.len() + MISSING.len()) as u64
+    );
+
+    // get_key counts as a get of the selector key plus the resolved key.
+    let trx = db.create_trx()?;
+    let selector = KeySelector::first_greater_or_equal(keys[0].as_slice());
+    let resolved = trx.get_key(&selector, false).await?;
+
+    let usage = trx.attempt_usage();
+    assert_eq!(usage.call_get, 1);
+    assert_eq!(usage.keys_values_fetched, 0);
+    assert_eq!(usage.bytes_read, (keys[0].len() + resolved.len()) as u64);
+
+    // get_range counts one call per resolved batch.
+    let trx = db.create_trx()?;
+    let opt = RangeOption {
+        mode: StreamingMode::WantAll,
+        ..RangeOption::from((PREFIX, b"test-budget-reads.".as_ref()))
+    };
+    let values = trx.get_range(&opt, 1, false).await?;
+    assert_eq!(values.len(), keys.len());
+
+    let usage = trx.attempt_usage();
+    assert_eq!(usage.call_get_range, 1);
+    assert_eq!(usage.call_get, 0);
+    assert_eq!(usage.keys_values_fetched, keys.len() as u64);
+    assert_eq!(
+        usage.bytes_read,
+        keys.iter().map(|k| (k.len() + VALUE.len()) as u64).sum()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn budget_exceeded_on_bytes_written() -> FdbResult<()> {
+    const KEY: &[u8] = b"test-budget-bytes-written-key";
+    const VALUE: &[u8] = b"a-value-larger-than-the-limit";
+
+    let db = common::database().await?;
+    let trx = db.create_trx()?;
+
+    trx.set_client_budget(ClientBudget {
+        max_bytes_written: Some(8),
+        ..ClientBudget::default()
+    });
+    assert!(trx.check_client_budget().is_ok());
+
+    trx.set(KEY, VALUE);
+
+    let err = trx.check_client_budget().unwrap_err();
+    assert_eq!(err.kind, BudgetKind::BytesWritten);
+    assert_eq!(err.used, (KEY.len() + VALUE.len()) as u64);
+    assert_eq!(err.limit, 8);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn budget_exceeded_on_bytes_read() -> FdbResult<()> {
+    const KEY: &[u8] = b"test-budget-bytes-read-key";
+    const VALUE: &[u8] = b"a-value-larger-than-the-limit";
+
+    let db = common::database().await?;
+
+    {
+        let trx = db.create_trx()?;
+        trx.set(KEY, VALUE);
+        trx.commit().await.expect("failed to commit");
+    }
+
+    let trx = db.create_trx()?;
+    trx.set_client_budget(ClientBudget {
+        max_bytes_read: Some(8),
+        ..ClientBudget::default()
+    });
+    assert!(trx.check_client_budget().is_ok());
+
+    trx.get(KEY, false).await?;
+
+    let err = trx.check_client_budget().unwrap_err();
+    assert_eq!(err.kind, BudgetKind::BytesRead);
+    assert_eq!(err.used, (KEY.len() + VALUE.len()) as u64);
+    assert_eq!(err.limit, 8);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn budget_exceeded_on_time() -> FdbResult<()> {
+    let db = common::database().await?;
+    let trx = db.create_trx()?;
+
+    trx.set_client_budget(ClientBudget {
+        time_limit: Some(Duration::from_millis(20)),
+        ..ClientBudget::default()
+    });
+    assert!(trx.check_client_budget().is_ok());
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let err = trx.check_client_budget().unwrap_err();
+    assert_eq!(err.kind, BudgetKind::Time);
+    assert!(err.used >= 20, "used {} ms", err.used);
+    assert_eq!(err.limit, 20);
+
+    Ok(())
+}
+
+/// The budget is configuration, the usage is per-attempt: `on_error` keeps the
+/// former and resets the latter.
+#[tokio::test]
+async fn budget_survives_on_error_while_usage_resets() -> FdbResult<()> {
+    const KEY: &[u8] = b"test-budget-on-error-key";
+    const VALUE: &[u8] = b"a-value-larger-than-the-limit";
+
+    let db = common::database().await?;
+    let trx = db.create_trx()?;
+
+    trx.set_client_budget(ClientBudget {
+        max_bytes_written: Some(8),
+        ..ClientBudget::default()
+    });
+    trx.set(KEY, VALUE);
+    assert!(trx.check_client_budget().is_err());
+
+    let trx = trx
+        .on_error(FdbError::from_code(TRANSACTION_TOO_OLD))
+        .await?;
+
+    let usage = trx.attempt_usage();
+    assert_eq!(usage.bytes_written, 0);
+    assert_eq!(usage.call_set, 0);
+    assert!(
+        trx.check_client_budget().is_ok(),
+        "usage should have been reset by the new attempt"
+    );
+
+    // The limit is still armed for the new attempt.
+    trx.set(KEY, VALUE);
+    assert_eq!(
+        trx.check_client_budget().unwrap_err().kind,
+        BudgetKind::BytesWritten
+    );
+
+    Ok(())
+}
+
+/// Same contract for an explicit `reset`.
+#[tokio::test]
+async fn reset_starts_a_new_attempt() -> FdbResult<()> {
+    const KEY: &[u8] = b"test-budget-reset-key";
+    const VALUE: &[u8] = b"a-value-larger-than-the-limit";
+
+    let db = common::database().await?;
+    let mut trx = db.create_trx()?;
+
+    trx.set_client_budget(ClientBudget {
+        max_bytes_written: Some(8),
+        ..ClientBudget::default()
+    });
+    trx.set(KEY, VALUE);
+    assert!(trx.check_client_budget().is_err());
+
+    trx.reset();
+
+    assert_eq!(trx.attempt_usage().bytes_written, 0);
+    assert!(trx.check_client_budget().is_ok());
+
+    trx.clear_client_budget();
+    trx.set(KEY, VALUE);
+    assert!(trx.check_client_budget().is_ok());
+
+    Ok(())
+}
+
+/// An exceeded budget converts into an `FdbBindingError`, so `?` works inside a
+/// `run` closure, and it is not retried.
+#[tokio::test]
+async fn budget_exceeded_is_fatal_in_run() -> FdbResult<()> {
+    const KEY: &[u8] = b"test-budget-run-key";
+    const VALUE: &[u8] = b"a-value-larger-than-the-limit";
+
+    let db = common::database().await?;
+
+    let result: Result<(), FdbBindingError> = db
+        .run(|trx, _| async move {
+            trx.set_client_budget(ClientBudget {
+                max_bytes_written: Some(8),
+                ..ClientBudget::default()
+            });
+            trx.set(KEY, VALUE);
+            trx.check_client_budget()?;
+            Ok(())
+        })
+        .await;
+
+    match result {
+        Err(FdbBindingError::ClientBudgetExceeded(err)) => {
+            assert_eq!(err.kind, BudgetKind::BytesWritten);
+            assert!(err.to_string().contains("client-side estimate"));
+        }
+        other => panic!("expected a ClientBudgetExceeded error, got {other:?}"),
+    }
+
+    Ok(())
+}

--- a/foundationdb/tests/budget.rs
+++ b/foundationdb/tests/budget.rs
@@ -287,3 +287,114 @@ async fn budget_exceeded_is_fatal_in_run() -> FdbResult<()> {
 
     Ok(())
 }
+
+/// The pattern of `examples/budgeted_scan.rs`: a scan cut into pages by the
+/// budget, each page resuming exclusively after the last key of the previous
+/// one. Every row must be seen exactly once across the pages.
+#[tokio::test]
+async fn budgeted_scan_resumes_without_losing_or_repeating_rows() -> FdbResult<()> {
+    const PREFIX: &[u8] = b"test-budget-scan/";
+    const END: &[u8] = b"test-budget-scan0";
+    const ROWS: usize = 400;
+    const VALUE_SIZE: usize = 1024;
+
+    fn key_of(index: usize) -> Vec<u8> {
+        let mut key = PREFIX.to_vec();
+        key.extend_from_slice(format!("{index:05}").as_bytes());
+        key
+    }
+
+    let db = common::database().await?;
+
+    db.run(|trx, _| async move {
+        trx.clear_range(PREFIX, END);
+        for index in 0..ROWS {
+            trx.set(&key_of(index), &vec![b'x'; VALUE_SIZE]);
+        }
+        Ok::<_, FdbBindingError>(())
+    })
+    .await
+    .expect("setup");
+
+    let mut seen: Vec<Vec<u8>> = Vec::new();
+    let mut continuation: Option<Vec<u8>> = None;
+    let mut transactions = 0;
+
+    loop {
+        let after = continuation.clone();
+        // A budget smaller than one batch: each transaction reads a single
+        // batch, then stops on the check that follows it.
+        let (keys, complete) = db
+            .run(move |trx, _| {
+                let after = after.clone();
+                async move {
+                    trx.set_client_budget(ClientBudget {
+                        max_bytes_read: Some(1),
+                        ..ClientBudget::default()
+                    });
+
+                    let begin = match &after {
+                        Some(last) => KeySelector::first_greater_than(last.as_slice()),
+                        None => KeySelector::first_greater_or_equal(PREFIX),
+                    };
+                    let opt = RangeOption {
+                        begin,
+                        end: KeySelector::first_greater_or_equal(END),
+                        mode: StreamingMode::Serial,
+                        target_bytes: 1 << 20,
+                        ..RangeOption::default()
+                    };
+
+                    let mut keys: Vec<Vec<u8>> = Vec::new();
+                    let mut complete = true;
+                    let mut batches = trx.get_ranges(opt, false);
+                    while let Some(batch) =
+                        futures_util::TryStreamExt::try_next(&mut batches).await?
+                    {
+                        for kv in batch.iter() {
+                            keys.push(kv.key().to_vec());
+                        }
+                        // Matched, not propagated: the page is kept and the
+                        // caller resumes from its last key.
+                        if trx.check_client_budget().is_err() {
+                            complete = false;
+                            break;
+                        }
+                    }
+
+                    Ok::<_, FdbBindingError>((keys, complete))
+                }
+            })
+            .await
+            .expect("scan page");
+
+        transactions += 1;
+        let last = keys.last().cloned();
+        seen.extend(keys);
+
+        if complete {
+            break;
+        }
+        match last {
+            Some(last) => continuation = Some(last),
+            None => break,
+        }
+    }
+
+    assert!(
+        transactions > 1,
+        "the budget should have cut the scan into several transactions, got {transactions}"
+    );
+    assert_eq!(seen.len(), ROWS, "a row was lost or read twice");
+    let expected: Vec<Vec<u8>> = (0..ROWS).map(key_of).collect();
+    assert_eq!(seen, expected, "rows are not the expected ones, in order");
+
+    db.run(|trx, _| async move {
+        trx.clear_range(PREFIX, END);
+        Ok::<_, FdbBindingError>(())
+    })
+    .await
+    .expect("cleanup");
+
+    Ok(())
+}

--- a/foundationdb/tests/conflict_ranges.rs
+++ b/foundationdb/tests/conflict_ranges.rs
@@ -1,0 +1,218 @@
+// Copyright 2018 foundationdb-rs developers, https://github.com/Clikengo/foundationdb-rs/graphs/contributors
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! The read and write conflict range readers, against a live cluster.
+//!
+//! The `\xff\xff/transaction/{read,write}_conflict_range/` special keyspaces
+//! exist from API version 630.
+
+#[allow(unused_imports)]
+use foundationdb::*;
+#[allow(unused_imports)]
+use foundationdb_macros::cfg_api_versions;
+
+mod common;
+
+/// Whether `ranges` holds exactly `begin..end`.
+#[allow(dead_code)]
+fn contains(ranges: &[ConflictRange], begin: &[u8], end: &[u8]) -> bool {
+    ranges
+        .iter()
+        .any(|range| range.begin() == begin && range.end() == end)
+}
+
+/// A point read registers `key..key\x00`, a range read the range itself.
+#[cfg_api_versions(min = 630)]
+#[tokio::test]
+async fn read_conflict_ranges_report_reads() -> FdbResult<()> {
+    const POINT: &[u8] = b"test-rcr-point";
+    const RANGE_BEGIN: &[u8] = b"test-rcr-range-a";
+    const RANGE_END: &[u8] = b"test-rcr-range-z";
+
+    let db = common::database().await?;
+    let trx = db.create_trx()?;
+
+    trx.get(POINT, false).await?;
+    trx.get_range(
+        &RangeOption::from((RANGE_BEGIN, RANGE_END)),
+        1,
+        false, // not a snapshot read: it must register a conflict range
+    )
+    .await?;
+
+    let ranges = trx.read_conflict_ranges().await?;
+
+    let mut point_key = POINT.to_vec();
+    point_key.push(0);
+    assert!(
+        contains(&ranges, POINT, &point_key),
+        "point read missing from {ranges:?}"
+    );
+    assert!(
+        contains(&ranges, RANGE_BEGIN, RANGE_END),
+        "range read missing from {ranges:?}"
+    );
+
+    Ok(())
+}
+
+/// A snapshot read is not serializable and registers no read conflict range.
+#[cfg_api_versions(min = 630)]
+#[tokio::test]
+async fn snapshot_reads_register_no_read_conflict_range() -> FdbResult<()> {
+    const KEY: &[u8] = b"test-rcr-snapshot";
+
+    let db = common::database().await?;
+    let trx = db.create_trx()?;
+
+    trx.get(KEY, true).await?;
+
+    assert!(trx.read_conflict_ranges().await?.is_empty());
+
+    Ok(())
+}
+
+/// Writes register write conflict ranges, and only those.
+#[cfg_api_versions(min = 630)]
+#[tokio::test]
+async fn write_conflict_ranges_report_writes() -> FdbResult<()> {
+    const KEY: &[u8] = b"test-wcr-key";
+    const CLEAR_BEGIN: &[u8] = b"test-wcr-cleared-a";
+    const CLEAR_END: &[u8] = b"test-wcr-cleared-z";
+
+    let db = common::database().await?;
+    let trx = db.create_trx()?;
+
+    trx.set(KEY, b"value");
+    trx.clear_range(CLEAR_BEGIN, CLEAR_END);
+
+    let ranges = trx.write_conflict_ranges().await?;
+
+    let mut key_end = KEY.to_vec();
+    key_end.push(0);
+    assert!(
+        contains(&ranges, KEY, &key_end),
+        "set missing from {ranges:?}"
+    );
+    assert!(
+        contains(&ranges, CLEAR_BEGIN, CLEAR_END),
+        "cleared range missing from {ranges:?}"
+    );
+
+    // A write is not a read.
+    assert!(trx.read_conflict_ranges().await?.is_empty());
+
+    Ok(())
+}
+
+/// A range added without the associated read or write shows up in the keyspace
+/// matching its type.
+#[cfg_api_versions(min = 630)]
+#[tokio::test]
+async fn add_conflict_range_shows_up() -> FdbResult<()> {
+    const READ_BEGIN: &[u8] = b"test-acr-read-a";
+    const READ_END: &[u8] = b"test-acr-read-z";
+    const WRITE_BEGIN: &[u8] = b"test-acr-write-a";
+    const WRITE_END: &[u8] = b"test-acr-write-z";
+
+    let db = common::database().await?;
+    let trx = db.create_trx()?;
+
+    trx.add_conflict_range(READ_BEGIN, READ_END, options::ConflictRangeType::Read)?;
+    trx.add_conflict_range(WRITE_BEGIN, WRITE_END, options::ConflictRangeType::Write)?;
+
+    let read_ranges = trx.read_conflict_ranges().await?;
+    let write_ranges = trx.write_conflict_ranges().await?;
+
+    assert!(
+        contains(&read_ranges, READ_BEGIN, READ_END),
+        "added read range missing from {read_ranges:?}"
+    );
+    assert!(
+        contains(&write_ranges, WRITE_BEGIN, WRITE_END),
+        "added write range missing from {write_ranges:?}"
+    );
+    assert!(!contains(&read_ranges, WRITE_BEGIN, WRITE_END));
+    assert!(!contains(&write_ranges, READ_BEGIN, READ_END));
+
+    Ok(())
+}
+
+/// A fresh transaction has no conflict range at all.
+#[cfg_api_versions(min = 630)]
+#[tokio::test]
+async fn fresh_transaction_has_no_conflict_range() -> FdbResult<()> {
+    let db = common::database().await?;
+    let trx = db.create_trx()?;
+
+    assert!(trx.read_conflict_ranges().await?.is_empty());
+    assert!(trx.write_conflict_ranges().await?.is_empty());
+
+    Ok(())
+}
+
+/// Hundreds of disjoint ranges do not fit in one `get_range` batch, so the
+/// reader has to paginate and to carry a begin marker whose end marker lands in
+/// the next batch. A single-batch read truncates the result here.
+#[cfg_api_versions(min = 630)]
+#[tokio::test]
+async fn many_conflict_ranges_are_fully_paginated() -> FdbResult<()> {
+    const RANGES: usize = 500;
+
+    let db = common::database().await?;
+    let trx = db.create_trx()?;
+
+    for index in 0..RANGES {
+        let begin = format!("test-many-rcr/{index:05}/a");
+        let end = format!("test-many-rcr/{index:05}/b");
+        trx.add_conflict_range(
+            begin.as_bytes(),
+            end.as_bytes(),
+            options::ConflictRangeType::Read,
+        )?;
+    }
+
+    let ranges = trx.read_conflict_ranges().await?;
+
+    assert_eq!(ranges.len(), RANGES, "conflict ranges were truncated");
+    for (index, range) in ranges.iter().enumerate() {
+        assert_eq!(
+            range.begin(),
+            format!("test-many-rcr/{index:05}/a").as_bytes()
+        );
+        assert_eq!(
+            range.end(),
+            format!("test-many-rcr/{index:05}/b").as_bytes()
+        );
+    }
+
+    Ok(())
+}
+
+/// Reading the conflict ranges is a binding-internal read: it must not move the
+/// usage counters of the attempt, nor consume the client budget.
+#[cfg_api_versions(min = 630)]
+#[tokio::test]
+async fn reading_conflict_ranges_is_unmetered() -> FdbResult<()> {
+    const KEY: &[u8] = b"test-rcr-unmetered";
+
+    let db = common::database().await?;
+    let trx = db.create_trx()?;
+
+    trx.set(KEY, b"value");
+    let before = trx.attempt_usage();
+
+    trx.read_conflict_ranges().await?;
+    trx.write_conflict_ranges().await?;
+
+    let after = trx.attempt_usage();
+    assert_eq!(after.bytes_read, before.bytes_read);
+    assert_eq!(after.call_get_range, before.call_get_range);
+    assert_eq!(after.keys_values_fetched, before.keys_values_fetched);
+
+    Ok(())
+}

--- a/foundationdb/tests/metrics.rs
+++ b/foundationdb/tests/metrics.rs
@@ -1,4 +1,5 @@
 use foundationdb::metrics::{AttemptOutcome, MetricKey, TransactionMetrics};
+use foundationdb::runner::MetricsHooks;
 use foundationdb::*;
 mod common;
 use std::borrow::Cow;
@@ -314,17 +315,24 @@ async fn test_transaction_info() -> FdbResult<()> {
     // the transaction information.
     {
         let metrics = TransactionMetrics::new();
-        let txn = db
-            .create_instrumented_trx(metrics.clone())
-            .expect("Could not create transaction");
+        let hooks = MetricsHooks::new(&metrics);
 
-        let read_version = txn.get_read_version().await?;
-        assert_eq!(
-            metrics.get_transaction_info().read_version,
-            Some(read_version)
-        );
-
-        txn.commit().await?;
+        let read_version = db
+            .run_with_hooks(&hooks, |txn, _| {
+                let metrics = metrics.clone();
+                async move {
+                    let read_version = txn.get_read_version().await?;
+                    // Visible on the transaction information as soon as it is
+                    // read, without waiting for the run to end.
+                    assert_eq!(
+                        metrics.get_transaction_info().read_version,
+                        Some(read_version)
+                    );
+                    Ok::<_, FdbBindingError>(read_version)
+                }
+            })
+            .await
+            .expect("transaction should succeed");
 
         let report = metrics.get_metrics_data();
         assert_eq!(report.attempts.len(), 1);
@@ -372,6 +380,54 @@ async fn test_transaction_info() -> FdbResult<()> {
         assert_eq!(metrics.transaction.retries, EXPECTED_RETRIES);
         assert_eq!(metrics.attempts.len(), EXPECTED_RETRIES as usize + 1);
     }
+
+    Ok(())
+}
+
+/// Setting a client budget mid-attempt starts a fresh accounting generation,
+/// and the attempt being recorded goes with it: only what happens after the call
+/// is reported.
+#[tokio::test]
+async fn set_client_budget_mid_attempt_drops_what_was_recorded() -> FdbResult<()> {
+    const KEY: &[u8] = b"test_metrics_budget_mid_attempt";
+    const VALUE: &[u8] = b"value";
+
+    let db = common::database().await?;
+
+    let (_, metrics) = db
+        .instrumented_run(|txn, _| async move {
+            txn.set(b"test_metrics_budget_before", VALUE);
+            txn.set_custom_metric("before_budget", 1, &[]);
+
+            txn.set_client_budget(ClientBudget::default());
+
+            txn.set(KEY, VALUE);
+            txn.set_custom_metric("after_budget", 1, &[]);
+            Ok::<_, FdbBindingError>(())
+        })
+        .await
+        .expect("transaction should succeed");
+
+    assert_eq!(metrics.attempts.len(), 1);
+    let attempt = &metrics.attempts[0];
+
+    // The write itself did happen, only its accounting was dropped.
+    assert_eq!(attempt.usage.call_set, 1);
+    assert_eq!(
+        attempt.usage.bytes_written,
+        (KEY.len() + VALUE.len()) as u64
+    );
+
+    assert!(
+        attempt
+            .custom_metrics
+            .contains_key(&MetricKey::new("after_budget", &[]))
+    );
+    assert!(
+        !attempt
+            .custom_metrics
+            .contains_key(&MetricKey::new("before_budget", &[]))
+    );
 
     Ok(())
 }

--- a/foundationdb/tests/metrics.rs
+++ b/foundationdb/tests/metrics.rs
@@ -1,13 +1,13 @@
-use foundationdb::{metrics::TransactionMetrics, *};
+use foundationdb::metrics::{AttemptOutcome, MetricKey, TransactionMetrics};
+use foundationdb::*;
 mod common;
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
 /// Tests a successful transaction using `instrumented_run`.
 ///
-/// This test verifies that a simple transaction (one SET and one GET operation)
-/// completes successfully and that the returned metrics correctly report the number
-/// of operations performed.
+/// A run without retry reports exactly one attempt, holding the operations of
+/// the transaction and ending as committed.
 #[tokio::test]
 async fn instrumented_run_success() -> FdbResult<()> {
     const KEY: &[u8] = b"test_metrics_success";
@@ -16,36 +16,43 @@ async fn instrumented_run_success() -> FdbResult<()> {
 
     let db = common::database().await?;
 
-    let (result, metrics) = match db
+    let (result, metrics) = db
         .instrumented_run(|txn, _| async move {
             txn.set(KEY, VALUE);
             Ok::<_, FdbBindingError>(SUCCESS)
         })
         .await
-    {
-        Ok((result, metrics)) => (result, metrics),
-        Err(_err) => {
-            panic!()
-        }
-    };
+        .expect("transaction should succeed");
 
     assert_eq!(result, SUCCESS);
 
-    let total = metrics.total;
+    assert_eq!(metrics.attempts.len(), 1);
+    let attempt = &metrics.attempts[0];
+    assert_eq!(attempt.index, 0);
+    assert_eq!(attempt.usage.call_set, 1);
+    assert_eq!(
+        attempt.usage.bytes_written,
+        (KEY.len() + VALUE.len()) as u64
+    );
+    assert!(matches!(attempt.outcome, AttemptOutcome::Committed));
+    assert!(attempt.commit_duration.is_some());
+    assert!(attempt.on_error_duration.is_none());
+
+    let total = metrics.total_usage();
     assert_eq!(total.call_set, 1);
     assert_eq!(total.bytes_written, (KEY.len() + VALUE.len()) as u64);
 
-    let transaction_info = metrics.transaction;
-    assert_eq!(transaction_info.retries, 0);
+    assert_eq!(metrics.transaction.retries, 0);
+    assert!(metrics.total_duration.is_some());
 
     Ok(())
 }
 
 /// Tests the retry mechanism of `instrumented_run`.
 ///
-/// This test simulates a retryable error (`transaction_too_old`) to ensure that
-/// the `instrumented_run` method correctly retries the transaction. It then
-/// asserts that the `retries` count in the final metrics report is accurate.
+/// A forced retryable error gives one attempt per try: every attempt keeps its
+/// own counters and custom metrics instead of being wiped by the next one, and
+/// only the last one is committed.
 #[tokio::test]
 async fn instrumented_run_with_n_retries() -> FdbResult<()> {
     const KEY: &[u8] = b"test_metrics_retry";
@@ -58,9 +65,9 @@ async fn instrumented_run_with_n_retries() -> FdbResult<()> {
     let db = common::database().await?;
 
     // Use Arc<Mutex<>> to share and modify the counter across async calls
-    let attempt_counter = Arc::new(Mutex::new(0));
+    let attempt_counter = Arc::new(Mutex::new(0u64));
 
-    let (result, metrics) = match db
+    let (result, metrics) = db
         .instrumented_run(|txn, _| {
             let counter = attempt_counter.clone();
             async move {
@@ -71,11 +78,12 @@ async fn instrumented_run_with_n_retries() -> FdbResult<()> {
                 let mut attempts = counter.lock().unwrap();
                 *attempts += 1;
 
+                // Each attempt tags itself, so a wiped attempt would show up.
+                txn.set_custom_metric("attempt_number", *attempts, &[("kind", "forced")]);
+
                 if *attempts <= EXPECTED_RETRIES {
                     // Return a retryable error (not_committed) for the first N attempts
-                    let fdb_error = FdbError::from_code(1020);
-                    // Return FdbBindingError directly - instrumented_run will handle metrics
-                    Err(FdbBindingError::from(fdb_error))
+                    Err(FdbBindingError::from(FdbError::from_code(1020)))
                 } else {
                     // Succeed on attempt N+1
                     Ok(SUCCESS)
@@ -83,34 +91,56 @@ async fn instrumented_run_with_n_retries() -> FdbResult<()> {
             }
         })
         .await
-    {
-        Ok((result, metrics)) => (result, metrics),
-        Err(err) => {
-            panic!("Test failed: {:?}", err);
-        }
-    };
+        .expect("transaction should succeed after retries");
 
-    // Verify the result
     assert_eq!(result, SUCCESS);
 
-    // Verify the metrics
-    let total = metrics.total;
-    assert_eq!(total.call_set, EXPECTED_RETRIES + 1); // One set operation per attempt
+    // One attempt per try, nothing lost across the retries.
+    assert_eq!(metrics.attempts.len(), EXPECTED_RETRIES as usize + 1);
+    assert_eq!(metrics.transaction.retries, EXPECTED_RETRIES);
+
+    let custom_key = MetricKey::new("attempt_number", &[("kind", "forced")]);
+    for (index, attempt) in metrics.attempts.iter().enumerate() {
+        assert_eq!(attempt.index, index);
+
+        // The per-attempt usage is retained, not wiped by the following attempt.
+        assert_eq!(attempt.usage.call_set, 1, "attempt {index}");
+        assert_eq!(
+            attempt.usage.bytes_written,
+            (KEY.len() + VALUE.len()) as u64,
+            "attempt {index}"
+        );
+        assert_eq!(
+            attempt.custom_metrics.get(&custom_key).copied(),
+            Some(index as u64 + 1),
+            "attempt {index}"
+        );
+
+        let is_last = index == EXPECTED_RETRIES as usize;
+        match (&attempt.outcome, is_last) {
+            (AttemptOutcome::Committed, true) => {}
+            (AttemptOutcome::Retried { cause }, false) => {
+                assert_eq!(cause.code(), 1020, "attempt {index}");
+                assert!(
+                    attempt.on_error_duration.is_some(),
+                    "attempt {index} went through on_error"
+                );
+            }
+            (outcome, _) => panic!("unexpected outcome for attempt {index}: {outcome:?}"),
+        }
+    }
+
+    // Totals are the sum of the attempts.
+    let total = metrics.total_usage();
+    assert_eq!(total.call_set, EXPECTED_RETRIES + 1);
     assert_eq!(
         total.bytes_written,
         (EXPECTED_RETRIES + 1) * (KEY.len() + VALUE.len()) as u64
     );
 
-    let current = metrics.current;
-    assert_eq!(current.call_set, 1);
-    assert_eq!(current.bytes_written, (KEY.len() + VALUE.len()) as u64);
-
-    let transaction_info = metrics.transaction;
-    assert_eq!(transaction_info.retries, EXPECTED_RETRIES); // Should match our expected retry count
-
     // Verify the counter
     let final_attempts = *attempt_counter.lock().unwrap();
-    assert_eq!(final_attempts, EXPECTED_RETRIES + 1); // Total attempts should be retries + 1
+    assert_eq!(final_attempts, EXPECTED_RETRIES + 1);
 
     Ok(())
 }
@@ -126,7 +156,7 @@ async fn instrumented_run_with_n_retries() -> FdbResult<()> {
 ///
 /// It then performs precise assertions on all relevant counter metrics, including
 /// operation counts, exact bytes written, and exact bytes read, ensuring they are
-/// all tracked correctly within a single transaction.
+/// all tracked correctly within a single attempt.
 #[tokio::test]
 async fn test_counter_metrics() -> FdbResult<()> {
     let db = common::database().await?;
@@ -139,6 +169,14 @@ async fn test_counter_metrics() -> FdbResult<()> {
         let value = format!("value{}", i);
         bytes_written += (key.len() + value.len()) as u64;
     }
+    // clear, clear_range and atomic_op of the closure below.
+    let clear_key = format!("{}_key2", std::str::from_utf8(PREFIX).unwrap());
+    let clear_range_begin = format!("{}_key1", std::str::from_utf8(PREFIX).unwrap());
+    let clear_range_end = format!("{}_key3", std::str::from_utf8(PREFIX).unwrap());
+    let atomic_key = format!("{}_atomic", std::str::from_utf8(PREFIX).unwrap());
+    bytes_written +=
+        (clear_key.len() + clear_range_begin.len() + clear_range_end.len() + atomic_key.len() + 8)
+            as u64;
 
     let ((fetched_count, bytes_read), metrics) = match db
         .instrumented_run(|txn, _| {
@@ -209,68 +247,58 @@ async fn test_counter_metrics() -> FdbResult<()> {
         },
     };
 
-    // Verify the metrics
-    let report = metrics;
+    // A single attempt: its usage is the whole story.
+    assert_eq!(metrics.attempts.len(), 1);
+    let usage = metrics.attempts[0].usage;
 
-    // Check counter metrics for current attempt
     assert_eq!(
-        report.current.call_set, SET_OPS as u64,
+        usage.call_set, SET_OPS as u64,
         "Should have {} SET operations",
         SET_OPS
     );
-    assert_eq!(report.current.call_get, 1, "Should have 1 GET operation");
+    assert_eq!(usage.call_get, 1, "Should have 1 GET operation");
+    assert_eq!(usage.call_get_range, 1, "Should have 1 GET_RANGE operation");
 
     // Verify the number of key-values fetched matches our result count
     assert_eq!(
-        report.current.keys_values_fetched, fetched_count as u64,
+        usage.keys_values_fetched, fetched_count as u64,
         "Should have fetched {} key-values",
         fetched_count
     );
 
     assert_eq!(
-        report.current.bytes_written, bytes_written,
+        usage.bytes_written, bytes_written,
         "Should have written {} bytes",
         bytes_written
     );
     assert_eq!(
-        report.current.bytes_read, bytes_read,
+        usage.bytes_read, bytes_read,
         "Should have read {} bytes",
         bytes_read
     );
 
+    assert_eq!(usage.call_clear, 1, "Should have 1 CLEAR operation");
     assert_eq!(
-        report.current.call_clear, 1,
-        "Should have 1 CLEAR operation"
-    );
-    assert_eq!(
-        report.current.call_clear_range, 1,
+        usage.call_clear_range, 1,
         "Should have 1 CLEAR_RANGE operation"
     );
-    assert_eq!(
-        report.current.call_atomic_op, 1,
-        "Should have 1 ATOMIC operation"
-    );
+    assert_eq!(usage.call_atomic_op, 1, "Should have 1 ATOMIC operation");
 
-    // Total metrics should match current metrics (no retries)
-    assert_eq!(report.total.call_set, report.current.call_set);
-    assert_eq!(report.total.call_get, report.current.call_get);
-    assert_eq!(
-        report.total.keys_values_fetched,
-        report.current.keys_values_fetched
-    );
-    assert_eq!(report.total.bytes_read, report.current.bytes_read);
-    assert_eq!(report.total.call_clear, report.current.call_clear);
-    assert_eq!(
-        report.total.call_clear_range,
-        report.current.call_clear_range
-    );
-    assert_eq!(report.total.call_atomic_op, report.current.call_atomic_op);
-    assert_eq!(report.total.bytes_written, report.current.bytes_written);
+    // Without a retry, the totals are that single attempt.
+    let total = metrics.total_usage();
+    assert_eq!(total.call_set, usage.call_set);
+    assert_eq!(total.call_get, usage.call_get);
+    assert_eq!(total.keys_values_fetched, usage.keys_values_fetched);
+    assert_eq!(total.bytes_read, usage.bytes_read);
+    assert_eq!(total.bytes_written, usage.bytes_written);
+    assert_eq!(total.call_clear, usage.call_clear);
+    assert_eq!(total.call_clear_range, usage.call_clear_range);
+    assert_eq!(total.call_atomic_op, usage.call_atomic_op);
 
     // Verify transaction info
-    assert_eq!(report.transaction.retries, 0, "Should have no retries");
+    assert_eq!(metrics.transaction.retries, 0, "Should have no retries");
     assert!(
-        report.transaction.commit_version.is_some(),
+        metrics.transaction.commit_version.is_some(),
         "Should have a commit version"
     );
 
@@ -278,143 +306,166 @@ async fn test_counter_metrics() -> FdbResult<()> {
 }
 
 /// Tests the `TransactionInfo` fields within the metrics report.
-///
-/// This test runs two transactions:
-/// 1. A simple successful transaction to verify that `commit_version` is present
-///    and the `retries` count is zero.
-/// 2. A transaction that is forced to retry, to verify that the `retries` count
-///    is correctly reported.
 #[tokio::test]
 async fn test_transaction_info() -> FdbResult<()> {
     let db = common::database().await?;
 
-    // Test read_version field
+    // read_version: recorded when the user asks for it, on the attempt and on
+    // the transaction information.
     {
-        // Create a transaction with metrics
         let metrics = TransactionMetrics::new();
         let txn = db
             .create_instrumented_trx(metrics.clone())
             .expect("Could not create transaction");
 
-        // Get the read version from the transaction
         let read_version = txn.get_read_version().await?;
+        assert_eq!(
+            metrics.get_transaction_info().read_version,
+            Some(read_version)
+        );
 
-        // Set the read version in metrics
-        metrics.set_read_version(read_version);
-
-        // Verify the read version was set correctly
-        let transaction_info = metrics.get_transaction_info();
-        assert_eq!(transaction_info.read_version, Some(read_version));
-
-        // Commit the transaction
         txn.commit().await?;
+
+        let report = metrics.get_metrics_data();
+        assert_eq!(report.attempts.len(), 1);
+        assert_eq!(report.attempts[0].read_version, Some(read_version));
     }
 
-    // Test commit_version field
+    // commit_version
     {
-        // Test with a write transaction
-        let _metrics = TransactionMetrics::new();
-
-        let (_result, metrics_data) = db
+        let (_result, metrics) = db
             .instrumented_run(|txn, _| async move {
-                // Perform a write operation
                 txn.set(b"test_commit_version", b"value");
                 Ok::<_, FdbBindingError>(())
             })
             .await
             .expect("Transaction failed");
 
-        // Verify transaction info
-        let transaction_info = metrics_data.transaction;
-
-        // Commit version should be set (we don't know the exact value)
-        assert!(transaction_info.commit_version.is_some());
+        assert!(metrics.transaction.commit_version.is_some());
+        // Not asked for, not fetched.
+        assert!(metrics.transaction.read_version.is_none());
     }
 
-    // Test retries field
+    // retries
     {
-        // Number of retries we want to force
         const EXPECTED_RETRIES: u64 = 2;
 
-        // Use Arc<Mutex<>> to share and modify the counter across async calls
-        let attempt_counter = Arc::new(Mutex::new(0));
+        let attempt_counter = Arc::new(Mutex::new(0u64));
 
-        // Run a transaction that will be retried
-        let result = db
+        let (_, metrics) = db
             .instrumented_run(|_txn, _| {
                 let counter = attempt_counter.clone();
                 async move {
-                    // Increment the counter and check if we should still fail
                     let mut attempts = counter.lock().unwrap();
                     *attempts += 1;
 
                     if *attempts <= EXPECTED_RETRIES {
-                        // Return a retryable error for the first N attempts
-                        let fdb_error = FdbError::from_code(1020); // not_committed
-                        Err(FdbBindingError::from(fdb_error))
+                        Err(FdbBindingError::from(FdbError::from_code(1020)))
                     } else {
-                        // Succeed on attempt N+1
                         Ok(())
                     }
                 }
             })
-            .await;
+            .await
+            .expect("Transaction should have succeeded after retries");
 
-        match result {
-            Ok((_, metrics_data)) => {
-                // Verify retry count
-                let transaction_info = metrics_data.transaction;
-                assert_eq!(transaction_info.retries, EXPECTED_RETRIES);
-            }
-            Err(_) => panic!("Transaction should have succeeded after retries"),
-        }
+        assert_eq!(metrics.transaction.retries, EXPECTED_RETRIES);
+        assert_eq!(metrics.attempts.len(), EXPECTED_RETRIES as usize + 1);
     }
 
     Ok(())
 }
 
-/// Tests that timing metrics are recorded.
-///
-/// This test runs a transaction and verifies that the timing metrics
-/// (`commit_seconds`, `error_seconds`, `total_seconds`) are greater than zero,
-/// confirming that the time spent in different phases of the transaction is being measured.
+/// A run that never commits reports its last attempt as failed.
+#[tokio::test]
+async fn instrumented_run_failure_reports_the_last_attempt() -> FdbResult<()> {
+    let db = common::database().await?;
+
+    #[derive(Debug)]
+    struct Fatal;
+    impl std::fmt::Display for Fatal {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "fatal")
+        }
+    }
+    impl std::error::Error for Fatal {}
+
+    let (_err, metrics) = db
+        .instrumented_run(|txn, _| async move {
+            txn.set(b"test_metrics_failure", b"value");
+            // A custom error with no FdbError underneath is not retryable.
+            Err::<(), _>(FdbBindingError::new_custom_error(Box::new(Fatal)))
+        })
+        .await
+        .expect_err("transaction should fail");
+
+    assert_eq!(metrics.attempts.len(), 1);
+    let attempt = &metrics.attempts[0];
+    assert!(matches!(attempt.outcome, AttemptOutcome::Failed));
+    assert_eq!(attempt.usage.call_set, 1);
+    assert!(attempt.commit_duration.is_none(), "commit never ran");
+    assert_eq!(metrics.transaction.retries, 0);
+
+    Ok(())
+}
+
+/// Exhausting the retry limit consumes the transaction inside `on_error`: the
+/// attempt it was running must still be reported.
+#[tokio::test]
+async fn instrumented_run_reports_the_attempt_that_exhausted_the_retries() -> FdbResult<()> {
+    let db = common::database().await?;
+
+    let (_err, metrics) = db
+        .instrumented_run(|txn, _| async move {
+            txn.set_option(options::TransactionOption::RetryLimit(0))?;
+            txn.set(b"test_metrics_retry_limit", b"value");
+            Err::<(), _>(FdbBindingError::from(FdbError::from_code(1020)))
+        })
+        .await
+        .expect_err("the retry limit should be reached");
+
+    assert_eq!(metrics.attempts.len(), 1);
+    let attempt = &metrics.attempts[0];
+    assert!(matches!(attempt.outcome, AttemptOutcome::Failed));
+    assert_eq!(attempt.usage.call_set, 1);
+    assert_eq!(metrics.transaction.retries, 0);
+
+    Ok(())
+}
+
+/// Tests that the timings of the attempts are recorded.
 #[tokio::test]
 async fn test_time_metrics() -> FdbResult<()> {
     let db = common::database().await?;
 
-    // Test time metrics
+    // A committed attempt has a duration and a commit duration, and never went
+    // through on_error.
     {
-        // Run a transaction to generate time metrics
-        let (_result, metrics_data) = db
+        let (_result, metrics) = db
             .instrumented_run(|txn, _| async move {
-                // Perform multiple operations to ensure measurable time
                 for i in 0..10 {
                     let key = format!("test_time_metrics_{}", i).into_bytes();
                     txn.set(&key, b"value");
                 }
-                // Read some data to add more execution time
                 let _ = txn.get(b"test_time_metrics_0", false).await?;
                 Ok::<_, FdbBindingError>(())
             })
             .await
             .expect("Transaction failed");
 
-        // Get time metrics
-        let time_metrics = metrics_data.time;
+        assert_eq!(metrics.attempts.len(), 1);
+        let attempt = &metrics.attempts[0];
+        assert!(attempt.duration.is_some(), "attempt duration");
+        assert!(attempt.commit_duration.is_some(), "commit duration");
+        assert!(attempt.on_error_duration.is_none(), "on_error did not run");
+        assert!(metrics.total_duration >= attempt.duration);
+    }
 
-        // Verify time metrics
-        assert!(
-            time_metrics.get_total_error_time() == 0,
-            "Total execution time should not be recorded"
-        );
-        assert!(
-            time_metrics.commit_execution_ms > 0,
-            "Commit execution time should be recorded"
-        );
-
-        // Run a transaction that will generate error handling time
-        let attempt_counter = Arc::new(Mutex::new(0));
-        let result = db
+    // A retried attempt has its on_error duration recorded, and its own
+    // duration excludes the retry backoff.
+    {
+        let attempt_counter = Arc::new(Mutex::new(0u64));
+        let (_, metrics) = db
             .instrumented_run(|_txn, _| {
                 let counter = attempt_counter.clone();
                 async move {
@@ -422,141 +473,66 @@ async fn test_time_metrics() -> FdbResult<()> {
                     *attempts += 1;
 
                     if *attempts == 1 {
-                        // Return a retryable error on first attempt
-                        let fdb_error = FdbError::from_code(1020); // not_committed
-                        Err(FdbBindingError::from(fdb_error))
+                        Err(FdbBindingError::from(FdbError::from_code(1020)))
                     } else {
                         Ok(())
                     }
                 }
             })
-            .await;
+            .await
+            .expect("Transaction should have succeeded after retry");
 
-        if let Ok((_, metrics_data)) = result {
-            let time_metrics = metrics_data.time;
-
-            // Verify error handling time
-            assert!(
-                !time_metrics.on_error_execution_ms.is_empty(),
-                "Error handling time should be recorded"
-            );
-        } else {
-            panic!("Transaction should have succeeded after retry");
-        }
+        assert_eq!(metrics.attempts.len(), 2);
+        assert!(
+            metrics.attempts[0].on_error_duration.is_some(),
+            "Error handling time should be recorded"
+        );
+        assert!(metrics.attempts[1].on_error_duration.is_none());
     }
 
     Ok(())
 }
 
-/// Tests the functionality of custom metrics set on the `TransactionMetrics` object.
-///
-/// This test verifies that `set_custom_metric` and `increment_custom_metric` work
-/// correctly when called on the central `TransactionMetrics` object outside of any
-/// specific transaction. It ensures that custom metrics are properly registered and aggregated.
-#[tokio::test]
-async fn test_custom_metrics() -> FdbResult<()> {
-    let db = common::database().await?;
-
-    // Test custom metrics
-    {
-        // Create metrics and transaction
-        let metrics = TransactionMetrics::new();
-        let txn = db
-            .create_instrumented_trx(metrics.clone())
-            .expect("Could not create transaction");
-
-        // Test custom metrics with labels
-        metrics.set_custom(
-            "custom_counter",
-            123,
-            &[("tenant", "test"), ("region", "us-west")],
-        );
-        metrics.set_custom("custom_timer", 456, &[("operation", "write")]);
-
-        // Test incrementing custom metrics
-        metrics.increment_custom("incremented_counter", 5, &[("service", "api")]);
-        metrics.increment_custom("incremented_counter", 10, &[("service", "api")]);
-
-        // Get metrics data
-        let metrics_data = metrics.get_metrics_data();
-        let custom = metrics_data.custom_metrics;
-
-        // Verify custom counter with labels
-        let key = foundationdb::metrics::MetricKey::new(
-            "custom_counter",
-            &[("tenant", "test"), ("region", "us-west")],
-        );
-        let custom_counter = custom.get(&key).copied();
-        assert_eq!(custom_counter, Some(123));
-
-        // Verify custom timer with labels
-        let key = foundationdb::metrics::MetricKey::new("custom_timer", &[("operation", "write")]);
-        let custom_timer = custom.get(&key).copied();
-        assert_eq!(custom_timer, Some(456));
-
-        // Verify incremented counter
-        let key =
-            foundationdb::metrics::MetricKey::new("incremented_counter", &[("service", "api")]);
-        let incremented = custom.get(&key).copied();
-        assert_eq!(incremented, Some(15));
-
-        // Commit the transaction
-        txn.commit().await?;
-    }
-
-    Ok(())
-}
-
-/// Tests custom metrics that are set directly on a transaction.
-///
-/// This test uses `instrumented_run` to execute a transaction and calls
-/// `set_custom_metric` and `increment_custom_metric` on the `Transaction` object
-/// itself. It then verifies that these transaction-specific custom metrics are
-/// correctly recorded in the final metrics report.
+/// Custom metrics recorded on the transaction are reported per attempt, and are
+/// infallible: an uninstrumented transaction simply drops them.
 #[tokio::test]
 async fn test_transaction_custom_metrics() -> Result<(), FdbBindingError> {
     let db = common::database().await?;
 
-    // Test transaction custom metrics methods using instrumented_run
-    let result = db
-        .instrumented_run(|txn, _| async move {
-            // Set custom metrics directly on the transaction
-            txn.set_custom_metric("txn_counter", 100, &[("operation", "read")])?;
-            txn.set_custom_metric("txn_timer", 200, &[("component", "storage")])?;
+    // No metrics consumer: recording is a no-op, not an error.
+    let txn = db.create_trx()?;
+    txn.set_custom_metric("dropped", 1, &[]);
+    txn.increment_custom_metric("dropped", 1, &[]);
+    drop(txn);
 
-            // Increment a custom metric
-            txn.increment_custom_metric("txn_incremented", 10, &[("type", "query")])?;
-            txn.increment_custom_metric("txn_incremented", 15, &[("type", "query")])?;
+    let (_, metrics) = db
+        .instrumented_run(|txn, _| async move {
+            txn.set_custom_metric("txn_counter", 100, &[("operation", "read")]);
+            txn.set_custom_metric("txn_timer", 200, &[("component", "storage")]);
+
+            txn.increment_custom_metric("txn_incremented", 10, &[("type", "query")]);
+            txn.increment_custom_metric("txn_incremented", 15, &[("type", "query")]);
 
             // Read a value to make sure the transaction does something
             let _value = txn.get(b"test_key", false).await?;
 
-            Ok(())
+            Ok::<_, FdbBindingError>(())
         })
-        .await;
+        .await
+        .map_err(|(err, _)| err)?;
 
-    // Verify the result and check metrics in the returned metrics data
-    match result {
-        Ok((_, metrics_data)) => {
-            let custom = metrics_data.custom_metrics;
+    assert_eq!(metrics.attempts.len(), 1);
+    let custom = &metrics.attempts[0].custom_metrics;
 
-            // Verify metrics were properly recorded
-            let key =
-                foundationdb::metrics::MetricKey::new("txn_counter", &[("operation", "read")]);
-            assert_eq!(custom.get(&key).copied(), Some(100));
+    let key = MetricKey::new("txn_counter", &[("operation", "read")]);
+    assert_eq!(custom.get(&key).copied(), Some(100));
 
-            let key =
-                foundationdb::metrics::MetricKey::new("txn_timer", &[("component", "storage")]);
-            assert_eq!(custom.get(&key).copied(), Some(200));
+    let key = MetricKey::new("txn_timer", &[("component", "storage")]);
+    assert_eq!(custom.get(&key).copied(), Some(200));
 
-            let key =
-                foundationdb::metrics::MetricKey::new("txn_incremented", &[("type", "query")]);
-            assert_eq!(custom.get(&key).copied(), Some(25));
-        }
-        Err((err, _)) => {
-            return Err(err);
-        }
-    }
+    // Increments accumulate within the attempt.
+    let key = MetricKey::new("txn_incremented", &[("type", "query")]);
+    assert_eq!(custom.get(&key).copied(), Some(25));
 
     Ok(())
 }

--- a/foundationdb/tests/run_retry.rs
+++ b/foundationdb/tests/run_retry.rs
@@ -9,8 +9,9 @@
 //! FdbError, request an app-level retry, or are fatal (#479).
 
 use std::fmt;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
+use foundationdb::runner::{AttemptFailure, RetryPolicy};
 use foundationdb::{FdbBindingError, FdbError, RetryDecision, RetryableError, options};
 
 mod common;
@@ -199,4 +200,81 @@ async fn run_typed_error_fatal_returns_original() {
         "fatal error must be returned as-is, got {result:?}"
     );
     assert_eq!(attempt.load(Ordering::SeqCst), 1);
+}
+
+/// `MaybeCommitted` is computed from the closure error itself: an error
+/// wrapping `commit_unknown_result` (1021) tells the next attempt that the
+/// previous one may have committed.
+#[tokio::test]
+async fn run_reports_maybe_committed_from_the_closure_error() {
+    let db = common::database().await.expect("failed to open database");
+    let attempt = AtomicU8::new(0);
+    let attempt_ref = &attempt;
+    let seen = AtomicBool::new(false);
+    let seen_ref = &seen;
+
+    let result: Result<(), RetryTestError> = db
+        .run(|trx, maybe_committed| async move {
+            if attempt_ref.fetch_add(1, Ordering::SeqCst) == 0 {
+                // commit_unknown_result: retryable and maybe committed.
+                return Err(RetryTestError::from(FdbError::from_code(1021)));
+            }
+            seen_ref.store(maybe_committed.into(), Ordering::SeqCst);
+            trx.set(b"run_retry_maybe_committed", b"ok");
+            Ok(())
+        })
+        .await;
+
+    assert!(result.is_ok(), "1021 must be retried: {result:?}");
+    assert_eq!(attempt.load(Ordering::SeqCst), 2);
+    assert!(
+        seen.load(Ordering::SeqCst),
+        "the retried closure must see maybe_committed"
+    );
+}
+
+/// A [`RetryPolicy`] rewriting the decision cannot clear `MaybeCommitted`: the
+/// flag is computed from the original error, before the policy is consulted.
+#[tokio::test]
+async fn retry_policy_cannot_clear_maybe_committed() {
+    /// Turns every failure into a plain retry, which on its own would leave
+    /// `MaybeCommitted` untouched.
+    struct AlwaysRetry;
+
+    impl RetryPolicy<RetryTestError> for AlwaysRetry {
+        fn decide(
+            &self,
+            _failure: AttemptFailure<'_, RetryTestError>,
+            _proposed: RetryDecision,
+            _attempt: usize,
+        ) -> RetryDecision {
+            RetryDecision::Retry
+        }
+    }
+
+    let db = common::database().await.expect("failed to open database");
+    let attempt = AtomicU8::new(0);
+    let attempt_ref = &attempt;
+    let seen = AtomicBool::new(false);
+    let seen_ref = &seen;
+
+    let result: Result<(), RetryTestError> = db
+        .runner()
+        .retry_policy(&AlwaysRetry)
+        .run(|trx, maybe_committed| async move {
+            if attempt_ref.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(RetryTestError::from(FdbError::from_code(1021)));
+            }
+            seen_ref.store(maybe_committed.into(), Ordering::SeqCst);
+            trx.set(b"run_retry_policy_maybe_committed", b"ok");
+            Ok(())
+        })
+        .await;
+
+    assert!(result.is_ok(), "the policy must retry: {result:?}");
+    assert_eq!(attempt.load(Ordering::SeqCst), 2);
+    assert!(
+        seen.load(Ordering::SeqCst),
+        "the policy must not be able to clear maybe_committed"
+    );
 }

--- a/foundationdb/tests/runner_hooks.rs
+++ b/foundationdb/tests/runner_hooks.rs
@@ -23,13 +23,15 @@ async fn test_happy_path_instrumented() -> FdbResult<()> {
 
     assert_eq!(result, 42);
     assert_eq!(metrics.transaction.retries, 0);
-    assert!(metrics.conflicting_keys.is_empty());
+    assert_eq!(metrics.attempts.len(), 1);
+    assert!(metrics.attempts[0].conflicting_keys.ranges().is_empty());
 
     Ok(())
 }
 
-/// Conflict path via instrumented_run: force a conflict and verify
-/// MetricsReport.conflicting_keys is populated when ReportConflictingKeys is enabled.
+/// Conflict path via instrumented_run: force a conflict and verify the
+/// conflicting keys of the conflicted attempt are populated when
+/// ReportConflictingKeys is enabled.
 ///
 /// ReportConflictingKeys (option 712) was added in FDB 6.3.
 #[cfg_api_versions(min = 630)]
@@ -72,9 +74,12 @@ async fn test_conflict_reports_in_metrics() -> FdbResult<()> {
     assert!(metrics.transaction.retries >= 1);
     // Should have recorded at least one conflict
     assert!(metrics.transaction.conflict_count >= 1);
-    // Conflicting keys should be populated from the first (failed) attempt
+    // Conflicting keys should be populated on the attempt that conflicted
     assert!(
-        !metrics.conflicting_keys.is_empty(),
+        metrics
+            .attempts
+            .iter()
+            .any(|attempt| !attempt.conflicting_keys.ranges().is_empty()),
         "expected conflicting keys to be reported"
     );
 

--- a/foundationdb/tests/runner_hooks.rs
+++ b/foundationdb/tests/runner_hooks.rs
@@ -139,3 +139,502 @@ async fn test_conflict_keys_direct_api() -> FdbResult<()> {
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Hook composition, ordering and lifecycle
+// ---------------------------------------------------------------------------
+
+use foundationdb::runner::{AttemptFailure, MetricsHooks, RetryPolicy, RunnerHooks};
+use std::fmt;
+use std::sync::Mutex;
+
+/// A layer error with an app-level retry condition and a fatal domain error,
+/// the two cases a [`RetryPolicy`] is expected to arbitrate.
+#[derive(Debug)]
+enum HookTestError {
+    /// Carries a retryable FdbError, so the runner proposes `Fdb`.
+    Fdb(FdbError),
+    Binding(FdbBindingError),
+    /// No FdbError anywhere in the chain: the runner proposes `Fatal`.
+    Domain,
+}
+
+impl fmt::Display for HookTestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for HookTestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Fdb(e) => Some(e),
+            Self::Binding(e) => Some(e),
+            Self::Domain => None,
+        }
+    }
+}
+
+impl From<FdbError> for HookTestError {
+    fn from(e: FdbError) -> Self {
+        Self::Fdb(e)
+    }
+}
+
+impl From<FdbBindingError> for HookTestError {
+    fn from(e: FdbBindingError) -> Self {
+        Self::Binding(e)
+    }
+}
+
+impl RetryableError for HookTestError {}
+
+/// Records every callback it receives, tagged with the name of the hook, so a
+/// tuple of them shows both the lifecycle order and the order inside the tuple.
+struct RecordingHooks {
+    name: &'static str,
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+impl RecordingHooks {
+    fn new(name: &'static str, events: &Arc<Mutex<Vec<String>>>) -> Self {
+        Self {
+            name,
+            events: events.clone(),
+        }
+    }
+
+    fn record(&self, event: &str) {
+        self.events
+            .lock()
+            .expect("events mutex")
+            .push(format!("{}:{event}", self.name));
+    }
+}
+
+impl RunnerHooks for RecordingHooks {
+    fn on_attempt_start(&self, _trx: &Transaction, attempt: usize) {
+        self.record(&format!("attempt_start:{attempt}"));
+    }
+
+    async fn before_commit(&self, _trx: &Transaction, attempt: usize) -> FdbResult<()> {
+        self.record(&format!("before_commit:{attempt}"));
+        Ok(())
+    }
+
+    fn on_hook_error(&self, err: &FdbError, attempt: usize) {
+        self.record(&format!("hook_error:{}:{attempt}", err.code()));
+    }
+
+    fn on_commit_success(&self, _committed: &TransactionCommitted, _ms: u64, attempt: usize) {
+        self.record(&format!("commit_success:{attempt}"));
+    }
+
+    async fn on_commit_error(&self, err: &TransactionCommitError, attempt: usize) -> FdbResult<()> {
+        self.record(&format!("commit_error:{}:{attempt}", err.code()));
+        Ok(())
+    }
+
+    fn on_closure_error(&self, err: &FdbError, attempt: usize) {
+        self.record(&format!("closure_error:{}:{attempt}", err.code()));
+    }
+
+    fn on_error_duration(&self, _ms: u64, attempt: usize) {
+        self.record(&format!("error_duration:{attempt}"));
+    }
+
+    fn on_retry(&self, attempt: usize) {
+        self.record(&format!("retry:{attempt}"));
+    }
+
+    fn on_complete(&self) {
+        self.record("complete");
+    }
+}
+
+/// Hooks whose `before_commit` always fails, to check that the runner reports
+/// it and commits anyway.
+struct FailingBeforeCommit {
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+impl RunnerHooks for FailingBeforeCommit {
+    async fn before_commit(&self, _trx: &Transaction, _attempt: usize) -> FdbResult<()> {
+        self.events
+            .lock()
+            .expect("events mutex")
+            .push("before_commit".to_string());
+        // transaction_timed_out, an error the transaction itself never hit.
+        Err(FdbError::from_code(1031))
+    }
+
+    fn on_hook_error(&self, err: &FdbError, attempt: usize) {
+        self.events
+            .lock()
+            .expect("events mutex")
+            .push(format!("hook_error:{}:{attempt}", err.code()));
+    }
+}
+
+/// Both hooks of a tuple fire, left to right, and the lifecycle order of a run
+/// that retries once is stable.
+#[tokio::test]
+async fn tuple_hooks_fire_left_to_right_in_lifecycle_order() {
+    let db = common::database().await.expect("failed to open database");
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let hooks = (
+        RecordingHooks::new("a", &events),
+        RecordingHooks::new("b", &events),
+    );
+    let attempts = AtomicU64::new(0);
+    let attempts_ref = &attempts;
+
+    let result: Result<(), HookTestError> = db
+        .run_with_hooks(&hooks, |trx, _| async move {
+            if attempts_ref.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(HookTestError::Fdb(FdbError::from_code(1020)));
+            }
+            trx.set(b"runner_hooks_tuple", b"ok");
+            Ok(())
+        })
+        .await;
+
+    assert!(result.is_ok(), "run should succeed on the second attempt");
+    let events = events.lock().expect("events mutex").clone();
+    assert_eq!(
+        events,
+        vec![
+            "a:attempt_start:0",
+            "b:attempt_start:0",
+            "a:closure_error:1020:0",
+            "b:closure_error:1020:0",
+            "a:error_duration:0",
+            "b:error_duration:0",
+            "a:retry:0",
+            "b:retry:0",
+            "a:attempt_start:1",
+            "b:attempt_start:1",
+            "a:before_commit:1",
+            "b:before_commit:1",
+            "a:commit_success:1",
+            "b:commit_success:1",
+            "a:complete",
+            "b:complete",
+        ],
+    );
+}
+
+/// `Option<H>`: `Some` behaves like the hooks themselves, `None` is a no-op.
+#[tokio::test]
+async fn option_hooks_are_a_noop_when_none() {
+    let db = common::database().await.expect("failed to open database");
+
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let some = Some(RecordingHooks::new("some", &events));
+    db.run_with_hooks(&some, |trx, _| async move {
+        trx.set(b"runner_hooks_option_some", b"ok");
+        Ok::<_, FdbBindingError>(())
+    })
+    .await
+    .expect("run should succeed");
+
+    assert_eq!(
+        events.lock().expect("events mutex").clone(),
+        vec![
+            "some:attempt_start:0",
+            "some:before_commit:0",
+            "some:commit_success:0",
+            "some:complete",
+        ],
+    );
+
+    let none: Option<RecordingHooks> = None;
+    db.run_with_hooks(&none, |trx, _| async move {
+        trx.set(b"runner_hooks_option_none", b"ok");
+        Ok::<_, FdbBindingError>(())
+    })
+    .await
+    .expect("run should succeed without hooks");
+}
+
+/// A `before_commit` that fails is reported through `on_hook_error`, and the
+/// transaction is committed all the same.
+#[tokio::test]
+async fn before_commit_error_is_reported_but_does_not_abort_the_commit() {
+    let db = common::database().await.expect("failed to open database");
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let hooks = FailingBeforeCommit {
+        events: events.clone(),
+    };
+
+    db.run_with_hooks(&hooks, |trx, _| async move {
+        trx.set(b"runner_hooks_before_commit", b"committed");
+        Ok::<_, FdbBindingError>(())
+    })
+    .await
+    .expect("the failing hook must not abort the run");
+
+    assert_eq!(
+        events.lock().expect("events mutex").clone(),
+        vec!["before_commit", "hook_error:1031:0"],
+    );
+
+    let value = db
+        .run(|trx, _| async move {
+            Ok::<_, FdbBindingError>(
+                trx.get(b"runner_hooks_before_commit", false)
+                    .await?
+                    .map(|slice| slice.to_vec()),
+            )
+        })
+        .await
+        .expect("read back");
+    assert_eq!(value.as_deref(), Some(b"committed".as_ref()));
+}
+
+/// `on_complete` fires exactly once on the fatal path, and the original error
+/// is returned.
+#[tokio::test]
+async fn on_complete_fires_once_on_the_fatal_path() {
+    let db = common::database().await.expect("failed to open database");
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let hooks = RecordingHooks::new("h", &events);
+
+    let result: Result<(), HookTestError> = db
+        .run_with_hooks(&hooks, |_trx, _| async move { Err(HookTestError::Domain) })
+        .await;
+
+    assert!(matches!(result, Err(HookTestError::Domain)));
+    assert_eq!(
+        events.lock().expect("events mutex").clone(),
+        vec!["h:attempt_start:0", "h:complete"],
+    );
+}
+
+/// `on_complete` fires exactly once when the C API retry budget is exhausted.
+#[tokio::test]
+async fn on_complete_fires_once_when_retries_are_exhausted() {
+    let db = common::database().await.expect("failed to open database");
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let hooks = RecordingHooks::new("h", &events);
+
+    let result: Result<(), HookTestError> = db
+        .run_with_hooks(&hooks, |trx, _| async move {
+            trx.set_option(options::TransactionOption::RetryLimit(1))?;
+            Err(HookTestError::Fdb(FdbError::from_code(1020)))
+        })
+        .await;
+
+    assert!(matches!(result, Err(HookTestError::Fdb(_))));
+    let events = events.lock().expect("events mutex").clone();
+    assert_eq!(
+        events.iter().filter(|event| *event == "h:complete").count(),
+        1,
+        "on_complete must fire exactly once, got {events:?}"
+    );
+    assert_eq!(
+        events.last().map(String::as_str),
+        Some("h:complete"),
+        "on_complete must be the last event, got {events:?}"
+    );
+    // RetryLimit(1): one retry, so two attempts.
+    assert!(events.contains(&"h:attempt_start:1".to_string()));
+    assert!(!events.contains(&"h:attempt_start:2".to_string()));
+}
+
+// ---------------------------------------------------------------------------
+// Retry policies
+// ---------------------------------------------------------------------------
+
+/// Stops the run once `max` attempts have been made, whatever the error.
+struct MaxAttempts {
+    max: usize,
+}
+
+impl RetryPolicy<HookTestError> for MaxAttempts {
+    fn decide(
+        &self,
+        _failure: AttemptFailure<'_, HookTestError>,
+        proposed: RetryDecision,
+        attempt: usize,
+    ) -> RetryDecision {
+        if attempt + 1 >= self.max {
+            RetryDecision::Fatal
+        } else {
+            proposed
+        }
+    }
+}
+
+/// Retries an app-level error the runner would consider fatal.
+struct RetryDomainErrors;
+
+impl RetryPolicy<HookTestError> for RetryDomainErrors {
+    fn decide(
+        &self,
+        failure: AttemptFailure<'_, HookTestError>,
+        proposed: RetryDecision,
+        _attempt: usize,
+    ) -> RetryDecision {
+        match failure {
+            AttemptFailure::Closure(HookTestError::Domain) => RetryDecision::Retry,
+            _ => proposed,
+        }
+    }
+}
+
+/// A policy capping the attempts ends the run with the original closure error,
+/// before the C API retry budget has anything to say.
+#[tokio::test]
+async fn retry_policy_can_cap_the_number_of_attempts() {
+    let db = common::database().await.expect("failed to open database");
+    let attempts = AtomicU64::new(0);
+    let attempts_ref = &attempts;
+    let policy = MaxAttempts { max: 3 };
+
+    let result: Result<(), HookTestError> = db
+        .runner()
+        .retry_policy(&policy)
+        .run(|_trx, _| async move {
+            attempts_ref.fetch_add(1, Ordering::SeqCst);
+            // Retryable on its own: only the policy can stop this run.
+            Err(HookTestError::Fdb(FdbError::from_code(1020)))
+        })
+        .await;
+
+    assert!(
+        matches!(result, Err(HookTestError::Fdb(e)) if e.code() == 1020),
+        "the original closure error must be returned, got {result:?}"
+    );
+    assert_eq!(attempts.load(Ordering::SeqCst), 3);
+}
+
+/// A policy can retry an error the runner classifies as fatal: it goes through
+/// `on_error` with code 1020, like a `RetryDecision::Retry` from the error
+/// itself would.
+#[tokio::test]
+async fn retry_policy_can_retry_an_otherwise_fatal_error() {
+    let db = common::database().await.expect("failed to open database");
+    let attempts = AtomicU64::new(0);
+    let attempts_ref = &attempts;
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let hooks = RecordingHooks::new("h", &events);
+
+    let result: Result<(), HookTestError> = db
+        .runner()
+        .hooks(&hooks)
+        .retry_policy(&RetryDomainErrors)
+        .run(|trx, _| async move {
+            if attempts_ref.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(HookTestError::Domain);
+            }
+            trx.set(b"runner_hooks_policy_retry", b"ok");
+            Ok(())
+        })
+        .await;
+
+    assert!(result.is_ok(), "the policy must force a retry: {result:?}");
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    let events = events.lock().expect("events mutex").clone();
+    assert!(
+        events.contains(&"h:closure_error:1020:0".to_string()),
+        "the fatal error must be routed through on_error(1020), got {events:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// MetricsHooks stacked on user hooks
+// ---------------------------------------------------------------------------
+
+/// The wiring case: metrics hooks stacked on a user hook through the plain
+/// `run_with_hooks` produce the same complete report as `instrumented_run`.
+#[tokio::test]
+async fn metrics_hooks_stacked_on_user_hooks_produce_a_full_report() {
+    let db = common::database().await.expect("failed to open database");
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let metrics = TransactionMetrics::new();
+    let hooks = (
+        MetricsHooks::new(&metrics),
+        RecordingHooks::new("user", &events),
+    );
+    let attempts = AtomicU64::new(0);
+    let attempts_ref = &attempts;
+
+    let result: Result<(), HookTestError> = db
+        .run_with_hooks(&hooks, |trx, _| async move {
+            let first = attempts_ref.fetch_add(1, Ordering::SeqCst) == 0;
+            trx.set(b"runner_hooks_metrics_stacked", b"value");
+            trx.set_custom_metric("stacked", 1, &[]);
+            let _ = trx.get(b"runner_hooks_metrics_stacked", false).await?;
+            if first {
+                return Err(HookTestError::Fdb(FdbError::from_code(1020)));
+            }
+            Ok(())
+        })
+        .await;
+
+    assert!(result.is_ok(), "run should succeed: {result:?}");
+
+    let report = metrics.get_metrics_data();
+    assert_eq!(report.transaction.retries, 1);
+    assert_eq!(
+        report.attempts.len(),
+        report.transaction.retries as usize + 1,
+        "attempts are pushed exactly once per attempt: {report:#?}"
+    );
+    assert!(report.total_duration.is_some());
+    assert!(report.transaction.commit_version.is_some());
+
+    let first = &report.attempts[0];
+    assert_eq!(first.index, 0);
+    assert!(matches!(first.outcome, AttemptOutcome::Retried { .. }));
+    assert!(first.on_error_duration.is_some());
+    assert_eq!(first.usage.call_set, 1);
+    assert_eq!(first.usage.call_get, 1);
+    assert!(first.usage.bytes_written > 0);
+    assert_eq!(
+        first
+            .custom_metrics
+            .get(&metrics::MetricKey::new("stacked", &[])),
+        Some(&1),
+    );
+
+    let last = report.attempts.last().expect("a last attempt");
+    assert!(matches!(last.outcome, AttemptOutcome::Committed));
+    assert!(last.commit_duration.is_some());
+    assert_eq!(last.usage.call_set, 1);
+
+    // The user hook saw the same run.
+    let events = events.lock().expect("events mutex").clone();
+    assert_eq!(
+        events.first().map(String::as_str),
+        Some("user:attempt_start:0")
+    );
+    assert_eq!(events.last().map(String::as_str), Some("user:complete"));
+}
+
+/// A reference to hooks is itself hooks, and delegates to what it points at.
+#[tokio::test]
+async fn reference_hooks_delegate_to_the_hooks_they_point_at() {
+    let db = common::database().await.expect("failed to open database");
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let hooks = RecordingHooks::new("ref", &events);
+    let by_reference = &hooks;
+
+    db.run_with_hooks(&by_reference, |trx, _| async move {
+        trx.set(b"runner_hooks_reference", b"ok");
+        Ok::<_, FdbBindingError>(())
+    })
+    .await
+    .expect("run should succeed");
+
+    assert_eq!(
+        events.lock().expect("events mutex").clone(),
+        vec![
+            "ref:attempt_start:0",
+            "ref:before_commit:0",
+            "ref:commit_success:0",
+            "ref:complete",
+        ],
+    );
+}


### PR DESCRIPTION
## What

Four commits reworking the transaction runner, metrics, and adding client-side budgets, aimed at layers built on top of this crate (continuation-style scans, custom instrumentation).

### 1. Client-side budget + always-on usage accounting (`c784097`)
- Every `Transaction` carries an always-on `AttemptUsage` generation: atomic counters for bytes read/written and per-op calls, reset per attempt. In-flight futures record into the generation active when issued, so a stale read cannot pollute the next attempt.
- `ClientBudget` (time limit, max bytes read/written) set on a transaction, checked explicitly with `check_client_budget()`; returns a typed `BudgetExceeded` error. Pull-based by design: nothing is auto-cancelled, the caller decides (commit partial work, resume later, abort). Clearly documented as a client-side estimate of the binding, decoupled from the native `Timeout`/`SizeLimit` options.
- Fixes byte-accounting gaps: `clear`, `clear_range`, `atomic_op`, `get_key`, mapped ranges.

### 2. Per-attempt metrics (`f56bacd`, breaking)
- `MetricsReport` now holds one `AttemptMetrics` per attempt (usage snapshot, custom metrics, durations, outcome, conflicting keys, read version) instead of wiping counters on retry.
- `AttemptUsage` is the single counter source; `CounterMetrics`/`FdbCommand` removed.
- Custom metrics are always on and infallible; `TransactionMetricsNotFound` removed.

### 3. Modular retry runner (`53a9da2`, breaking)
- New `runner` module: single-attempt layer + retry loop. `fdb_transaction_on_error` remains the sole retry governor.
- `RunnerHooks` is purely observational, composes via `()`, `&H`, `Option<H>` and nested tuples; `on_complete` fires exactly once on every exit path; hook errors are reported via `on_hook_error` instead of swallowed.
- Retry decisions move to a typed `RetryPolicy<E>` (sees the real closure error or the commit error, plus the proposed decision); `maybe_committed` is computed before the policy runs and cannot be corrupted by it.
- `db.runner()` builder assembles hooks + policy; `run`/`run_with_hooks`/`instrumented_run` are sugar over it. `MetricsHooks` is public and attaches itself on first attempt start, so stacking it on any run produces a complete report.

### 4. Conflict-range introspection + budgeted scan example (`81c00a3`)
- `read_conflict_ranges()` / `write_conflict_ranges()` (API 630+), unmetered so diagnostics never consume the user's budget.
- One incremental parser shared by all three conflict-range readers, fixing `conflicting_keys()` silently truncating past the first batch (verified live: 500 ranges span 6 batches).
- `examples/budgeted_scan.rs`: the scan-for-2.5s pattern with exclusive continuation keys; verified live (4000 rows, 8 resumed transactions under a 512 KiB budget, no row missed or duplicated).

## Testing

Each phase passed `cargo fmt`, `cargo clippy-all` (workspace, -D warnings), `cargo doc` with warnings denied, and the full `cargo test-fdb-latest` suite against a live 7.4.6 cluster. Version gating checked at fdb-6_0 and fdb-7_1. New coverage: budget/usage semantics (17 tests), per-attempt metrics retention across forced retries, hook ordering/composition, retry-policy overrides incl. maybe_committed preservation, conflict-range pagination, and a multi-transaction continuation scan.

## Notes for review

- The runner rework preserves the existing retry semantics exactly (original typed errors on fatal paths, synthetic 1020 for `RetryDecision::Retry`, backoff fully delegated to the C client); the tests in `tests/run_retry.rs` pin these invariants.
- `StreamingMode::Serial` caps batches around 80 KiB in practice; `target_bytes` only acts as an upper bound (documented in the example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeEgEXXcBpawQ4GNRADGcs