### PR TITLE
docs: warn about RandomState non-determinism and directory concurrency

### DIFF
--- a/foundationdb-simulation/README.md
+++ b/foundationdb-simulation/README.md
@@ -216,6 +216,11 @@ To maintain determinism, all random numbers must be sourced from the simulator.
 Use `WorkloadContext::rnd()` or `WorkloadContext::shared_random_number()` for a shared seed.
 Do not use external entropy sources like `rand::thread_rng()`.
 
+> **Warning:** `std::collections::HashMap` and `HashSet` use `RandomState` by default, which
+> seeds from the OS RNG. This breaks simulation determinism — iteration order and hash values
+> will differ across runs. Use `BTreeMap`/`BTreeSet` instead, or provide a fixed seed to
+> `RandomState::with_seed`. See [#329](https://github.com/foundationdb-rs/foundationdb-rs/issues/329).
+
 # Workload Lifecycle
 
 ## Instantiation

--- a/foundationdb/src/directory/mod.rs
+++ b/foundationdb/src/directory/mod.rs
@@ -90,7 +90,10 @@ pub trait Directory {
     ///
     /// # Warning
     ///
-    /// If you need to create several paths with the same prefix, you **must** use several transactions(See [this link](https://github.com/apple/foundationdb/issues/895#issuecomment-436704180) for context)
+    /// Creating several paths with the same prefix **concurrently** within the same transaction
+    /// is unsafe and may race. Serial calls (fully awaiting each `create_or_open` before issuing
+    /// the next) within the same transaction are safe. Alternatively, use separate transactions.
+    /// See [this link](https://github.com/apple/foundationdb/issues/895#issuecomment-436704180) for context.
     async fn create_or_open(
         &self,
         txn: &Transaction,
@@ -103,7 +106,10 @@ pub trait Directory {
     ///
     /// # Warning
     ///
-    /// If you need to create several paths with the same prefix, you **must** use several transactions(See [this link](https://github.com/apple/foundationdb/issues/895#issuecomment-436704180) for context)
+    /// Creating several paths with the same prefix **concurrently** within the same transaction
+    /// is unsafe and may race. Serial calls (fully awaiting each `create` before issuing the
+    /// next) within the same transaction are safe. Alternatively, use separate transactions.
+    /// See [this link](https://github.com/apple/foundationdb/issues/895#issuecomment-436704180) for context.
     async fn create(
         &self,
         txn: &Transaction,


### PR DESCRIPTION
- Add warning to simulation README: `HashMap`/`HashSet` use `RandomState` by default, which breaks simulation determinism. Use `BTreeMap`/`BTreeSet` instead.
- Clarify directory layer warning: serial `create_or_open`/`create` calls within the same transaction are safe; only concurrent calls race.

Closes #383, #382