### PR TITLE
fix(simulation): escape NUL bytes in trace strings

### DIFF
--- a/foundationdb-simulation/src/bindings.rs
+++ b/foundationdb-simulation/src/bindings.rs
@@ -45,7 +45,21 @@ pub fn str_for_c<T>(buf: T) -> ffi::CString
 where
     T: Into<Vec<u8>>,
 {
-    ffi::CString::new(buf).unwrap()
+    let mut buf = buf.into();
+    if buf.contains(&0) {
+        let mut escaped = Vec::with_capacity(buf.len());
+        for byte in buf {
+            if byte == 0 {
+                escaped.extend_from_slice(br"\0");
+            } else {
+                escaped.push(byte);
+            }
+        }
+        buf = escaped;
+    }
+
+    // SAFETY: Every interior NUL byte was escaped above.
+    unsafe { ffi::CString::from_vec_unchecked(buf) }
 }
 
 /// Capitalizes the first letter of a string.
@@ -310,5 +324,15 @@ impl<'a> Metric<'a> {
             avg: true,
             fmt: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::str_for_c;
+
+    #[test]
+    fn str_for_c_escapes_interior_nul() {
+        assert_eq!(str_for_c("a\0b").to_bytes(), br"a\0b");
     }
 }


### PR DESCRIPTION
## Summary

- escape interior NUL bytes before forwarding strings to the fdbserver trace API
- preserve NUL-free strings unchanged
- cover event names, detail keys, detail values, metrics, and option names through the shared conversion
- add a regression test for a detail value containing a NUL byte

Found on 2026-07-30 by a Clever Cloud deterministic-simulation workload using adversarial IDs.

## Testing

- nix develop -c cargo test -p foundationdb-simulation --no-default-features --features embedded-fdb-include,fdb-7_4 --all-targets
- nix develop -c cargo clippy-all