### PR TITLE
fix(ci): run security audit on stable to bypass MSRV toolchain pin

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,12 +7,21 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     if: github.repository == 'foundationdb-rs/foundationdb-rs'
+    # The checked-in rust-toolchain.toml pins the repo to the MSRV (1.85.1),
+    # but the latest cargo-audit needs a newer rustc to build. Override the
+    # file here to install and run it on stable (same trick as msrv.yml).
+    env:
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - name: Install FoundationDB
         uses: foundationdb-rs/foundationdb-actions-install@v2.3.0
         with:
           version: "7.1.37"
       - uses: actions/checkout@v7.0.0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The daily security audit job fails since the repo added `rust-toolchain.toml` pinning the toolchain to the MSRV (1.85.1): `rustsec/audit-check` installs the latest `cargo-audit` (0.22.2), which now requires rustc 1.88, so `cargo install` bails out (see run [30325410353](https://github.com/foundationdb-rs/foundationdb-rs/actions/runs/30325410353/job/90169682149)).

Fix: override the toolchain file at the job level with `RUSTUP_TOOLCHAIN: stable` and install stable explicitly, the same pattern already used in `msrv.yml`. `cargo-audit` only reads `Cargo.lock`, so running it on stable does not weaken the MSRV guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQH8FUiZVUTZ15FDWvQuGT