### PR TITLE
fix(simulation): use c_char instead of i8 at FFI boundaries

### DIFF
--- a/foundationdb-simulation/src/bindings.rs
+++ b/foundationdb-simulation/src/bindings.rs
@@ -3,7 +3,11 @@
 //! This module defines all C and Rust structures.
 //! It also provides bindings and wrappers to map behavior from Rust to C.
 
-use std::{ffi, str::FromStr, time::Duration};
+use std::{
+    ffi::{self, c_char},
+    str::FromStr,
+    time::Duration,
+};
 
 use foundationdb as fdb;
 
@@ -32,7 +36,7 @@ pub const FDB_WORKLOAD_API_VERSION: i32 = raw_bindings::FDB_WORKLOAD_API_VERSION
 
 #[doc(hidden)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub fn str_from_c(c_buf: *const i8) -> String {
+pub fn str_from_c(c_buf: *const c_char) -> String {
     let c_str = unsafe { ffi::CStr::from_ptr(c_buf) };
     c_str.to_str().unwrap().to_string()
 }

--- a/foundationdb-simulation/src/lib.rs
+++ b/foundationdb-simulation/src/lib.rs
@@ -224,7 +224,7 @@ macro_rules! register_factory {
     ($name:ident) => {
         #[unsafe(no_mangle)]
         extern "C" fn workloadCFactory(
-            raw_name: *const i8,
+            raw_name: *const std::ffi::c_char,
             raw_context: $crate::internals::FDBWorkloadContext,
         ) -> $crate::WrappedWorkload {
             use std::sync::atomic::{AtomicBool, Ordering};
@@ -260,7 +260,7 @@ macro_rules! register_workload {
     ($name:ident) => {
         #[unsafe(no_mangle)]
         extern "C" fn workloadCFactory(
-            raw_name: *const i8,
+            raw_name: *const std::ffi::c_char,
             raw_context: $crate::internals::FDBWorkloadContext,
         ) -> $crate::WrappedWorkload {
             use std::sync::atomic::{AtomicBool, Ordering};


### PR DESCRIPTION
Replace hardcoded `*const i8` with `*const c_char` in `str_from_c()`, `register_factory!` and `register_workload!` macros.

On aarch64-linux, `c_char` is `u8` (unsigned), not `i8`, so the crate failed to compile. No behavior change on x86_64/macOS where `c_char == i8`.

Closes #458