### PR TITLE
feat(metrics): record get_read_version wait on AttemptMetrics

### DIFF
--- a/foundationdb/examples/instrumented.rs
+++ b/foundationdb/examples/instrumented.rs
@@ -102,6 +102,7 @@ MetricsReport {
             commit_duration: Some(
                 10.609832ms,
             ),
+            grv_duration: None,
             on_error_duration: None,
             outcome: Committed,
             conflicting_keys: NotRequested,

--- a/foundationdb/src/metrics.rs
+++ b/foundationdb/src/metrics.rs
@@ -116,6 +116,11 @@ pub struct AttemptMetrics {
     pub duration: Option<Duration>,
     /// Time spent in `commit`, `None` if the attempt never reached it.
     pub commit_duration: Option<Duration>,
+    /// Time spent waiting on
+    /// [`Transaction::get_read_version`](crate::Transaction::get_read_version),
+    /// `None` if it was never called. The first completion of the attempt is
+    /// kept.
+    pub grv_duration: Option<Duration>,
     /// Time spent in `on_error`, backoff included. `None` if `on_error` did not
     /// run, which is the case for the last attempt of a run.
     pub on_error_duration: Option<Duration>,
@@ -198,6 +203,7 @@ struct OpenAttempt {
     usage: Option<Arc<AttemptUsage>>,
     duration: Option<Duration>,
     commit_duration: Option<Duration>,
+    grv_duration: Option<Duration>,
     conflicting_keys: ConflictKeys,
     read_version: Option<i64>,
 }
@@ -251,7 +257,7 @@ impl TransactionMetrics {
             // the attempt being dropped did anything worth reporting. Some
             // activity is recorded straight on `OpenAttempt` instead of
             // `AttemptUsage` (read version, conflicting keys, commit
-            // duration), so it has to be checked too.
+            // duration, grv duration), so it has to be checked too.
             let snapshot = dropped.snapshot();
             let idle = snapshot
                 == UsageSnapshot {
@@ -262,6 +268,7 @@ impl TransactionMetrics {
                 && open.read_version.is_none()
                 && open.duration.is_none()
                 && open.commit_duration.is_none()
+                && open.grv_duration.is_none()
                 && matches!(open.conflicting_keys, ConflictKeys::NotRequested);
 
             if !idle {
@@ -297,6 +304,15 @@ impl TransactionMetrics {
         }
     }
 
+    /// Records the time spent waiting on `get_read_version`, whatever its
+    /// result. Later calls of the same attempt are ignored.
+    pub(crate) fn record_grv(&self, duration: Duration) {
+        let mut open = self.open();
+        if open.grv_duration.is_none() {
+            open.grv_duration = Some(duration);
+        }
+    }
+
     /// Ends the current attempt and pushes it to the report.
     ///
     /// Does nothing when no attempt is being recorded, which makes it safe to
@@ -321,6 +337,7 @@ impl TransactionMetrics {
             custom_metrics: usage.custom_metrics(),
             duration: open.duration.or_else(|| Some(usage.elapsed())),
             commit_duration: open.commit_duration,
+            grv_duration: open.grv_duration,
             on_error_duration: None,
             outcome,
             conflicting_keys: open.conflicting_keys,
@@ -517,6 +534,8 @@ mod tests {
         first.record_set(10);
         first.increment_custom(key.clone(), 1);
         metrics.record_commit(Duration::from_millis(3));
+        metrics.record_grv(Duration::from_millis(5));
+        metrics.record_grv(Duration::from_millis(1)); // first sample wins
         metrics.finish_attempt(AttemptOutcome::Retried {
             cause: FdbError::from_code(1020),
         });
@@ -540,6 +559,7 @@ mod tests {
         assert_eq!(first.usage.bytes_written, 10);
         assert_eq!(first.custom_metrics.get(&key), Some(&1));
         assert_eq!(first.commit_duration, Some(Duration::from_millis(3)));
+        assert_eq!(first.grv_duration, Some(Duration::from_millis(5)));
         assert_eq!(first.on_error_duration, Some(Duration::from_millis(7)));
         assert!(matches!(
             first.outcome,
@@ -551,6 +571,7 @@ mod tests {
         assert_eq!(second.usage.bytes_written, 4);
         assert_eq!(second.custom_metrics.get(&key), Some(&2));
         assert!(second.commit_duration.is_none());
+        assert!(second.grv_duration.is_none());
         assert!(matches!(second.outcome, AttemptOutcome::Committed));
 
         assert_eq!(report.total_usage().bytes_written, 14);

--- a/foundationdb/src/metrics.rs
+++ b/foundationdb/src/metrics.rs
@@ -116,10 +116,8 @@ pub struct AttemptMetrics {
     pub duration: Option<Duration>,
     /// Time spent in `commit`, `None` if the attempt never reached it.
     pub commit_duration: Option<Duration>,
-    /// Time spent waiting on
-    /// [`Transaction::get_read_version`](crate::Transaction::get_read_version),
-    /// `None` if it was never called. The first completion of the attempt is
-    /// kept.
+    /// Time spent waiting on `get_read_version`, `None` if it was never called.
+    /// The first completion of the attempt is kept.
     pub grv_duration: Option<Duration>,
     /// Time spent in `on_error`, backoff included. `None` if `on_error` did not
     /// run, which is the case for the last attempt of a run.
@@ -128,9 +126,8 @@ pub struct AttemptMetrics {
     pub outcome: AttemptOutcome,
     /// Conflicting key ranges, only read after a commit conflict.
     pub conflicting_keys: ConflictKeys,
-    /// Read version of the attempt, recorded when
-    /// [`Transaction::get_read_version`](crate::Transaction::get_read_version)
-    /// is called. The binding never fetches it on its own.
+    /// Read version of the attempt, recorded when `get_read_version` is called.
+    /// The binding never fetches it on its own.
     pub read_version: Option<i64>,
 }
 

--- a/foundationdb/src/metrics.rs
+++ b/foundationdb/src/metrics.rs
@@ -126,8 +126,9 @@ pub struct AttemptMetrics {
     pub outcome: AttemptOutcome,
     /// Conflicting key ranges, only read after a commit conflict.
     pub conflicting_keys: ConflictKeys,
-    /// Read version of the attempt, recorded when `get_read_version` is called.
-    /// The binding never fetches it on its own.
+    /// Read version of the attempt, recorded when
+    /// [`Transaction::get_read_version`](crate::Transaction::get_read_version)
+    /// is called. The binding never fetches it on its own.
     pub read_version: Option<i64>,
 }
 

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -1588,22 +1588,27 @@ impl Transaction {
     /// compromised by transaction options) is guaranteed to represent all transactions which were
     /// reported committed before that call.
     ///
-    /// On an instrumented transaction, the version is recorded in the metrics of
-    /// the current attempt. It is only ever recorded when this method is called:
-    /// the binding never fetches a read version on its own.
+    /// On an instrumented transaction, the version and the wait on this future
+    /// are recorded in the metrics of the current attempt. They are only ever
+    /// recorded when this method is called: the binding never fetches a read
+    /// version on its own.
     pub fn get_read_version(
         &self,
     ) -> impl Future<Output = FdbResult<i64>> + Send + Sync + Unpin + use<> {
         let metrics = self.metrics().cloned();
+        let started_at = metrics.as_ref().map(|_| Instant::now());
 
         FdbFuture::<i64>::new(unsafe {
             fdb_sys::fdb_transaction_get_read_version(self.inner.as_ptr())
         })
-        .map_ok(move |version| {
-            if let Some(metrics) = &metrics {
-                metrics.set_read_version(version);
+        .map(move |result| {
+            if let (Some(metrics), Some(started_at)) = (&metrics, started_at) {
+                metrics.record_grv(started_at.elapsed());
+                if let Ok(version) = result {
+                    metrics.set_read_version(version);
+                }
             }
-            version
+            result
         })
     }
 

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -1588,10 +1588,9 @@ impl Transaction {
     /// compromised by transaction options) is guaranteed to represent all transactions which were
     /// reported committed before that call.
     ///
-    /// On an instrumented transaction, the version and the wait on this future
-    /// are recorded in the metrics of the current attempt. They are only ever
-    /// recorded when this method is called: the binding never fetches a read
-    /// version on its own.
+    /// On an instrumented transaction, the version is recorded in the metrics of
+    /// the current attempt. It is only ever recorded when this method is called:
+    /// the binding never fetches a read version on its own.
     pub fn get_read_version(
         &self,
     ) -> impl Future<Output = FdbResult<i64>> + Send + Sync + Unpin + use<> {

--- a/foundationdb/tests/metrics.rs
+++ b/foundationdb/tests/metrics.rs
@@ -313,7 +313,7 @@ async fn test_transaction_info() -> FdbResult<()> {
     let db = common::database().await?;
 
     // read_version: recorded when the user asks for it, on the attempt and on
-    // the transaction information. grv_duration is the wait of that call.
+    // the transaction information.
     {
         let metrics = TransactionMetrics::new();
         let hooks = MetricsHooks::new(&metrics);

--- a/foundationdb/tests/metrics.rs
+++ b/foundationdb/tests/metrics.rs
@@ -37,6 +37,7 @@ async fn instrumented_run_success() -> FdbResult<()> {
     );
     assert!(matches!(attempt.outcome, AttemptOutcome::Committed));
     assert!(attempt.commit_duration.is_some());
+    assert!(attempt.grv_duration.is_none());
     assert!(attempt.on_error_duration.is_none());
 
     let total = metrics.total_usage();
@@ -312,7 +313,7 @@ async fn test_transaction_info() -> FdbResult<()> {
     let db = common::database().await?;
 
     // read_version: recorded when the user asks for it, on the attempt and on
-    // the transaction information.
+    // the transaction information. grv_duration is the wait of that call.
     {
         let metrics = TransactionMetrics::new();
         let hooks = MetricsHooks::new(&metrics);
@@ -328,6 +329,8 @@ async fn test_transaction_info() -> FdbResult<()> {
                         metrics.get_transaction_info().read_version,
                         Some(read_version)
                     );
+                    let again = txn.get_read_version().await?;
+                    assert_eq!(again, read_version);
                     Ok::<_, FdbBindingError>(read_version)
                 }
             })
@@ -337,6 +340,7 @@ async fn test_transaction_info() -> FdbResult<()> {
         let report = metrics.get_metrics_data();
         assert_eq!(report.attempts.len(), 1);
         assert_eq!(report.attempts[0].read_version, Some(read_version));
+        assert!(report.attempts[0].grv_duration.is_some());
     }
 
     // commit_version
@@ -352,6 +356,7 @@ async fn test_transaction_info() -> FdbResult<()> {
         assert!(metrics.transaction.commit_version.is_some());
         // Not asked for, not fetched.
         assert!(metrics.transaction.read_version.is_none());
+        assert!(metrics.attempts[0].grv_duration.is_none());
     }
 
     // retries
@@ -513,6 +518,10 @@ async fn test_time_metrics() -> FdbResult<()> {
         let attempt = &metrics.attempts[0];
         assert!(attempt.duration.is_some(), "attempt duration");
         assert!(attempt.commit_duration.is_some(), "commit duration");
+        assert!(
+            attempt.grv_duration.is_none(),
+            "get_read_version was not called"
+        );
         assert!(attempt.on_error_duration.is_none(), "on_error did not run");
         assert!(metrics.total_duration >= attempt.duration);
     }


### PR DESCRIPTION
instrumented_run already splits out commit and on_error. GRV is the other phase we are interested in, and we can time it the same way we already record `read_version`: only when the caller awaits `get_read_version`.

`AttemptMetrics.grv_duration` is that wait (success or error). First completion on the attempt sticks; calling it again is usually a cache hit and would trash the sample if we overwrote.

Not wiring this into the runner on purpose. Forcing GRV would change blind writes (commit currently takes the cheap causal-risky path if nothing has read) and we'd be breaking the "binding never fetches a read version on its own" rule. Implicit GRV on a first `get` is still mixed into the read. Commit-time GRV stays in `commit_duration`.

C API doesn't expose the client's GRV latency, so this is just wall time of the rust future.

Metrics tests run against 7.3 locally.

Note: Created with AI