### PR TITLE
fix(sys): rerun build script when FDB_CLIENT_LIB_PATH changes

### DIFF
--- a/foundationdb-sys/build.rs
+++ b/foundationdb-sys/build.rs
@@ -60,6 +60,7 @@ fn main() {
     // Link against fdb_c.
     println!("cargo:rustc-link-lib=fdb_c");
 
+    println!("cargo:rerun-if-env-changed=FDB_CLIENT_LIB_PATH");
     if let Ok(lib_path) = env::var("FDB_CLIENT_LIB_PATH") {
         println!("cargo:rustc-link-search=native={lib_path}");
     }


### PR DESCRIPTION
Add `cargo:rerun-if-env-changed=FDB_CLIENT_LIB_PATH` directive so Cargo invalidates the build cache when the env var is updated. Without this, a warm target directory keeps using the stale link search path.

Closes #438